### PR TITLE
Receive Events over Websocket connection

### DIFF
--- a/API.md
+++ b/API.md
@@ -1592,6 +1592,88 @@ The server sends application-level pings every 30 seconds. The connection is als
 
 ---
 
+### GET /v1/events/ws
+
+Upgrade to a WebSocket connection and receive all events in real-time as JSON text frames. The JSON shape is identical to webhook payloads (same `Event.MarshalJSON` format).
+
+**Upgrade:** Standard HTTP → WebSocket upgrade. No request body.
+
+**Query Parameters:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `app_id` | string (regex) | If set, only events whose `app_id` matches the regex are forwarded. Omit to receive all events. |
+
+Set `app_id` on legs via `POST /v1/legs` body or `X-App-ID` SIP header on inbound calls. Set on rooms via `POST /v1/rooms` body. Auto-created rooms inherit `app_id` from the originating leg.
+
+**Example with filter:**
+
+```bash
+websocat "ws://localhost:8080/v1/events/ws?app_id=^billing$"
+```
+
+#### Message Format
+
+**Server → Client (on connect):**
+
+```json
+{"type": "connected"}
+```
+
+**Server → Client (event):**
+
+```json
+{"type": "leg.connected", "timestamp": "2026-04-15T12:00:00Z", "instance_id": "i-abc", "leg_id": "550e8400-...", "leg_type": "sip_outbound"}
+```
+
+Events use the same flattened JSON envelope as webhook POSTs. Clients already parsing webhook payloads can reuse the same deserializer.
+
+**Server → Client (keepalive ping):**
+
+```json
+{"type": "ping", "event_id": 1}
+```
+
+**Client → Server (keepalive pong):**
+
+```json
+{"type": "pong"}
+```
+
+**Client → Server (disconnect):**
+
+```json
+{"type": "stop"}
+```
+
+**Client → Server (future commands):**
+
+All client messages support an optional `request_id` field that is echoed back in any response. Unknown message types receive an error response:
+
+```json
+// Client sends:
+{"type": "unknown_cmd", "request_id": "req-42"}
+
+// Server responds:
+{"type": "error", "request_id": "req-42", "data": {"message": "unknown command: unknown_cmd"}}
+```
+
+The server sends application-level pings every 30 seconds. If a client reads too slowly, events are buffered (up to 256). When the buffer is full, events are dropped and the server sends a notification before the next successfully delivered event:
+
+```json
+{"type": "events_dropped", "count": 12}
+```
+
+On receiving this, the client should resync state via REST (e.g. `GET /v1/legs`, `GET /v1/rooms`) since it may have missed transitions.
+
+**Example:**
+
+```bash
+websocat ws://localhost:8080/v1/events/ws
+```
+
+---
+
 ## WebRTC
 
 ### POST /v1/webrtc/offer

--- a/API.md
+++ b/API.md
@@ -1592,7 +1592,7 @@ The server sends application-level pings every 30 seconds. The connection is als
 
 ---
 
-### GET /v1/events/ws
+### GET /v1/vsi (VSI)
 
 Upgrade to a WebSocket connection and receive all events in real-time as JSON text frames. The JSON shape is identical to webhook payloads (same `Event.MarshalJSON` format).
 
@@ -1609,7 +1609,7 @@ Set `app_id` on legs via `POST /v1/legs` body or `X-App-ID` SIP header on inboun
 **Example with filter:**
 
 ```bash
-websocat "ws://localhost:8080/v1/events/ws?app_id=^billing$"
+websocat "ws://localhost:8080/v1/vsi?app_id=^billing$"
 ```
 
 #### Message Format
@@ -1646,17 +1646,45 @@ Events use the same flattened JSON envelope as webhook POSTs. Clients already pa
 {"type": "stop"}
 ```
 
-**Client → Server (future commands):**
+**Client → Server (commands):**
 
-All client messages support an optional `request_id` field that is echoed back in any response. Unknown message types receive an error response:
+The WebSocket accepts bidirectional commands using the same naming as the REST API. All commands support an optional `request_id` echoed back in the response.
 
 ```json
 // Client sends:
-{"type": "unknown_cmd", "request_id": "req-42"}
+{"type": "mute_leg", "request_id": "req-1", "payload": {"id": "abc-123"}}
 
-// Server responds:
-{"type": "error", "request_id": "req-42", "data": {"message": "unknown command: unknown_cmd"}}
+// Server responds (success):
+{"type": "mute_leg.result", "request_id": "req-1", "data": {"status": "muted"}}
+
+// Server responds (error):
+{"type": "error", "request_id": "req-1", "data": {"code": 404, "message": "leg not found"}}
 ```
+
+#### Available commands
+
+| Command | Payload | Description |
+|---------|---------|-------------|
+| `list_legs` | *(none)* | List all legs |
+| `get_leg` | `{"id":"..."}` | Get a single leg |
+| `create_leg` | `CreateLegRequest` | Create a leg (not yet implemented over WS; use REST) |
+| `delete_leg` | `{"id":"..."}` | Hang up and delete a leg |
+| `answer_leg` | `{"id":"..."}` | Answer a ringing inbound leg |
+| `mute_leg` | `{"id":"..."}` | Mute a leg |
+| `unmute_leg` | `{"id":"..."}` | Unmute a leg |
+| `deaf_leg` | `{"id":"..."}` | Deafen a leg |
+| `undeaf_leg` | `{"id":"..."}` | Undeafen a leg |
+| `hold_leg` | `{"id":"..."}` | Put a SIP leg on hold |
+| `unhold_leg` | `{"id":"..."}` | Resume a held SIP leg |
+| `send_leg_dtmf` | `{"id":"...","digits":"123"}` | Send DTMF digits on a leg |
+| `accept_leg_dtmf` | `{"id":"..."}` | Enable DTMF reception |
+| `reject_leg_dtmf` | `{"id":"..."}` | Disable DTMF reception |
+| `list_rooms` | *(none)* | List all rooms |
+| `get_room` | `{"id":"..."}` | Get a single room |
+| `create_room` | `CreateRoomRequest` | Create a room |
+| `delete_room` | `{"id":"..."}` | Delete a room |
+| `add_leg_to_room` | `{"room_id":"...","leg_id":"..."}` | Add or move leg to room (supports `mute`, `deaf`, `accept_dtmf`) |
+| `remove_leg_from_room` | `{"room_id":"...","leg_id":"..."}` | Remove leg from room |
 
 The server sends application-level pings every 30 seconds. If a client reads too slowly, events are buffered (up to 256). When the buffer is full, events are dropped and the server sends a notification before the next successfully delivered event:
 
@@ -1669,7 +1697,7 @@ On receiving this, the client should resync state via REST (e.g. `GET /v1/legs`,
 **Example:**
 
 ```bash
-websocat ws://localhost:8080/v1/events/ws
+websocat ws://localhost:8080/v1/vsi
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A Go service that bridges SIP and WebRTC voice calls with multi-party audio mixi
 - **AI Agent** -- attach a conversational AI agent to a leg or room (ElevenLabs, VAPI, Pipecat, Deepgram) with mid-session context injection
 - **Answering Machine Detection (AMD)** -- per-call analysis of outbound call audio to classify the answerer as human, machine, no-speech, or not-sure; optional voicemail beep detection via Goertzel frequency analysis
 - **Webhooks** -- real-time event delivery with HMAC-SHA256 signing and retry; typed event data with CDR-style `leg.disconnected` (disposition, timing, quality)
-- **WebSocket event stream** -- `GET /v1/events/ws` streams all events over a persistent WebSocket (same JSON as webhooks); filter by `app_id` regex for multi-tenant isolation; ready for bidirectional command support
+- **WebSocket event stream (VSI)** -- `GET /v1/vsi` streams all events and accepts commands (mute, hold, DTMF, room management) over a single persistent WebSocket; filter by `app_id` regex for multi-tenant isolation
 - **Prometheus metrics** -- operational metrics exposed at `GET /metrics` (active legs/rooms, call durations, disconnect reasons, Go runtime). See [API.md](API.md) for the full metric reference. Profiling via `go tool pprof` is available at `/debug/pprof/` when built with `-tags pprof`.
 
 ## Quick Start
@@ -136,7 +136,7 @@ DELETE /v1/rooms/{id}/agent        # Detach AI agent from room
 ### Events
 
 ```
-GET    /v1/events/ws                       # WebSocket event stream
+GET    /v1/vsi                              # VoiceBlender Streaming Interface (VSI)
 ```
 
 ### WebRTC

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A Go service that bridges SIP and WebRTC voice calls with multi-party audio mixi
 - **AI Agent** -- attach a conversational AI agent to a leg or room (ElevenLabs, VAPI, Pipecat, Deepgram) with mid-session context injection
 - **Answering Machine Detection (AMD)** -- per-call analysis of outbound call audio to classify the answerer as human, machine, no-speech, or not-sure; optional voicemail beep detection via Goertzel frequency analysis
 - **Webhooks** -- real-time event delivery with HMAC-SHA256 signing and retry; typed event data with CDR-style `leg.disconnected` (disposition, timing, quality)
+- **WebSocket event stream** -- `GET /v1/events/ws` streams all events over a persistent WebSocket (same JSON as webhooks); filter by `app_id` regex for multi-tenant isolation; ready for bidirectional command support
 - **Prometheus metrics** -- operational metrics exposed at `GET /metrics` (active legs/rooms, call durations, disconnect reasons, Go runtime). See [API.md](API.md) for the full metric reference. Profiling via `go tool pprof` is available at `/debug/pprof/` when built with `-tags pprof`.
 
 ## Quick Start
@@ -130,6 +131,12 @@ DELETE /v1/rooms/{id}/stt          # Stop room STT
 POST   /v1/rooms/{id}/agent        # Attach AI agent to room
 POST   /v1/rooms/{id}/agent/message # Inject message into agent
 DELETE /v1/rooms/{id}/agent        # Detach AI agent from room
+```
+
+### Events
+
+```
+GET    /v1/events/ws                       # WebSocket event stream
 ```
 
 ### WebRTC

--- a/TESTING.md
+++ b/TESTING.md
@@ -129,9 +129,11 @@ go test -tags integration -v -timeout 60s -run TestWSEvents ./tests/integration/
 | `TestDTMFBroadcast_RejectAtRuntime` | `POST /v1/legs/{id}/dtmf/reject` blocks reception; `accept` re-enables it |
 | `TestDTMFBroadcast_RejectAtOriginate` | `accept_dtmf:false` in originate body blocks reception from the start |
 | `TestDTMFBroadcast_SenderExcluded` | Originating leg never receives a forwarded copy of its own DTMF |
-| `TestWSEvents_ConnectedAndEvents` | Connect to `/v1/events/ws`, originate a call, verify `leg.ringing` event arrives |
+| `TestWSEvents_ConnectedAndEvents` | Connect to `/v1/vsi`, originate a call, verify `leg.ringing` event arrives |
 | `TestWSEvents_UnknownCommand` | Send unknown command with `request_id`, verify error response echoes it |
 | `TestWSEvents_StopCommand` | Send `stop`, verify server closes the connection |
+| `TestWSCommands_RoomLifecycle` | Create, get, list, delete room via WS commands; error on deleted room |
+| `TestWSCommands_MuteLeg` | Mute/get_leg via WS; error on missing leg; error on unknown command |
 | `TestWSEvents_AppIDFilter` | Two WS clients (filtered + unfiltered), two legs with different `app_id`; filtered client only sees matching events |
 | `TestTransfer_Blind_Outbound` | A↔B, REFER on B's leg dials C, completion event fires, original hung up |
 | `TestTransfer_Inbound_DeclinedByDefault` | With default `SIP_REFER_AUTO_DIAL=false` the peer's REFER gets 603 and an audit event |

--- a/TESTING.md
+++ b/TESTING.md
@@ -92,6 +92,7 @@ go test -tags integration -v -timeout 60s -run TestOutboundInbound_Connect ./tes
 go test -tags integration -v -timeout 60s -run TestRecording ./tests/integration/
 go test -tags integration -v -timeout 60s -run TestMute ./tests/integration/
 go test -tags integration -v -timeout 60s -run TestDTMFBroadcast ./tests/integration/
+go test -tags integration -v -timeout 60s -run TestWSEvents ./tests/integration/
 ```
 
 ### Integration test list
@@ -128,6 +129,10 @@ go test -tags integration -v -timeout 60s -run TestDTMFBroadcast ./tests/integra
 | `TestDTMFBroadcast_RejectAtRuntime` | `POST /v1/legs/{id}/dtmf/reject` blocks reception; `accept` re-enables it |
 | `TestDTMFBroadcast_RejectAtOriginate` | `accept_dtmf:false` in originate body blocks reception from the start |
 | `TestDTMFBroadcast_SenderExcluded` | Originating leg never receives a forwarded copy of its own DTMF |
+| `TestWSEvents_ConnectedAndEvents` | Connect to `/v1/events/ws`, originate a call, verify `leg.ringing` event arrives |
+| `TestWSEvents_UnknownCommand` | Send unknown command with `request_id`, verify error response echoes it |
+| `TestWSEvents_StopCommand` | Send `stop`, verify server closes the connection |
+| `TestWSEvents_AppIDFilter` | Two WS clients (filtered + unfiltered), two legs with different `app_id`; filtered client only sees matching events |
 | `TestTransfer_Blind_Outbound` | A↔B, REFER on B's leg dials C, completion event fires, original hung up |
 | `TestTransfer_Inbound_DeclinedByDefault` | With default `SIP_REFER_AUTO_DIAL=false` the peer's REFER gets 603 and an audit event |
 | `TestTransfer_NotConnected` | `/transfer` on a ringing leg returns 409 |

--- a/cmd/voiceblender/main.go
+++ b/cmd/voiceblender/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	// Event bus + webhooks
 	bus := events.NewBus(cfg.InstanceID)
-	bus.Subscribe(func(e events.Event) {
+	_ = bus.Subscribe(func(e events.Event) {
 		log.Info("event", "type", string(e.Type), "data", e.Data)
 	})
 	webhookReg := events.NewWebhookRegistry(bus, log, cfg.WebhookURL, cfg.WebhookSecret)

--- a/internal/api/agent.go
+++ b/internal/api/agent.go
@@ -89,10 +89,10 @@ func (sb *streamBuffer) Close() {
 
 type agentInfo struct {
 	session  agent.Provider
-	sourceID string         // mixer playback source / participant ID
-	pipes    []*pipeWriter  // pipes to close on cleanup
-	speakBuf *streamBuffer  // paced speak buffer (closed before RemoveParticipant)
-	roomID   string         // for leg agents: which room (if any)
+	sourceID string             // mixer playback source / participant ID
+	pipes    []*pipeWriter      // pipes to close on cleanup
+	speakBuf *streamBuffer      // paced speak buffer (closed before RemoveParticipant)
+	roomID   string             // for leg agents: which room (if any)
 	cancel   context.CancelFunc // for room agents: dedicated context
 }
 
@@ -217,27 +217,28 @@ func (s *Server) startLegAgent(w http.ResponseWriter, r *http.Request, provider,
 	legAgents.Unlock()
 
 	bus := s.Bus
+	agentAppID := l.AppID()
 	cb := agent.Callbacks{
 		OnConnected: func(conversationID string) {
 			bus.Publish(events.AgentConnected, &events.AgentConnectedData{
-				LegRoomScope:   events.LegRoomScope{LegID: id},
+				LegRoomScope:   events.LegRoomScope{LegID: id, AppID: agentAppID},
 				ConversationID: conversationID,
 			})
 		},
 		OnDisconnected: func() {
 			bus.Publish(events.AgentDisconnected, &events.AgentDisconnectedData{
-				LegRoomScope: events.LegRoomScope{LegID: id},
+				LegRoomScope: events.LegRoomScope{LegID: id, AppID: agentAppID},
 			})
 		},
 		OnUserTranscript: func(text string) {
 			bus.Publish(events.AgentUserTranscript, &events.AgentTranscriptData{
-				LegRoomScope: events.LegRoomScope{LegID: id},
+				LegRoomScope: events.LegRoomScope{LegID: id, AppID: agentAppID},
 				Text:         text,
 			})
 		},
 		OnAgentResponse: func(text string) {
 			bus.Publish(events.AgentAgentResponse, &events.AgentResponseData{
-				LegRoomScope: events.LegRoomScope{LegID: id},
+				LegRoomScope: events.LegRoomScope{LegID: id, AppID: agentAppID},
 				Text:         text,
 			})
 		},
@@ -506,27 +507,28 @@ func (s *Server) startRoomAgent(w http.ResponseWriter, r *http.Request, provider
 	roomAgents.Unlock()
 
 	bus := s.Bus
+	roomAgentAppID := rm.AppID
 	cb := agent.Callbacks{
 		OnConnected: func(conversationID string) {
 			bus.Publish(events.AgentConnected, &events.AgentConnectedData{
-				LegRoomScope:   events.LegRoomScope{RoomID: id},
+				LegRoomScope:   events.LegRoomScope{RoomID: id, AppID: roomAgentAppID},
 				ConversationID: conversationID,
 			})
 		},
 		OnDisconnected: func() {
 			bus.Publish(events.AgentDisconnected, &events.AgentDisconnectedData{
-				LegRoomScope: events.LegRoomScope{RoomID: id},
+				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAgentAppID},
 			})
 		},
 		OnUserTranscript: func(text string) {
 			bus.Publish(events.AgentUserTranscript, &events.AgentTranscriptData{
-				LegRoomScope: events.LegRoomScope{RoomID: id},
+				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAgentAppID},
 				Text:         text,
 			})
 		},
 		OnAgentResponse: func(text string) {
 			bus.Publish(events.AgentAgentResponse, &events.AgentResponseData{
-				LegRoomScope: events.LegRoomScope{RoomID: id},
+				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAgentAppID},
 				Text:         text,
 			})
 		},

--- a/internal/api/dtmf.go
+++ b/internal/api/dtmf.go
@@ -9,13 +9,24 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-func (s *Server) sendDTMF(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doSendLegDTMF(ctx context.Context, id, digits string) error {
 	l, ok := s.LegMgr.Get(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
-		return
+		return newAPIError(http.StatusNotFound, "leg not found")
 	}
+
+	if digits == "" {
+		return newAPIError(http.StatusBadRequest, "digits required")
+	}
+
+	if err := l.SendDTMF(ctx, digits); err != nil {
+		return newAPIError(http.StatusInternalServerError, "%s", err.Error())
+	}
+	return nil
+}
+
+func (s *Server) sendDTMF(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
 
 	var req DTMFRequest
 	if err := decodeJSON(r, &req); err != nil {
@@ -23,37 +34,46 @@ func (s *Server) sendDTMF(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Digits == "" {
-		writeError(w, http.StatusBadRequest, "digits required")
-		return
-	}
-
-	if err := l.SendDTMF(r.Context(), req.Digits); err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
+	if err := s.doSendLegDTMF(r.Context(), id, req.Digits); err != nil {
+		handleAPIError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "sent"})
 }
 
-func (s *Server) acceptDTMFLeg(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doAcceptLegDTMF(id string) error {
 	l, ok := s.LegMgr.Get(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
-		return
+		return newAPIError(http.StatusNotFound, "leg not found")
 	}
 	l.SetAcceptDTMF(true)
+	return nil
+}
+
+func (s *Server) acceptDTMFLeg(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.doAcceptLegDTMF(id); err != nil {
+		handleAPIError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "dtmf_accepting"})
+}
+
+func (s *Server) doRejectLegDTMF(id string) error {
+	l, ok := s.LegMgr.Get(id)
+	if !ok {
+		return newAPIError(http.StatusNotFound, "leg not found")
+	}
+	l.SetAcceptDTMF(false)
+	return nil
 }
 
 func (s *Server) rejectDTMFLeg(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	l, ok := s.LegMgr.Get(id)
-	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
+	if err := s.doRejectLegDTMF(id); err != nil {
+		handleAPIError(w, err)
 		return
 	}
-	l.SetAcceptDTMF(false)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "dtmf_rejecting"})
 }
 

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// apiError carries an HTTP-style status code so do* methods can signal
+// error severity to both HTTP handlers and the WS command dispatcher.
+type apiError struct {
+	Code    int
+	Message string
+}
+
+func (e *apiError) Error() string { return e.Message }
+
+func newAPIError(code int, format string, args ...interface{}) *apiError {
+	return &apiError{Code: code, Message: fmt.Sprintf(format, args...)}
+}
+
+// handleAPIError writes the error as an HTTP response. *apiError uses its
+// Code; other errors become 500.
+func handleAPIError(w http.ResponseWriter, err error) {
+	if ae, ok := err.(*apiError); ok {
+		writeError(w, ae.Code, ae.Message)
+		return
+	}
+	writeError(w, http.StatusInternalServerError, err.Error())
+}

--- a/internal/api/legs.go
+++ b/internal/api/legs.go
@@ -142,26 +142,31 @@ func (s *Server) getLeg(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, toLegView(l))
 }
 
-func (s *Server) answerLeg(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doAnswerLeg(id string) error {
 	l, ok := s.LegMgr.Get(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
-		return
+		return newAPIError(http.StatusNotFound, "leg not found")
 	}
 
 	sipLeg, ok := l.(*leg.SIPLeg)
 	if !ok {
-		writeError(w, http.StatusBadRequest, "only SIP inbound legs can be answered")
-		return
+		return newAPIError(http.StatusBadRequest, "only SIP inbound legs can be answered")
 	}
 
 	if l.State() != leg.StateRinging && l.State() != leg.StateEarlyMedia {
-		writeError(w, http.StatusConflict, fmt.Sprintf("leg is %s, expected ringing or early_media", l.State()))
-		return
+		return newAPIError(http.StatusConflict, "leg is %s, expected ringing or early_media", l.State())
 	}
 
 	sipLeg.SignalAnswer()
+	return nil
+}
+
+func (s *Server) answerLeg(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.doAnswerLeg(id); err != nil {
+		handleAPIError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "answering"})
 }
 
@@ -192,17 +197,14 @@ func (s *Server) earlyMediaLeg(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "early_media"})
 }
 
-func (s *Server) muteLeg(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doMuteLeg(id string) error {
 	l, ok := s.LegMgr.Get(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
-		return
+		return newAPIError(http.StatusNotFound, "leg not found")
 	}
 
 	l.SetMuted(true)
 
-	// Sync to mixer if the leg is in a room.
 	if roomID := l.RoomID(); roomID != "" {
 		if rm, ok := s.RoomMgr.Get(roomID); ok {
 			rm.Mixer().SetParticipantMuted(id, true)
@@ -210,20 +212,26 @@ func (s *Server) muteLeg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.Bus.Publish(events.LegMuted, &events.LegMutedData{LegScope: events.LegScope{LegID: id, AppID: l.AppID()}})
+	return nil
+}
+
+func (s *Server) muteLeg(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.doMuteLeg(id); err != nil {
+		handleAPIError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "muted"})
 }
 
-func (s *Server) unmuteLeg(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doUnmuteLeg(id string) error {
 	l, ok := s.LegMgr.Get(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
-		return
+		return newAPIError(http.StatusNotFound, "leg not found")
 	}
 
 	l.SetMuted(false)
 
-	// Sync to mixer if the leg is in a room.
 	if roomID := l.RoomID(); roomID != "" {
 		if rm, ok := s.RoomMgr.Get(roomID); ok {
 			rm.Mixer().SetParticipantMuted(id, false)
@@ -231,15 +239,22 @@ func (s *Server) unmuteLeg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.Bus.Publish(events.LegUnmuted, &events.LegUnmutedData{LegScope: events.LegScope{LegID: id, AppID: l.AppID()}})
+	return nil
+}
+
+func (s *Server) unmuteLeg(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.doUnmuteLeg(id); err != nil {
+		handleAPIError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "unmuted"})
 }
 
-func (s *Server) deafLeg(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doDeafLeg(id string) error {
 	l, ok := s.LegMgr.Get(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
-		return
+		return newAPIError(http.StatusNotFound, "leg not found")
 	}
 
 	l.SetDeaf(true)
@@ -251,15 +266,22 @@ func (s *Server) deafLeg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.Bus.Publish(events.LegDeaf, &events.LegDeafData{LegScope: events.LegScope{LegID: id, AppID: l.AppID()}})
+	return nil
+}
+
+func (s *Server) deafLeg(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.doDeafLeg(id); err != nil {
+		handleAPIError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deaf"})
 }
 
-func (s *Server) undeafLeg(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doUndeafLeg(id string) error {
 	l, ok := s.LegMgr.Get(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
-		return
+		return newAPIError(http.StatusNotFound, "leg not found")
 	}
 
 	l.SetDeaf(false)
@@ -271,28 +293,42 @@ func (s *Server) undeafLeg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.Bus.Publish(events.LegUndeaf, &events.LegUndeafData{LegScope: events.LegScope{LegID: id, AppID: l.AppID()}})
+	return nil
+}
+
+func (s *Server) undeafLeg(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.doUndeafLeg(id); err != nil {
+		handleAPIError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "undeaf"})
 }
 
-func (s *Server) holdLeg(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doHoldLeg(ctx context.Context, id string) error {
 	l, ok := s.LegMgr.Get(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
-		return
+		return newAPIError(http.StatusNotFound, "leg not found")
 	}
 
 	sipLeg, ok := l.(*leg.SIPLeg)
 	if !ok {
-		writeError(w, http.StatusBadRequest, "only SIP legs support hold")
-		return
+		return newAPIError(http.StatusBadRequest, "only SIP legs support hold")
 	}
 
-	if err := sipLeg.Hold(r.Context()); err != nil {
-		writeError(w, http.StatusConflict, err.Error())
-		return
+	if err := sipLeg.Hold(ctx); err != nil {
+		return newAPIError(http.StatusConflict, "%s", err.Error())
 	}
 
+	return nil
+}
+
+func (s *Server) holdLeg(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.doHoldLeg(r.Context(), id); err != nil {
+		handleAPIError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "held"})
 }
 
@@ -333,25 +369,30 @@ func (s *Server) HandleReInvite(callID string, direction string) []byte {
 	return nil
 }
 
-func (s *Server) unholdLeg(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doUnholdLeg(ctx context.Context, id string) error {
 	l, ok := s.LegMgr.Get(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
-		return
+		return newAPIError(http.StatusNotFound, "leg not found")
 	}
 
 	sipLeg, ok := l.(*leg.SIPLeg)
 	if !ok {
-		writeError(w, http.StatusBadRequest, "only SIP legs support hold")
-		return
+		return newAPIError(http.StatusBadRequest, "only SIP legs support hold")
 	}
 
-	if err := sipLeg.Unhold(r.Context()); err != nil {
-		writeError(w, http.StatusConflict, err.Error())
-		return
+	if err := sipLeg.Unhold(ctx); err != nil {
+		return newAPIError(http.StatusConflict, "%s", err.Error())
 	}
 
+	return nil
+}
+
+func (s *Server) unholdLeg(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.doUnholdLeg(r.Context(), id); err != nil {
+		handleAPIError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "resumed"})
 }
 
@@ -378,19 +419,26 @@ func (s *Server) cleanupLeg(l leg.Leg) {
 	s.LegMgr.Remove(l.ID())
 }
 
-func (s *Server) deleteLeg(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doDeleteLeg(id string) error {
 	l, ok := s.LegMgr.Get(id)
 	if !ok {
-		writeError(w, http.StatusNotFound, "leg not found")
-		return
+		return newAPIError(http.StatusNotFound, "leg not found")
 	}
 
-	if err := l.Hangup(r.Context()); err != nil {
+	if err := l.Hangup(context.Background()); err != nil {
 		s.Log.Warn("hangup error", "error", err)
 	}
 	s.cleanupLeg(l)
 	s.publishDisconnect(l, "api_hangup")
+	return nil
+}
+
+func (s *Server) deleteLeg(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.doDeleteLeg(id); err != nil {
+		handleAPIError(w, err)
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "hung_up"})
 }
 

--- a/internal/api/legs.go
+++ b/internal/api/legs.go
@@ -33,6 +33,7 @@ func toLegView(l leg.Leg) LegView {
 		Deaf:       l.IsDeaf(),
 		AcceptDTMF: l.AcceptDTMF(),
 		Held:       l.IsHeld(),
+		AppID:      l.AppID(),
 		SIPHeaders: l.SIPHeaders(),
 	}
 }
@@ -42,7 +43,7 @@ func toLegView(l leg.Leg) LegView {
 func disconnectData(l leg.Leg, reason string) *events.LegDisconnectedData {
 	now := time.Now()
 	d := &events.LegDisconnectedData{
-		LegScope: events.LegScope{LegID: l.ID()},
+		LegScope: events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 		CDR: events.CallCDR{
 			Reason:        reason,
 			DurationTotal: roundTo2(now.Sub(l.CreatedAt()).Seconds()),
@@ -208,7 +209,7 @@ func (s *Server) muteLeg(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.Bus.Publish(events.LegMuted, &events.LegMutedData{LegScope: events.LegScope{LegID: id}})
+	s.Bus.Publish(events.LegMuted, &events.LegMutedData{LegScope: events.LegScope{LegID: id, AppID: l.AppID()}})
 	writeJSON(w, http.StatusOK, map[string]string{"status": "muted"})
 }
 
@@ -229,7 +230,7 @@ func (s *Server) unmuteLeg(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.Bus.Publish(events.LegUnmuted, &events.LegUnmutedData{LegScope: events.LegScope{LegID: id}})
+	s.Bus.Publish(events.LegUnmuted, &events.LegUnmutedData{LegScope: events.LegScope{LegID: id, AppID: l.AppID()}})
 	writeJSON(w, http.StatusOK, map[string]string{"status": "unmuted"})
 }
 
@@ -249,7 +250,7 @@ func (s *Server) deafLeg(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.Bus.Publish(events.LegDeaf, &events.LegDeafData{LegScope: events.LegScope{LegID: id}})
+	s.Bus.Publish(events.LegDeaf, &events.LegDeafData{LegScope: events.LegScope{LegID: id, AppID: l.AppID()}})
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deaf"})
 }
 
@@ -269,7 +270,7 @@ func (s *Server) undeafLeg(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.Bus.Publish(events.LegUndeaf, &events.LegUndeafData{LegScope: events.LegScope{LegID: id}})
+	s.Bus.Publish(events.LegUndeaf, &events.LegUndeafData{LegScope: events.LegScope{LegID: id, AppID: l.AppID()}})
 	writeJSON(w, http.StatusOK, map[string]string{"status": "undeaf"})
 }
 
@@ -299,13 +300,13 @@ func (s *Server) holdLeg(w http.ResponseWriter, r *http.Request) {
 func (s *Server) setupHoldCallbacks(l *leg.SIPLeg) {
 	l.OnHold(func() {
 		s.Bus.Publish(events.LegHold, &events.LegHoldData{
-			LegScope: events.LegScope{LegID: l.ID()},
+			LegScope: events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 			LegType:  string(l.Type()),
 		})
 	})
 	l.OnUnhold(func() {
 		s.Bus.Publish(events.LegUnhold, &events.LegUnholdData{
-			LegScope: events.LegScope{LegID: l.ID()},
+			LegScope: events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 			LegType:  string(l.Type()),
 		})
 	})
@@ -429,7 +430,7 @@ func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, re
 	// Ensure room exists if room_id is specified; create it if it doesn't.
 	if req.RoomID != "" {
 		if _, ok := s.RoomMgr.Get(req.RoomID); !ok {
-			if _, err := s.RoomMgr.Create(req.RoomID); err != nil {
+			if _, err := s.RoomMgr.Create(req.RoomID, req.AppID); err != nil {
 				writeError(w, http.StatusInternalServerError, fmt.Sprintf("create room: %v", err))
 				return
 			}
@@ -445,10 +446,13 @@ func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, re
 	if req.AcceptDTMF != nil {
 		l.SetAcceptDTMF(*req.AcceptDTMF)
 	}
+	if req.AppID != "" {
+		l.SetAppID(req.AppID)
+	}
 
 	l.OnDTMF(func(digit rune) {
 		s.Bus.Publish(events.DTMFReceived, &events.DTMFReceivedData{
-			LegScope: events.LegScope{LegID: l.ID()},
+			LegScope: events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 			Digit:    string(digit),
 		})
 		s.broadcastDTMF(l.ID(), digit)
@@ -504,7 +508,7 @@ func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, re
 			return
 		}
 		s.Bus.Publish(events.LegEarlyMedia, &events.LegEarlyMediaData{
-			LegScope: events.LegScope{LegID: l.ID()},
+			LegScope: events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 			LegType:  string(l.Type()),
 		})
 		// NOTE: AMD is NOT started here — early media carries ringback
@@ -525,7 +529,7 @@ func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, re
 		s.Webhooks.SetLegWebhook(l.ID(), req.WebhookURL, req.WebhookSecret)
 	}
 	s.Bus.Publish(events.LegRinging, &events.LegRingingData{
-		LegScope:   events.LegScope{LegID: l.ID()},
+		LegScope:   events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 		URI:        req.URI,
 		From:       req.From,
 		SIPHeaders: req.Headers,
@@ -570,7 +574,7 @@ func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, re
 		})
 
 		s.Bus.Publish(events.LegConnected, &events.LegConnectedData{
-			LegScope: events.LegScope{LegID: l.ID()},
+			LegScope: events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 			LegType:  string(l.Type()),
 		})
 		s.startSpeakingDetector(l)
@@ -619,6 +623,9 @@ func (s *Server) HandleInboundCall(call *sipmod.InboundCall) {
 	}
 
 	l := leg.NewSIPInboundLeg(call, s.SIPEngine, s.Log)
+	if appID, ok := l.SIPHeaders()["X-App-ID"]; ok {
+		l.SetAppID(appID)
+	}
 	s.LegMgr.Add(l)
 
 	// Apply server-default jitter buffer to inbound legs. No per-call
@@ -644,7 +651,7 @@ func (s *Server) HandleInboundCall(call *sipmod.InboundCall) {
 	}
 
 	s.Bus.Publish(events.LegRinging, &events.LegRingingData{
-		LegScope:   events.LegScope{LegID: l.ID()},
+		LegScope:   events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 		From:       call.From,
 		To:         call.To,
 		SIPHeaders: l.SIPHeaders(),
@@ -663,7 +670,7 @@ func (s *Server) HandleInboundCall(call *sipmod.InboundCall) {
 		// Set up DTMF event forwarding
 		l.OnDTMF(func(digit rune) {
 			s.Bus.Publish(events.DTMFReceived, &events.DTMFReceivedData{
-				LegScope: events.LegScope{LegID: l.ID()},
+				LegScope: events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 				Digit:    string(digit),
 			})
 			s.broadcastDTMF(l.ID(), digit)
@@ -687,7 +694,7 @@ func (s *Server) HandleInboundCall(call *sipmod.InboundCall) {
 		})
 
 		s.Bus.Publish(events.LegConnected, &events.LegConnectedData{
-			LegScope: events.LegScope{LegID: l.ID()},
+			LegScope: events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 			LegType:  string(l.Type()),
 		})
 		s.startSpeakingDetector(l)
@@ -737,7 +744,7 @@ func (s *Server) prepareAMD(l *leg.SIPLeg, req *AMDParams) (func(), error) {
 				detection := analyzer.Run(l.Context(), resampleReader)
 
 				s.Bus.Publish(events.AMDResult, &events.AMDResultData{
-					LegScope:           events.LegScope{LegID: l.ID()},
+					LegScope:           events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 					Result:             string(detection.Result),
 					InitialSilenceMs:   detection.InitialSilenceMs,
 					GreetingDurationMs: detection.GreetingDurationMs,
@@ -748,7 +755,7 @@ func (s *Server) prepareAMD(l *leg.SIPLeg, req *AMDParams) (func(), error) {
 					beep := analyzer.WaitForBeep(l.Context(), resampleReader)
 					if beep.Detected {
 						s.Bus.Publish(events.AMDBeep, &events.AMDBeepData{
-							LegScope: events.LegScope{LegID: l.ID()},
+							LegScope: events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 							BeepMs:   beep.BeepMs,
 						})
 					}
@@ -871,7 +878,7 @@ func (s *Server) startSpeakingDetector(l leg.Leg) {
 			typ = events.SpeakingStopped
 		}
 		s.Bus.Publish(typ, &events.SpeakingData{
-			LegRoomScope: events.LegRoomScope{LegID: e.LegID, RoomID: l.RoomID()},
+			LegRoomScope: events.LegRoomScope{LegID: e.LegID, RoomID: l.RoomID(), AppID: l.AppID()},
 		})
 	})
 	l.SetSpeakingTap(det)

--- a/internal/api/openapi_meta.go
+++ b/internal/api/openapi_meta.go
@@ -844,8 +844,8 @@ func RoutesMetadata() []RouteMeta {
 
 		// ── Event Stream ────────────────────────────────────────────────
 		{
-			Method: "GET", Path: "/events/ws", OperationID: "wsEvents",
-			Summary: "WebSocket event stream",
+			Method: "GET", Path: "/vsi", OperationID: "vsi",
+			Summary: "VoiceBlender Streaming Interface (VSI)",
 			Description: "Upgrades to a WebSocket connection and streams all events in real-time as " +
 				"JSON text frames. The JSON shape is identical to webhook payloads. " +
 				"The server sends a `{\"type\":\"connected\"}` message on connect, followed by events " +

--- a/internal/api/openapi_meta.go
+++ b/internal/api/openapi_meta.go
@@ -842,6 +842,22 @@ func RoutesMetadata() []RouteMeta {
 			},
 		},
 
+		// ── Event Stream ────────────────────────────────────────────────
+		{
+			Method: "GET", Path: "/events/ws", OperationID: "wsEvents",
+			Summary: "WebSocket event stream",
+			Description: "Upgrades to a WebSocket connection and streams all events in real-time as " +
+				"JSON text frames. The JSON shape is identical to webhook payloads. " +
+				"The server sends a `{\"type\":\"connected\"}` message on connect, followed by events " +
+				"and periodic `{\"type\":\"ping\"}` keepalives. " +
+				"Clients may send `{\"type\":\"pong\"}` or `{\"type\":\"stop\"}` to close gracefully. " +
+				"Unknown message types receive an error response with the echoed `request_id` (reserved for future commands).",
+			Tags: []string{"Events"},
+			Responses: map[int]ResponseMeta{
+				101: {Description: "WebSocket upgrade successful. Server sends events as JSON text frames."},
+			},
+		},
+
 		// ── WebRTC ──────────────────────────────────────────────────────
 		{
 			Method: "POST", Path: "/webrtc/offer", OperationID: "webrtcOffer",

--- a/internal/api/playback.go
+++ b/internal/api/playback.go
@@ -89,9 +89,10 @@ func (s *Server) playLeg(w http.ResponseWriter, r *http.Request) {
 
 	playRate := uint32(mixer.SampleRate) // always play at mixer rate
 
+	appID := l.AppID()
 	player.OnStart(func() {
 		s.Bus.Publish(events.PlaybackStarted, &events.PlaybackStartedData{
-			LegRoomScope: events.LegRoomScope{LegID: id},
+			LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 			PlaybackID:   playbackID,
 		})
 	})
@@ -101,7 +102,7 @@ func (s *Server) playLeg(w http.ResponseWriter, r *http.Request) {
 			spec, ok := playback.LookupTone(req.Tone)
 			if !ok {
 				s.Bus.Publish(events.PlaybackError, &events.PlaybackErrorData{
-					LegRoomScope: events.LegRoomScope{LegID: id},
+					LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 					PlaybackID:   playbackID,
 					Error:        fmt.Sprintf("unknown tone %q, available: %s", req.Tone, strings.Join(playback.ToneNames(), ", ")),
 				})
@@ -120,13 +121,13 @@ func (s *Server) playLeg(w http.ResponseWriter, r *http.Request) {
 		legPlayers.Unlock()
 		if err != nil && err != context.Canceled {
 			s.Bus.Publish(events.PlaybackError, &events.PlaybackErrorData{
-				LegRoomScope: events.LegRoomScope{LegID: id},
+				LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 				PlaybackID:   playbackID,
 				Error:        err.Error(),
 			})
 		} else {
 			s.Bus.Publish(events.PlaybackFinished, &events.PlaybackFinishedData{
-				LegRoomScope: events.LegRoomScope{LegID: id},
+				LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 				PlaybackID:   playbackID,
 			})
 		}
@@ -207,9 +208,10 @@ func (s *Server) playRoom(w http.ResponseWriter, r *http.Request) {
 	roomPlayers.m[id][playbackID] = player
 	roomPlayers.Unlock()
 
+	roomAppID := rm.AppID
 	player.OnStart(func() {
 		s.Bus.Publish(events.PlaybackStarted, &events.PlaybackStartedData{
-			LegRoomScope: events.LegRoomScope{RoomID: id},
+			LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 			PlaybackID:   playbackID,
 		})
 	})
@@ -222,7 +224,7 @@ func (s *Server) playRoom(w http.ResponseWriter, r *http.Request) {
 				pw.Close()
 				rm.Mixer().RemoveParticipant(playbackID)
 				s.Bus.Publish(events.PlaybackError, &events.PlaybackErrorData{
-					LegRoomScope: events.LegRoomScope{RoomID: id},
+					LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 					PlaybackID:   playbackID,
 					Error:        fmt.Sprintf("unknown tone %q, available: %s", req.Tone, strings.Join(playback.ToneNames(), ", ")),
 				})
@@ -245,13 +247,13 @@ func (s *Server) playRoom(w http.ResponseWriter, r *http.Request) {
 		if err != nil && err != context.Canceled {
 			s.Log.Debug("room playback error", "room_id", id, "error", err)
 			s.Bus.Publish(events.PlaybackError, &events.PlaybackErrorData{
-				LegRoomScope: events.LegRoomScope{RoomID: id},
+				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 				PlaybackID:   playbackID,
 				Error:        err.Error(),
 			})
 		} else {
 			s.Bus.Publish(events.PlaybackFinished, &events.PlaybackFinishedData{
-				LegRoomScope: events.LegRoomScope{RoomID: id},
+				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 				PlaybackID:   playbackID,
 			})
 		}
@@ -342,7 +344,7 @@ func (s *Server) volumePlayRoom(w http.ResponseWriter, r *http.Request) {
 type legPlaybackWriter struct {
 	legID        string
 	leg          leg.Leg
-	directWriter io.Writer   // leg.AudioWriter(), captured once
+	directWriter io.Writer // leg.AudioWriter(), captured once
 	roomMgr      *room.Manager
 }
 

--- a/internal/api/recording.go
+++ b/internal/api/recording.go
@@ -353,7 +353,7 @@ func (s *Server) recordLeg(w http.ResponseWriter, r *http.Request) {
 	legRecorders.Unlock()
 
 	s.Bus.Publish(events.RecordingStarted, &events.RecordingStartedData{
-		LegRoomScope: events.LegRoomScope{LegID: id},
+		LegRoomScope: events.LegRoomScope{LegID: id, AppID: l.AppID()},
 		File:         fpath,
 	})
 	writeJSON(w, http.StatusOK, map[string]interface{}{"status": "recording", "file": fpath})
@@ -423,8 +423,12 @@ func (s *Server) stopLegRecording(legID string) (string, bool) {
 		}
 	}
 
+	legAppID := ""
+	if ll, ok := s.LegMgr.Get(legID); ok {
+		legAppID = ll.AppID()
+	}
 	s.Bus.Publish(events.RecordingFinished, &events.RecordingFinishedData{
-		LegRoomScope: events.LegRoomScope{LegID: legID},
+		LegRoomScope: events.LegRoomScope{LegID: legID, AppID: legAppID},
 		File:         location,
 	})
 	return location, true
@@ -453,8 +457,12 @@ func (s *Server) pauseRecordLeg(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]interface{}{"status": "already_paused"})
 		return
 	}
+	legAppID := ""
+	if ll, ok := s.LegMgr.Get(id); ok {
+		legAppID = ll.AppID()
+	}
 	s.Bus.Publish(events.RecordingPaused, &events.RecordingPausedData{
-		LegRoomScope: events.LegRoomScope{LegID: id},
+		LegRoomScope: events.LegRoomScope{LegID: id, AppID: legAppID},
 	})
 	writeJSON(w, http.StatusOK, map[string]interface{}{"status": "paused"})
 }
@@ -472,8 +480,12 @@ func (s *Server) resumeRecordLeg(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]interface{}{"status": "not_paused"})
 		return
 	}
+	legAppID := ""
+	if ll, ok := s.LegMgr.Get(id); ok {
+		legAppID = ll.AppID()
+	}
 	s.Bus.Publish(events.RecordingResumed, &events.RecordingResumedData{
-		LegRoomScope: events.LegRoomScope{LegID: id},
+		LegRoomScope: events.LegRoomScope{LegID: id, AppID: legAppID},
 	})
 	writeJSON(w, http.StatusOK, map[string]interface{}{"status": "resumed"})
 }
@@ -552,7 +564,7 @@ func (s *Server) recordRoom(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.Bus.Publish(events.RecordingStarted, &events.RecordingStartedData{
-		LegRoomScope: events.LegRoomScope{RoomID: id},
+		LegRoomScope: events.LegRoomScope{RoomID: id, AppID: rm.AppID},
 		File:         fpath,
 	})
 	writeJSON(w, http.StatusOK, map[string]interface{}{"status": "recording", "file": fpath})
@@ -628,9 +640,13 @@ func (s *Server) stopRecordRoom(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	roomAppID := ""
+	if rm, ok := s.RoomMgr.Get(id); ok {
+		roomAppID = rm.AppID
+	}
 	resp := map[string]interface{}{"status": "stopped", "file": location}
 	evtData := &events.RecordingFinishedData{
-		LegRoomScope: events.LegRoomScope{RoomID: id},
+		LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 		File:         location,
 	}
 	if mcResult != nil {
@@ -703,8 +719,12 @@ func (s *Server) pauseRecordRoom(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]interface{}{"status": "already_paused"})
 		return
 	}
+	roomAppID := ""
+	if rm, ok := s.RoomMgr.Get(id); ok {
+		roomAppID = rm.AppID
+	}
 	s.Bus.Publish(events.RecordingPaused, &events.RecordingPausedData{
-		LegRoomScope: events.LegRoomScope{RoomID: id},
+		LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 	})
 	writeJSON(w, http.StatusOK, map[string]interface{}{"status": "paused"})
 }
@@ -720,8 +740,12 @@ func (s *Server) resumeRecordRoom(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]interface{}{"status": "not_paused"})
 		return
 	}
+	roomAppID := ""
+	if rm, ok := s.RoomMgr.Get(id); ok {
+		roomAppID = rm.AppID
+	}
 	s.Bus.Publish(events.RecordingResumed, &events.RecordingResumedData{
-		LegRoomScope: events.LegRoomScope{RoomID: id},
+		LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 	})
 	writeJSON(w, http.StatusOK, map[string]interface{}{"status": "resumed"})
 }
@@ -739,8 +763,12 @@ func (s *Server) stopRoomRecordingIfEmpty(roomID string) {
 		return
 	}
 
+	roomAppID := ""
+	if rm, ok := s.RoomMgr.Get(roomID); ok {
+		roomAppID = rm.AppID
+	}
 	evtData := &events.RecordingFinishedData{
-		LegRoomScope: events.LegRoomScope{RoomID: roomID},
+		LegRoomScope: events.LegRoomScope{RoomID: roomID, AppID: roomAppID},
 		File:         location,
 	}
 	if mcResult != nil {

--- a/internal/api/rooms.go
+++ b/internal/api/rooms.go
@@ -1,29 +1,36 @@
 package api
 
 import (
-	"fmt"
+	"context"
 	"net/http"
 
 	"github.com/VoiceBlender/voiceblender/internal/leg"
 	"github.com/go-chi/chi/v5"
 )
 
-func (s *Server) createRoom(w http.ResponseWriter, r *http.Request) {
-	var req CreateRoomRequest
-	if err := decodeJSON(r, &req); err != nil {
-		// Allow empty body
-		req.ID = ""
-	}
-
+func (s *Server) doCreateRoom(req CreateRoomRequest) (RoomView, error) {
 	room, err := s.RoomMgr.Create(req.ID, req.AppID)
 	if err != nil {
-		writeError(w, http.StatusConflict, err.Error())
-		return
+		return RoomView{}, newAPIError(http.StatusConflict, "%s", err.Error())
 	}
 	if req.WebhookURL != "" {
 		s.Webhooks.SetRoomWebhook(room.ID, req.WebhookURL, req.WebhookSecret)
 	}
-	writeJSON(w, http.StatusCreated, RoomView{ID: room.ID, AppID: room.AppID, Participants: []LegView{}})
+	return RoomView{ID: room.ID, AppID: room.AppID, Participants: []LegView{}}, nil
+}
+
+func (s *Server) createRoom(w http.ResponseWriter, r *http.Request) {
+	var req CreateRoomRequest
+	if err := decodeJSON(r, &req); err != nil {
+		req = CreateRoomRequest{}
+	}
+
+	view, err := s.doCreateRoom(req)
+	if err != nil {
+		handleAPIError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, view)
 }
 
 func (s *Server) listRooms(w http.ResponseWriter, r *http.Request) {
@@ -55,41 +62,39 @@ func (s *Server) getRoom(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, RoomView{ID: rm.ID, AppID: rm.AppID, Participants: pViews})
 }
 
-func (s *Server) deleteRoom(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+func (s *Server) doDeleteRoom(id string) error {
 	s.cleanupRoomAgent(id)
 	s.Webhooks.ClearRoomWebhook(id)
 	if err := s.RoomMgr.Delete(id); err != nil {
-		writeError(w, http.StatusNotFound, err.Error())
+		return newAPIError(http.StatusNotFound, "%s", err.Error())
+	}
+	return nil
+}
+
+func (s *Server) deleteRoom(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.doDeleteRoom(id); err != nil {
+		handleAPIError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 
-func (s *Server) addLegToRoom(w http.ResponseWriter, r *http.Request) {
-	roomID := chi.URLParam(r, "id")
-	var req AddLegRequest
-	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON")
-		return
-	}
+func (s *Server) doAddLegToRoom(ctx context.Context, roomID string, req AddLegRequest) (interface{}, error) {
 	l, ok := s.LegMgr.Get(req.LegID)
 	if !ok {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("leg %s not found", req.LegID))
-		return
+		return nil, newAPIError(http.StatusBadRequest, "leg %s not found", req.LegID)
 	}
 
 	// Auto-create the room if it doesn't exist, inheriting app_id from the leg.
 	if _, ok := s.RoomMgr.Get(roomID); !ok {
 		if _, err := s.RoomMgr.Create(roomID, l.AppID()); err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("create room: %v", err))
-			return
+			return nil, newAPIError(http.StatusInternalServerError, "create room: %v", err)
 		}
 	}
 
 	// Apply mute/deaf before the leg enters the mixer so the participant
-	// is added with the desired state in a single atomic step (no frame
-	// of un-muted audio leaks into the mix).
+	// is added with the desired state in a single atomic step.
 	if req.Mute != nil {
 		l.SetMuted(*req.Mute)
 	}
@@ -103,51 +108,67 @@ func (s *Server) addLegToRoom(w http.ResponseWriter, r *http.Request) {
 	// If the leg is already in a room, move it instead of adding.
 	if fromRoomID, inRoom := s.RoomMgr.FindLegRoom(req.LegID); inRoom {
 		if fromRoomID == roomID {
-			writeError(w, http.StatusBadRequest, "leg already in this room")
-			return
+			return nil, newAPIError(http.StatusBadRequest, "leg already in this room")
 		}
-		// Stop per-participant recording in the old room before moving.
 		s.onLegLeavingRoomRecording(fromRoomID, req.LegID)
 		if err := s.RoomMgr.MoveLeg(fromRoomID, roomID, req.LegID); err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
-			return
+			return nil, newAPIError(http.StatusBadRequest, "%s", err.Error())
 		}
 		s.onLegJoinedRoom(roomID, req.LegID)
 		s.stopRoomAgentIfEmpty(fromRoomID)
-		writeJSON(w, http.StatusOK, map[string]string{
+		return map[string]string{
 			"status": "moved",
 			"from":   fromRoomID,
 			"to":     roomID,
-		})
-		return
+		}, nil
 	}
 
 	// Auto-answer ringing inbound SIP legs before adding to the room.
 	if sipLeg, ok := l.(*leg.SIPLeg); ok && l.State() == leg.StateRinging && l.Type() == leg.TypeSIPInbound {
 		sipLeg.SignalAnswer()
-		if err := sipLeg.WaitConnected(r.Context()); err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("auto-answer failed: %v", err))
-			return
+		if err := sipLeg.WaitConnected(ctx); err != nil {
+			return nil, newAPIError(http.StatusInternalServerError, "auto-answer failed: %v", err)
 		}
 	}
 
 	if err := s.RoomMgr.AddLeg(roomID, req.LegID); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
+		return nil, newAPIError(http.StatusBadRequest, "%s", err.Error())
 	}
 	s.onLegJoinedRoom(roomID, req.LegID)
-	writeJSON(w, http.StatusOK, map[string]string{"status": "added"})
+	return map[string]string{"status": "added"}, nil
+}
+
+func (s *Server) addLegToRoom(w http.ResponseWriter, r *http.Request) {
+	roomID := chi.URLParam(r, "id")
+	var req AddLegRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+
+	result, err := s.doAddLegToRoom(r.Context(), roomID, req)
+	if err != nil {
+		handleAPIError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) doRemoveLegFromRoom(roomID, legID string) error {
+	s.onLegLeavingRoomRecording(roomID, legID)
+	if err := s.RoomMgr.RemoveLeg(roomID, legID); err != nil {
+		return newAPIError(http.StatusBadRequest, "%s", err.Error())
+	}
+	s.stopRoomAgentIfEmpty(roomID)
+	return nil
 }
 
 func (s *Server) removeLegFromRoom(w http.ResponseWriter, r *http.Request) {
 	roomID := chi.URLParam(r, "id")
 	legID := chi.URLParam(r, "legID")
-	// Stop per-participant recording before removing from mixer.
-	s.onLegLeavingRoomRecording(roomID, legID)
-	if err := s.RoomMgr.RemoveLeg(roomID, legID); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+	if err := s.doRemoveLegFromRoom(roomID, legID); err != nil {
+		handleAPIError(w, err)
 		return
 	}
-	s.stopRoomAgentIfEmpty(roomID)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "removed"})
 }

--- a/internal/api/rooms.go
+++ b/internal/api/rooms.go
@@ -15,7 +15,7 @@ func (s *Server) createRoom(w http.ResponseWriter, r *http.Request) {
 		req.ID = ""
 	}
 
-	room, err := s.RoomMgr.Create(req.ID)
+	room, err := s.RoomMgr.Create(req.ID, req.AppID)
 	if err != nil {
 		writeError(w, http.StatusConflict, err.Error())
 		return
@@ -23,7 +23,7 @@ func (s *Server) createRoom(w http.ResponseWriter, r *http.Request) {
 	if req.WebhookURL != "" {
 		s.Webhooks.SetRoomWebhook(room.ID, req.WebhookURL, req.WebhookSecret)
 	}
-	writeJSON(w, http.StatusCreated, RoomView{ID: room.ID, Participants: []LegView{}})
+	writeJSON(w, http.StatusCreated, RoomView{ID: room.ID, AppID: room.AppID, Participants: []LegView{}})
 }
 
 func (s *Server) listRooms(w http.ResponseWriter, r *http.Request) {
@@ -35,7 +35,7 @@ func (s *Server) listRooms(w http.ResponseWriter, r *http.Request) {
 		for j, p := range parts {
 			pViews[j] = toLegView(p)
 		}
-		views[i] = RoomView{ID: rm.ID, Participants: pViews}
+		views[i] = RoomView{ID: rm.ID, AppID: rm.AppID, Participants: pViews}
 	}
 	writeJSON(w, http.StatusOK, views)
 }
@@ -52,7 +52,7 @@ func (s *Server) getRoom(w http.ResponseWriter, r *http.Request) {
 	for j, p := range parts {
 		pViews[j] = toLegView(p)
 	}
-	writeJSON(w, http.StatusOK, RoomView{ID: rm.ID, Participants: pViews})
+	writeJSON(w, http.StatusOK, RoomView{ID: rm.ID, AppID: rm.AppID, Participants: pViews})
 }
 
 func (s *Server) deleteRoom(w http.ResponseWriter, r *http.Request) {
@@ -73,18 +73,18 @@ func (s *Server) addLegToRoom(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
-	// Auto-create the room if it doesn't exist.
-	if _, ok := s.RoomMgr.Get(roomID); !ok {
-		if _, err := s.RoomMgr.Create(roomID); err != nil {
-			writeError(w, http.StatusInternalServerError, fmt.Sprintf("create room: %v", err))
-			return
-		}
-	}
-
 	l, ok := s.LegMgr.Get(req.LegID)
 	if !ok {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("leg %s not found", req.LegID))
 		return
+	}
+
+	// Auto-create the room if it doesn't exist, inheriting app_id from the leg.
+	if _, ok := s.RoomMgr.Get(roomID); !ok {
+		if _, err := s.RoomMgr.Create(roomID, l.AppID()); err != nil {
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("create room: %v", err))
+			return
+		}
 	}
 
 	// Apply mute/deaf before the leg enters the mixer so the participant

--- a/internal/api/rooms_test.go
+++ b/internal/api/rooms_test.go
@@ -33,6 +33,8 @@ func (m *apiMockLeg) Answer(context.Context) error           { return nil }
 func (m *apiMockLeg) Context() context.Context               { return context.Background() }
 func (m *apiMockLeg) RoomID() string                         { return m.roomID }
 func (m *apiMockLeg) SetRoomID(id string)                    { m.roomID = id }
+func (m *apiMockLeg) AppID() string                          { return "" }
+func (m *apiMockLeg) SetAppID(string)                        {}
 func (m *apiMockLeg) IsMuted() bool                          { return m.muted }
 func (m *apiMockLeg) SetMuted(v bool)                        { m.muted = v }
 func (m *apiMockLeg) IsDeaf() bool                           { return m.deaf }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -161,6 +161,9 @@ func (s *Server) routes() {
 		r.Delete("/rooms/{id}/agent", s.stopAgentRoom)
 		r.Get("/rooms/{id}/ws", s.wsRoom)
 
+		// Event stream
+		r.Get("/events/ws", s.wsEvents)
+
 		// WebRTC
 		r.Post("/webrtc/offer", s.webrtcOffer)
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -162,7 +162,7 @@ func (s *Server) routes() {
 		r.Get("/rooms/{id}/ws", s.wsRoom)
 
 		// Event stream
-		r.Get("/events/ws", s.wsEvents)
+		r.Get("/vsi", s.vsi)
 
 		// WebRTC
 		r.Post("/webrtc/offer", s.webrtcOffer)

--- a/internal/api/stt.go
+++ b/internal/api/stt.go
@@ -121,10 +121,11 @@ func (s *Server) sttLeg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bus := s.Bus
+	legAppID := l.AppID()
 	cb := func(text string, isFinal bool) {
 		s.Log.Info("stt callback fired", "leg_id", id, "text", text, "is_final", isFinal)
 		bus.Publish(events.STTText, &events.STTTextData{
-			LegRoomScope: events.LegRoomScope{LegID: id},
+			LegRoomScope: events.LegRoomScope{LegID: id, AppID: legAppID},
 			Text:         text,
 			IsFinal:      isFinal,
 		})
@@ -272,10 +273,11 @@ func (s *Server) startRoomLegSTT(roomID, legID string, l leg.Leg, mix *mixer.Mix
 	bus := s.Bus
 	opts := state.opts
 	apiKey := state.apiKey
+	sttAppID := l.AppID()
 
 	cb := func(text string, isFinal bool) {
 		bus.Publish(events.STTText, &events.STTTextData{
-			LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: roomID},
+			LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: roomID, AppID: sttAppID},
 			Text:         text,
 			IsFinal:      isFinal,
 		})

--- a/internal/api/transfer.go
+++ b/internal/api/transfer.go
@@ -140,7 +140,7 @@ func (s *Server) transferLeg(w http.ResponseWriter, r *http.Request) {
 	// Some peers skip 202 Accepted and signal only via NOTIFY; emit
 	// transfer_initiated before Do() so the event fires regardless.
 	s.Bus.Publish(events.LegTransferInitiated, &events.LegTransferInitiatedData{
-		LegScope:      events.LegScope{LegID: sl.ID()},
+		LegScope:      events.LegScope{LegID: sl.ID(), AppID: sl.AppID()},
 		Kind:          kind,
 		Target:        req.Target,
 		ReplacesLegID: req.ReplacesLegID,
@@ -158,7 +158,7 @@ func (s *Server) transferLeg(w http.ResponseWriter, r *http.Request) {
 			s.Log.Info("transfer REFER failed", "leg_id", sl.ID(), "error", err)
 			s.transfers.del(callID)
 			s.Bus.Publish(events.LegTransferFailed, &events.LegTransferFailedData{
-				LegScope: events.LegScope{LegID: sl.ID()},
+				LegScope: events.LegScope{LegID: sl.ID(), AppID: sl.AppID()},
 				Error:    err.Error(),
 			})
 			return
@@ -175,6 +175,9 @@ func (s *Server) HandleReferNotify(callID string, statusCode int, reason string,
 		return
 	}
 	scope := events.LegScope{LegID: st.legID}
+	if l, ok := s.LegMgr.Get(st.legID); ok {
+		scope.AppID = l.AppID()
+	}
 
 	if !terminated {
 		s.Bus.Publish(events.LegTransferProgress, &events.LegTransferProgressData{
@@ -226,6 +229,7 @@ func (s *Server) HandleIncomingRefer(callID, target string, replaces *sipmod.Rep
 	scope := events.LegScope{}
 	if sl != nil {
 		scope.LegID = sl.ID()
+		scope.AppID = sl.AppID()
 	}
 
 	if !s.Config.SIPReferAutoDial {
@@ -284,7 +288,7 @@ func (s *Server) originateForRefer(referrer *leg.SIPLeg, target string, replaces
 	newLeg.SetJitterBuffer(s.Config.SIPJitterBufferMs, s.Config.SIPJitterBufferMaxMs)
 	s.LegMgr.Add(newLeg)
 	s.Bus.Publish(events.LegRinging, &events.LegRingingData{
-		LegScope: events.LegScope{LegID: newLeg.ID()},
+		LegScope: events.LegScope{LegID: newLeg.ID(), AppID: newLeg.AppID()},
 		URI:      target,
 	})
 
@@ -321,7 +325,7 @@ func (s *Server) originateForRefer(referrer *leg.SIPLeg, target string, replaces
 	}
 
 	s.Bus.Publish(events.LegConnected, &events.LegConnectedData{
-		LegScope: events.LegScope{LegID: newLeg.ID()},
+		LegScope: events.LegScope{LegID: newLeg.ID(), AppID: newLeg.AppID()},
 		LegType:  string(newLeg.Type()),
 	})
 
@@ -329,7 +333,7 @@ func (s *Server) originateForRefer(referrer *leg.SIPLeg, target string, replaces
 		s.Log.Warn("transfer NOTIFY 200 failed", "error", err)
 	}
 	s.Bus.Publish(events.LegTransferCompleted, &events.LegTransferCompletedData{
-		LegScope:   events.LegScope{LegID: referrer.ID()},
+		LegScope:   events.LegScope{LegID: referrer.ID(), AppID: referrer.AppID()},
 		StatusCode: 200,
 		Reason:     "OK",
 	})
@@ -342,7 +346,7 @@ func (s *Server) notifyAndFail(referrer *leg.SIPLeg, statusCode int, reason stri
 	if referrer != nil {
 		referrer.SendNotifySipfrag(context.Background(), statusCode, reason, true)
 		s.Bus.Publish(events.LegTransferFailed, &events.LegTransferFailedData{
-			LegScope:   events.LegScope{LegID: referrer.ID()},
+			LegScope:   events.LegScope{LegID: referrer.ID(), AppID: referrer.AppID()},
 			StatusCode: statusCode,
 			Reason:     reason,
 		})

--- a/internal/api/tts.go
+++ b/internal/api/tts.go
@@ -67,6 +67,7 @@ func (s *Server) ttsLeg(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ttsID := "tts-" + uuid.New().String()[:8]
+	appID := l.AppID()
 	player := playback.NewPlayer(s.Log)
 	player.SetVolume(req.Volume)
 
@@ -93,7 +94,7 @@ func (s *Server) ttsLeg(w http.ResponseWriter, r *http.Request) {
 			}
 			legPlayers.Unlock()
 			s.Bus.Publish(events.TTSError, &events.TTSErrorData{
-				LegRoomScope: events.LegRoomScope{LegID: id},
+				LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 				TTSID:        ttsID,
 				Error:        err.Error(),
 			})
@@ -103,7 +104,7 @@ func (s *Server) ttsLeg(w http.ResponseWriter, r *http.Request) {
 
 		player.OnStart(func() {
 			s.Bus.Publish(events.TTSStarted, &events.TTSStartedData{
-				LegRoomScope: events.LegRoomScope{LegID: id},
+				LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 				TTSID:        ttsID,
 			})
 		})
@@ -119,13 +120,13 @@ func (s *Server) ttsLeg(w http.ResponseWriter, r *http.Request) {
 
 		if playErr != nil && playErr != context.Canceled {
 			s.Bus.Publish(events.TTSError, &events.TTSErrorData{
-				LegRoomScope: events.LegRoomScope{LegID: id},
+				LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 				TTSID:        ttsID,
 				Error:        playErr.Error(),
 			})
 		} else {
 			s.Bus.Publish(events.TTSFinished, &events.TTSFinishedData{
-				LegRoomScope: events.LegRoomScope{LegID: id},
+				LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 				TTSID:        ttsID,
 			})
 		}
@@ -178,6 +179,7 @@ func (s *Server) ttsRoom(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ttsID := "tts-" + uuid.New().String()[:8]
+	roomAppID := rm.AppID
 
 	pr, pw := io.Pipe()
 	rm.Mixer().AddPlaybackSource(ttsID, pr)
@@ -208,7 +210,7 @@ func (s *Server) ttsRoom(w http.ResponseWriter, r *http.Request) {
 			}
 			roomPlayers.Unlock()
 			s.Bus.Publish(events.TTSError, &events.TTSErrorData{
-				LegRoomScope: events.LegRoomScope{RoomID: id},
+				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 				TTSID:        ttsID,
 				Error:        err.Error(),
 			})
@@ -218,7 +220,7 @@ func (s *Server) ttsRoom(w http.ResponseWriter, r *http.Request) {
 
 		player.OnStart(func() {
 			s.Bus.Publish(events.TTSStarted, &events.TTSStartedData{
-				LegRoomScope: events.LegRoomScope{RoomID: id},
+				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 				TTSID:        ttsID,
 			})
 		})
@@ -237,13 +239,13 @@ func (s *Server) ttsRoom(w http.ResponseWriter, r *http.Request) {
 		if playErr != nil && playErr != context.Canceled {
 			s.Log.Debug("room TTS playback error", "room_id", id, "error", playErr)
 			s.Bus.Publish(events.TTSError, &events.TTSErrorData{
-				LegRoomScope: events.LegRoomScope{RoomID: id},
+				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 				TTSID:        ttsID,
 				Error:        playErr.Error(),
 			})
 		} else {
 			s.Bus.Publish(events.TTSFinished, &events.TTSFinishedData{
-				LegRoomScope: events.LegRoomScope{RoomID: id},
+				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 				TTSID:        ttsID,
 			})
 		}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -36,6 +36,7 @@ type CreateLegRequest struct {
 	WebhookSecret string            `json:"webhook_secret,omitempty"` // HMAC secret for webhook signature
 	AMD           *AMDParams        `json:"amd,omitempty"`            // enable answering machine detection on outbound calls
 	AcceptDTMF    *bool             `json:"accept_dtmf,omitempty"`    // if false, leg will not receive DTMF broadcast from other legs in the same room
+	AppID         string            `json:"app_id,omitempty"`         // application identifier for event stream filtering
 }
 
 var createLegRequestFields = map[string]FieldEnrichment{
@@ -53,6 +54,7 @@ var createLegRequestFields = map[string]FieldEnrichment{
 	"webhook_secret": {Description: "HMAC-SHA256 signing secret for the per-leg webhook."},
 	"amd":            {Description: "Enable Answering Machine Detection on outbound calls. Include the object (even empty) to enable with defaults; omit to disable."},
 	"accept_dtmf":    {Description: "If false, this leg will not receive DTMF digits broadcast from other legs in the same room. Defaults to true.", Default: true},
+	"app_id":         {Description: "Application identifier. Carried through to all events for this leg. Use to filter the WebSocket event stream by app."},
 }
 
 // TransferRequest is the body for POST /v1/legs/{id}/transfer.
@@ -107,6 +109,7 @@ type LegView struct {
 	Deaf       bool              `json:"deaf"`
 	AcceptDTMF bool              `json:"accept_dtmf"`
 	Held       bool              `json:"held"`
+	AppID      string            `json:"app_id,omitempty"`
 	SIPHeaders map[string]string `json:"sip_headers,omitempty"`
 }
 
@@ -119,6 +122,7 @@ var legViewFields = map[string]FieldEnrichment{
 	"deaf":        {Description: "Whether the leg is deaf (cannot hear others)"},
 	"accept_dtmf": {Description: "Whether the leg receives DTMF digits broadcast from other legs in the same room. Defaults to true."},
 	"held":        {Description: "Whether the call is on hold (SIP legs only)"},
+	"app_id":      {Description: "Application identifier for event stream filtering."},
 	"sip_headers": {Description: "X-* headers from the inbound INVITE. Only present on sip_inbound legs."},
 }
 
@@ -127,22 +131,26 @@ type CreateRoomRequest struct {
 	ID            string `json:"id"`
 	WebhookURL    string `json:"webhook_url,omitempty"`
 	WebhookSecret string `json:"webhook_secret,omitempty"`
+	AppID         string `json:"app_id,omitempty"`
 }
 
 var createRoomRequestFields = map[string]FieldEnrichment{
 	"id":             {Description: "Custom room ID (auto-generated UUID if omitted)"},
 	"webhook_url":    {Description: "Route all events for this room exclusively to this URL instead of global webhooks.", Format: "uri"},
 	"webhook_secret": {Description: "HMAC-SHA256 signing secret for the per-room webhook."},
+	"app_id":         {Description: "Application identifier. Carried through to all events for this room. Use to filter the WebSocket event stream by app."},
 }
 
 // RoomView is the JSON representation of a room.
 type RoomView struct {
 	ID           string    `json:"id"`
+	AppID        string    `json:"app_id,omitempty"`
 	Participants []LegView `json:"participants"`
 }
 
 var roomViewFields = map[string]FieldEnrichment{
 	"id":           {Description: "Room identifier"},
+	"app_id":       {Description: "Application identifier for event stream filtering."},
 	"participants": {Description: "Legs currently in this room"},
 }
 

--- a/internal/api/webrtc.go
+++ b/internal/api/webrtc.go
@@ -115,7 +115,7 @@ func (s *Server) webrtcOffer(w http.ResponseWriter, r *http.Request) {
 	// Register leg immediately — no waiting for ICE gathering
 	s.LegMgr.Add(l)
 	s.Bus.Publish(events.LegConnected, &events.LegConnectedData{
-		LegScope: events.LegScope{LegID: l.ID()},
+		LegScope: events.LegScope{LegID: l.ID(), AppID: l.AppID()},
 		LegType:  "webrtc",
 	})
 

--- a/internal/api/ws_commands.go
+++ b/internal/api/ws_commands.go
@@ -1,0 +1,277 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// idPayload is the common payload shape for commands targeting a single resource.
+type idPayload struct {
+	ID string `json:"id"`
+}
+
+// roomLegPayload targets a leg within a room.
+type roomLegPayload struct {
+	RoomID string `json:"room_id"`
+	LegID  string `json:"leg_id"`
+}
+
+// dtmfPayload carries digits for send_leg_dtmf.
+type dtmfPayload struct {
+	ID     string `json:"id"`
+	Digits string `json:"digits"`
+}
+
+// addLegPayload combines room_id with AddLegRequest fields.
+type addLegPayload struct {
+	RoomID     string `json:"room_id"`
+	LegID      string `json:"leg_id"`
+	Mute       *bool  `json:"mute,omitempty"`
+	Deaf       *bool  `json:"deaf,omitempty"`
+	AcceptDTMF *bool  `json:"accept_dtmf,omitempty"`
+}
+
+func (s *Server) wsHandleCommand(lw *wsLockedWriter, msg vsiInMsg) {
+	switch msg.Type {
+
+	// ── Leg queries ─────────────────────────────────────────────────
+	case "list_legs":
+		legs := s.LegMgr.List()
+		views := make([]LegView, len(legs))
+		for i, l := range legs {
+			views[i] = toLegView(l)
+		}
+		s.wsCommandResult(lw, msg, views)
+
+	case "get_leg":
+		var p idPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		l, ok := s.LegMgr.Get(p.ID)
+		if !ok {
+			s.wsCommandError(lw, msg, newAPIError(404, "leg not found"))
+			return
+		}
+		s.wsCommandResult(lw, msg, toLegView(l))
+
+	// ── Leg lifecycle ───────────────────────────────────────────────
+	case "create_leg":
+		var req CreateLegRequest
+		if !s.wsParsePayload(lw, msg, &req) {
+			return
+		}
+		s.wsCreateLeg(lw, msg, req)
+
+	case "answer_leg":
+		var p idPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		if err := s.doAnswerLeg(p.ID); err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, map[string]string{"status": "answering"})
+
+	case "delete_leg":
+		var p idPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		if err := s.doDeleteLeg(p.ID); err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, map[string]string{"status": "deleted"})
+
+	// ── Leg state toggles ───────────────────────────────────────────
+	case "mute_leg":
+		s.wsSimpleLegCommand(lw, msg, s.doMuteLeg, "muted")
+	case "unmute_leg":
+		s.wsSimpleLegCommand(lw, msg, s.doUnmuteLeg, "unmuted")
+	case "deaf_leg":
+		s.wsSimpleLegCommand(lw, msg, s.doDeafLeg, "deaf")
+	case "undeaf_leg":
+		s.wsSimpleLegCommand(lw, msg, s.doUndeafLeg, "undeaf")
+	case "hold_leg":
+		var p idPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		if err := s.doHoldLeg(context.Background(), p.ID); err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, map[string]string{"status": "held"})
+	case "unhold_leg":
+		var p idPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		if err := s.doUnholdLeg(context.Background(), p.ID); err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, map[string]string{"status": "resumed"})
+
+	// ── DTMF ────────────────────────────────────────────────────────
+	case "send_leg_dtmf":
+		var p dtmfPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		if err := s.doSendLegDTMF(context.Background(), p.ID, p.Digits); err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, map[string]string{"status": "sent"})
+	case "accept_leg_dtmf":
+		s.wsSimpleLegCommand(lw, msg, s.doAcceptLegDTMF, "dtmf_accepting")
+	case "reject_leg_dtmf":
+		s.wsSimpleLegCommand(lw, msg, s.doRejectLegDTMF, "dtmf_rejecting")
+
+	// ── Room queries ────────────────────────────────────────────────
+	case "list_rooms":
+		rooms := s.RoomMgr.List()
+		views := make([]RoomView, len(rooms))
+		for i, rm := range rooms {
+			parts := rm.Participants()
+			pViews := make([]LegView, len(parts))
+			for j, p := range parts {
+				pViews[j] = toLegView(p)
+			}
+			views[i] = RoomView{ID: rm.ID, AppID: rm.AppID, Participants: pViews}
+		}
+		s.wsCommandResult(lw, msg, views)
+
+	case "get_room":
+		var p idPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		rm, ok := s.RoomMgr.Get(p.ID)
+		if !ok {
+			s.wsCommandError(lw, msg, newAPIError(404, "room not found"))
+			return
+		}
+		parts := rm.Participants()
+		pViews := make([]LegView, len(parts))
+		for j, p := range parts {
+			pViews[j] = toLegView(p)
+		}
+		s.wsCommandResult(lw, msg, RoomView{ID: rm.ID, AppID: rm.AppID, Participants: pViews})
+
+	// ── Room lifecycle ──────────────────────────────────────────────
+	case "create_room":
+		var req CreateRoomRequest
+		if !s.wsParsePayload(lw, msg, &req) {
+			return
+		}
+		view, err := s.doCreateRoom(req)
+		if err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, view)
+
+	case "delete_room":
+		var p idPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		if err := s.doDeleteRoom(p.ID); err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, map[string]string{"status": "deleted"})
+
+	case "add_leg_to_room":
+		var p addLegPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		result, err := s.doAddLegToRoom(context.Background(), p.RoomID, AddLegRequest{
+			LegID:      p.LegID,
+			Mute:       p.Mute,
+			Deaf:       p.Deaf,
+			AcceptDTMF: p.AcceptDTMF,
+		})
+		if err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, result)
+
+	case "remove_leg_from_room":
+		var p roomLegPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		if err := s.doRemoveLegFromRoom(p.RoomID, p.LegID); err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, map[string]string{"status": "removed"})
+
+	default:
+		s.vsiSendResponse(lw, msg.RequestID, "error",
+			map[string]interface{}{"code": 400, "message": "unknown command: " + msg.Type})
+	}
+}
+
+// wsSimpleLegCommand handles the common pattern: parse {id}, call doFn(id), respond.
+func (s *Server) wsSimpleLegCommand(lw *wsLockedWriter, msg vsiInMsg, doFn func(string) error, status string) {
+	var p idPayload
+	if !s.wsParsePayload(lw, msg, &p) {
+		return
+	}
+	if err := doFn(p.ID); err != nil {
+		s.wsCommandError(lw, msg, err)
+		return
+	}
+	s.wsCommandResult(lw, msg, map[string]string{"status": status})
+}
+
+// wsParsePayload unmarshals msg.Payload into dst. Returns false and sends an
+// error response if parsing fails.
+func (s *Server) wsParsePayload(lw *wsLockedWriter, msg vsiInMsg, dst interface{}) bool {
+	if len(msg.Payload) == 0 {
+		return true
+	}
+	if err := json.Unmarshal(msg.Payload, dst); err != nil {
+		s.wsCommandError(lw, msg, newAPIError(400, "invalid payload: %v", err))
+		return false
+	}
+	return true
+}
+
+func (s *Server) wsCommandResult(lw *wsLockedWriter, msg vsiInMsg, data interface{}) {
+	s.vsiSendResponse(lw, msg.RequestID, msg.Type+".result", data)
+}
+
+func (s *Server) wsCommandError(lw *wsLockedWriter, msg vsiInMsg, err error) {
+	code := 500
+	if ae, ok := err.(*apiError); ok {
+		code = ae.Code
+	}
+	s.vsiSendResponse(lw, msg.RequestID, "error", map[string]interface{}{
+		"code":    code,
+		"message": err.Error(),
+	})
+}
+
+// wsCreateLeg is a placeholder for create_leg over WS. It calls the HTTP-based
+// createSIPOutboundLeg flow synchronously. Full do* extraction of the complex
+// originate flow is deferred to Phase 2.
+func (s *Server) wsCreateLeg(lw *wsLockedWriter, msg vsiInMsg, req CreateLegRequest) {
+	switch req.Type {
+	case "sip":
+		// For now, return an error directing clients to use the REST API for
+		// leg creation until the complex originate flow is extracted into a
+		// do* method.
+		s.wsCommandError(lw, msg, newAPIError(501, "create_leg over WS not yet implemented; use POST /v1/legs"))
+	default:
+		s.wsCommandError(lw, msg, newAPIError(400, "unsupported leg type: %s", req.Type))
+	}
+}

--- a/internal/api/ws_events.go
+++ b/internal/api/ws_events.go
@@ -14,28 +14,27 @@ import (
 	"github.com/gobwas/ws/wsutil"
 )
 
-// wsEventsInMsg is the wire format for client → server messages on the event
+// vsiInMsg is the wire format for client → server messages on the VSI
 // WebSocket. The Type field selects the operation; RequestID, when set, is
 // echoed back in the response so the client can correlate async replies.
-// Payload carries command-specific data (unused in v1, reserved for future
-// commands like originate/mute/dtmf).
-type wsEventsInMsg struct {
+// Payload carries command-specific data.
+type vsiInMsg struct {
 	Type      string          `json:"type"`
 	RequestID string          `json:"request_id,omitempty"`
 	Payload   json.RawMessage `json:"payload,omitempty"`
 }
 
-// wsEventsOutMsg is the wire format for server → client response messages
+// vsiOutMsg is the wire format for server → client response messages
 // (distinct from streamed events which use the Event.MarshalJSON shape).
-type wsEventsOutMsg struct {
+type vsiOutMsg struct {
 	Type      string      `json:"type"`
 	RequestID string      `json:"request_id,omitempty"`
 	Data      interface{} `json:"data,omitempty"`
 }
 
-const wsEventsBufSize = 256
+const vsiBufSize = 256
 
-func (s *Server) wsEvents(w http.ResponseWriter, r *http.Request) {
+func (s *Server) vsi(w http.ResponseWriter, r *http.Request) {
 	// Parse optional app_id regex filter before upgrade so we can reject with 400.
 	var appFilter *regexp.Regexp
 	if pattern := r.URL.Query().Get("app_id"); pattern != "" {
@@ -49,13 +48,13 @@ func (s *Server) wsEvents(w http.ResponseWriter, r *http.Request) {
 
 	conn, _, _, err := ws.UpgradeHTTP(r, w)
 	if err != nil {
-		s.Log.Error("ws events upgrade failed", "error", err)
+		s.Log.Error("vsi upgrade failed", "error", err)
 		return
 	}
 	defer conn.Close()
 
 	var dropped atomic.Int64
-	ch := make(chan events.Event, wsEventsBufSize)
+	ch := make(chan events.Event, vsiBufSize)
 	unsub := s.Bus.Subscribe(func(e events.Event) {
 		if appFilter != nil && !appFilter.MatchString(e.Data.GetAppID()) {
 			return
@@ -72,11 +71,11 @@ func (s *Server) wsEvents(w http.ResponseWriter, r *http.Request) {
 
 	connMsg, _ := json.Marshal(map[string]string{"type": "connected"})
 	if err := lw.writeText(connMsg); err != nil {
-		s.Log.Error("ws events send connected failed", "error", err)
+		s.Log.Error("vsi send connected failed", "error", err)
 		return
 	}
 
-	s.Log.Info("ws events client connected")
+	s.Log.Info("vsi client connected")
 
 	var closed atomic.Bool
 	done := make(chan struct{})
@@ -88,7 +87,7 @@ func (s *Server) wsEvents(w http.ResponseWriter, r *http.Request) {
 			select {
 			case e := <-ch:
 				if n := dropped.Swap(0); n > 0 {
-					s.Log.Warn("ws events: notifying client of dropped events", "count", n)
+					s.Log.Warn("vsi: notifying client of dropped events", "count", n)
 					notice, _ := json.Marshal(map[string]interface{}{
 						"type":  "events_dropped",
 						"count": n,
@@ -99,7 +98,7 @@ func (s *Server) wsEvents(w http.ResponseWriter, r *http.Request) {
 				}
 				data, err := json.Marshal(e)
 				if err != nil {
-					s.Log.Warn("ws events marshal failed", "type", e.Type, "error", err)
+					s.Log.Warn("vsi marshal failed", "type", e.Type, "error", err)
 					continue
 				}
 				if err := lw.writeText(data); err != nil {
@@ -137,13 +136,13 @@ func (s *Server) wsEvents(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	// Recv loop with typed dispatch.
-	s.wsEventsRecvLoop(conn, lw, &closed)
+	s.vsiRecvLoop(conn, lw, &closed)
 
 	close(done)
-	s.Log.Info("ws events client disconnected")
+	s.Log.Info("vsi client disconnected")
 }
 
-func (s *Server) wsEventsRecvLoop(conn io.ReadWriter, lw *wsLockedWriter, closed *atomic.Bool) {
+func (s *Server) vsiRecvLoop(conn io.ReadWriter, lw *wsLockedWriter, closed *atomic.Bool) {
 	controlHandler := wsutil.ControlFrameHandler(conn, ws.StateServerSide)
 	rd := &wsutil.Reader{
 		Source: conn,
@@ -175,9 +174,9 @@ func (s *Server) wsEventsRecvLoop(conn io.ReadWriter, lw *wsLockedWriter, closed
 			continue
 		}
 
-		var msg wsEventsInMsg
+		var msg vsiInMsg
 		if err := json.Unmarshal(payload, &msg); err != nil {
-			s.wsEventsSendResponse(lw, "", "error",
+			s.vsiSendResponse(lw, "", "error",
 				map[string]string{"message": "invalid JSON"})
 			continue
 		}
@@ -189,14 +188,13 @@ func (s *Server) wsEventsRecvLoop(conn io.ReadWriter, lw *wsLockedWriter, closed
 			closed.Store(true)
 			return
 		default:
-			s.wsEventsSendResponse(lw, msg.RequestID, "error",
-				map[string]string{"message": "unknown command: " + msg.Type})
+			s.wsHandleCommand(lw, msg)
 		}
 	}
 }
 
-func (s *Server) wsEventsSendResponse(lw *wsLockedWriter, requestID, typ string, data interface{}) {
-	resp := wsEventsOutMsg{
+func (s *Server) vsiSendResponse(lw *wsLockedWriter, requestID, typ string, data interface{}) {
+	resp := vsiOutMsg{
 		Type:      typ,
 		RequestID: requestID,
 		Data:      data,

--- a/internal/api/ws_events.go
+++ b/internal/api/ws_events.go
@@ -1,0 +1,209 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"sync/atomic"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+)
+
+// wsEventsInMsg is the wire format for client → server messages on the event
+// WebSocket. The Type field selects the operation; RequestID, when set, is
+// echoed back in the response so the client can correlate async replies.
+// Payload carries command-specific data (unused in v1, reserved for future
+// commands like originate/mute/dtmf).
+type wsEventsInMsg struct {
+	Type      string          `json:"type"`
+	RequestID string          `json:"request_id,omitempty"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+}
+
+// wsEventsOutMsg is the wire format for server → client response messages
+// (distinct from streamed events which use the Event.MarshalJSON shape).
+type wsEventsOutMsg struct {
+	Type      string      `json:"type"`
+	RequestID string      `json:"request_id,omitempty"`
+	Data      interface{} `json:"data,omitempty"`
+}
+
+const wsEventsBufSize = 256
+
+func (s *Server) wsEvents(w http.ResponseWriter, r *http.Request) {
+	// Parse optional app_id regex filter before upgrade so we can reject with 400.
+	var appFilter *regexp.Regexp
+	if pattern := r.URL.Query().Get("app_id"); pattern != "" {
+		var err error
+		appFilter, err = regexp.Compile(pattern)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid app_id regex: %v", err))
+			return
+		}
+	}
+
+	conn, _, _, err := ws.UpgradeHTTP(r, w)
+	if err != nil {
+		s.Log.Error("ws events upgrade failed", "error", err)
+		return
+	}
+	defer conn.Close()
+
+	var dropped atomic.Int64
+	ch := make(chan events.Event, wsEventsBufSize)
+	unsub := s.Bus.Subscribe(func(e events.Event) {
+		if appFilter != nil && !appFilter.MatchString(e.Data.GetAppID()) {
+			return
+		}
+		select {
+		case ch <- e:
+		default:
+			dropped.Add(1)
+		}
+	})
+	defer unsub()
+
+	lw := &wsLockedWriter{conn: conn}
+
+	connMsg, _ := json.Marshal(map[string]string{"type": "connected"})
+	if err := lw.writeText(connMsg); err != nil {
+		s.Log.Error("ws events send connected failed", "error", err)
+		return
+	}
+
+	s.Log.Info("ws events client connected")
+
+	var closed atomic.Bool
+	done := make(chan struct{})
+
+	// Send loop: forward bus events as JSON text frames.
+	// Before each event, check if any were dropped and notify the client.
+	go func() {
+		for {
+			select {
+			case e := <-ch:
+				if n := dropped.Swap(0); n > 0 {
+					s.Log.Warn("ws events: notifying client of dropped events", "count", n)
+					notice, _ := json.Marshal(map[string]interface{}{
+						"type":  "events_dropped",
+						"count": n,
+					})
+					if err := lw.writeText(notice); err != nil {
+						return
+					}
+				}
+				data, err := json.Marshal(e)
+				if err != nil {
+					s.Log.Warn("ws events marshal failed", "type", e.Type, "error", err)
+					continue
+				}
+				if err := lw.writeText(data); err != nil {
+					return
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	// Ping loop.
+	go func() {
+		var eventID int64
+		ticker := time.NewTicker(wsPingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if closed.Load() {
+					return
+				}
+				eventID++
+				msg, _ := json.Marshal(map[string]interface{}{
+					"type":     "ping",
+					"event_id": eventID,
+				})
+				if err := lw.writeText(msg); err != nil {
+					return
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	// Recv loop with typed dispatch.
+	s.wsEventsRecvLoop(conn, lw, &closed)
+
+	close(done)
+	s.Log.Info("ws events client disconnected")
+}
+
+func (s *Server) wsEventsRecvLoop(conn io.ReadWriter, lw *wsLockedWriter, closed *atomic.Bool) {
+	controlHandler := wsutil.ControlFrameHandler(conn, ws.StateServerSide)
+	rd := &wsutil.Reader{
+		Source: conn,
+		State:  ws.StateServerSide,
+		OnIntermediate: func(hdr ws.Header, r io.Reader) error {
+			return controlHandler(hdr, r)
+		},
+	}
+
+	for {
+		hdr, err := rd.NextFrame()
+		if err != nil {
+			return
+		}
+
+		if hdr.OpCode.IsControl() {
+			if err := controlHandler(hdr, rd); err != nil {
+				return
+			}
+			continue
+		}
+
+		payload, err := io.ReadAll(rd)
+		if err != nil {
+			return
+		}
+
+		if hdr.OpCode != ws.OpText {
+			continue
+		}
+
+		var msg wsEventsInMsg
+		if err := json.Unmarshal(payload, &msg); err != nil {
+			s.wsEventsSendResponse(lw, "", "error",
+				map[string]string{"message": "invalid JSON"})
+			continue
+		}
+
+		switch msg.Type {
+		case "pong":
+			continue
+		case "stop":
+			closed.Store(true)
+			return
+		default:
+			s.wsEventsSendResponse(lw, msg.RequestID, "error",
+				map[string]string{"message": "unknown command: " + msg.Type})
+		}
+	}
+}
+
+func (s *Server) wsEventsSendResponse(lw *wsLockedWriter, requestID, typ string, data interface{}) {
+	resp := wsEventsOutMsg{
+		Type:      typ,
+		RequestID: requestID,
+		Data:      data,
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return
+	}
+	lw.writeText(b)
+}

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -9,18 +9,30 @@ type Handler func(Event)
 
 type Bus struct {
 	mu         sync.RWMutex
-	handlers   []Handler
+	handlers   map[uint64]Handler
+	nextID     uint64
 	instanceID string
 }
 
 func NewBus(instanceID string) *Bus {
-	return &Bus{instanceID: instanceID}
+	return &Bus{
+		handlers:   make(map[uint64]Handler),
+		instanceID: instanceID,
+	}
 }
 
-func (b *Bus) Subscribe(h Handler) {
+// Subscribe registers h and returns an unsubscribe function that removes it.
+func (b *Bus) Subscribe(h Handler) func() {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.handlers = append(b.handlers, h)
+	id := b.nextID
+	b.nextID++
+	b.handlers[id] = h
+	b.mu.Unlock()
+	return func() {
+		b.mu.Lock()
+		delete(b.handlers, id)
+		b.mu.Unlock()
+	}
 }
 
 func (b *Bus) Publish(typ EventType, data EventData) {
@@ -31,8 +43,10 @@ func (b *Bus) Publish(typ EventType, data EventData) {
 		Data:       data,
 	}
 	b.mu.RLock()
-	handlers := make([]Handler, len(b.handlers))
-	copy(handlers, b.handlers)
+	handlers := make([]Handler, 0, len(b.handlers))
+	for _, h := range b.handlers {
+		handlers = append(handlers, h)
+	}
 	b.mu.RUnlock()
 	for _, h := range handlers {
 		h(e)

--- a/internal/events/data.go
+++ b/internal/events/data.go
@@ -6,32 +6,39 @@ import "github.com/VoiceBlender/voiceblender/internal/recording"
 type EventData interface {
 	GetLegID() string
 	GetRoomID() string
+	GetAppID() string
 }
 
 // LegScope embeds in events scoped to a single leg.
 type LegScope struct {
 	LegID string `json:"leg_id"`
+	AppID string `json:"app_id,omitempty"`
 }
 
 func (b LegScope) GetLegID() string  { return b.LegID }
 func (b LegScope) GetRoomID() string { return "" }
+func (b LegScope) GetAppID() string  { return b.AppID }
 
 // RoomScope embeds in events scoped to a single room.
 type RoomScope struct {
 	RoomID string `json:"room_id"`
+	AppID  string `json:"app_id,omitempty"`
 }
 
 func (b RoomScope) GetLegID() string  { return "" }
 func (b RoomScope) GetRoomID() string { return b.RoomID }
+func (b RoomScope) GetAppID() string  { return b.AppID }
 
 // LegRoomScope embeds in events that may target a leg, a room, or both.
 type LegRoomScope struct {
 	LegID  string `json:"leg_id,omitempty"`
 	RoomID string `json:"room_id,omitempty"`
+	AppID  string `json:"app_id,omitempty"`
 }
 
 func (b LegRoomScope) GetLegID() string  { return b.LegID }
 func (b LegRoomScope) GetRoomID() string { return b.RoomID }
+func (b LegRoomScope) GetAppID() string  { return b.AppID }
 
 // --- Leg lifecycle events ---
 

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -20,7 +20,7 @@ func TestNewBus(t *testing.T) {
 func TestBus_Subscribe_Publish(t *testing.T) {
 	bus := NewBus("test")
 	received := make(chan Event, 1)
-	bus.Subscribe(func(e Event) {
+	_ = bus.Subscribe(func(e Event) {
 		received <- e
 	})
 
@@ -47,7 +47,7 @@ func TestBus_MultipleSubscribers(t *testing.T) {
 	var count atomic.Int32
 
 	for i := 0; i < 3; i++ {
-		bus.Subscribe(func(e Event) {
+		_ = bus.Subscribe(func(e Event) {
 			count.Add(1)
 		})
 	}
@@ -59,10 +59,32 @@ func TestBus_MultipleSubscribers(t *testing.T) {
 	}
 }
 
+func TestBus_Unsubscribe(t *testing.T) {
+	bus := NewBus("test")
+	var count1, count2 atomic.Int32
+
+	unsub1 := bus.Subscribe(func(e Event) { count1.Add(1) })
+	_ = bus.Subscribe(func(e Event) { count2.Add(1) })
+
+	bus.Publish(RoomCreated, &RoomCreatedData{RoomScope: RoomScope{RoomID: "r1"}})
+	if count1.Load() != 1 || count2.Load() != 1 {
+		t.Fatalf("before unsub: count1=%d count2=%d, want 1,1", count1.Load(), count2.Load())
+	}
+
+	unsub1()
+	bus.Publish(RoomCreated, &RoomCreatedData{RoomScope: RoomScope{RoomID: "r2"}})
+	if count1.Load() != 1 {
+		t.Errorf("after unsub: count1=%d, want 1 (handler should be removed)", count1.Load())
+	}
+	if count2.Load() != 2 {
+		t.Errorf("after unsub: count2=%d, want 2", count2.Load())
+	}
+}
+
 func TestBus_PublishSetsTimestamp(t *testing.T) {
 	bus := NewBus("inst")
 	var got Event
-	bus.Subscribe(func(e Event) { got = e })
+	_ = bus.Subscribe(func(e Event) { got = e })
 
 	before := time.Now().UTC()
 	bus.Publish(RoomDeleted, &RoomDeletedData{RoomScope: RoomScope{RoomID: "r1"}})

--- a/internal/events/webhook.go
+++ b/internal/events/webhook.go
@@ -54,7 +54,7 @@ func NewWebhookRegistry(bus *Bus, log *slog.Logger, globalURL, globalSecret stri
 		workCh:        make(chan deliveryJob, 1000),
 		stopCh:        make(chan struct{}),
 	}
-	bus.Subscribe(r.dispatch)
+	_ = bus.Subscribe(r.dispatch)
 	for i := 0; i < 10; i++ {
 		go r.worker()
 	}

--- a/internal/leg/leg.go
+++ b/internal/leg/leg.go
@@ -68,6 +68,8 @@ type Leg interface {
 	Context() context.Context
 	RoomID() string
 	SetRoomID(id string)
+	AppID() string
+	SetAppID(id string)
 	IsMuted() bool
 	SetMuted(muted bool)
 	IsDeaf() bool

--- a/internal/leg/leg_test.go
+++ b/internal/leg/leg_test.go
@@ -42,6 +42,8 @@ func (m *mockLeg) Answer(ctx context.Context) error             { return nil }
 func (m *mockLeg) Context() context.Context                     { return context.Background() }
 func (m *mockLeg) RoomID() string                               { return m.roomID }
 func (m *mockLeg) SetRoomID(id string)                          { m.roomID = id }
+func (m *mockLeg) AppID() string                                { return "" }
+func (m *mockLeg) SetAppID(string)                              {}
 func (m *mockLeg) IsMuted() bool                                { return m.muted }
 func (m *mockLeg) SetMuted(v bool)                              { m.muted = v }
 func (m *mockLeg) IsDeaf() bool                                 { return m.deaf }

--- a/internal/leg/sip_leg.go
+++ b/internal/leg/sip_leg.go
@@ -40,6 +40,7 @@ type SIPLeg struct {
 	ctx           context.Context
 	cancel        context.CancelFunc
 	roomID        string
+	appID         string
 	muted         atomic.Bool
 	deaf          atomic.Bool
 	acceptDTMF    atomic.Bool
@@ -353,6 +354,18 @@ func (l *SIPLeg) SetRoomID(id string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.roomID = id
+}
+
+func (l *SIPLeg) AppID() string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.appID
+}
+
+func (l *SIPLeg) SetAppID(id string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.appID = id
 }
 
 func (l *SIPLeg) IsMuted() bool             { return l.muted.Load() }

--- a/internal/leg/webrtc_leg.go
+++ b/internal/leg/webrtc_leg.go
@@ -36,6 +36,7 @@ type WebRTCLeg struct {
 	ctx        context.Context
 	cancel     context.CancelFunc
 	roomID     string
+	appID      string
 	muted      atomic.Bool
 	deaf       atomic.Bool
 	acceptDTMF atomic.Bool
@@ -97,6 +98,18 @@ func (l *WebRTCLeg) SetRoomID(id string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.roomID = id
+}
+
+func (l *WebRTCLeg) AppID() string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.appID
+}
+
+func (l *WebRTCLeg) SetAppID(id string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.appID = id
 }
 
 func (l *WebRTCLeg) IsMuted() bool              { return l.muted.Load() }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -97,7 +97,7 @@ func New(bus *events.Bus) *Collector {
 		c.callTotalDurationSeconds,
 	)
 
-	bus.Subscribe(c.handle)
+	_ = bus.Subscribe(c.handle)
 	return c
 }
 

--- a/internal/room/manager.go
+++ b/internal/room/manager.go
@@ -28,7 +28,7 @@ func NewManager(legMgr *leg.Manager, bus *events.Bus, log *slog.Logger) *Manager
 	}
 }
 
-func (m *Manager) Create(id string) (*Room, error) {
+func (m *Manager) Create(id, appID string) (*Room, error) {
 	if id == "" {
 		id = uuid.New().String()
 	}
@@ -40,9 +40,9 @@ func (m *Manager) Create(id string) (*Room, error) {
 		return nil, fmt.Errorf("room %s already exists", id)
 	}
 
-	r := NewRoom(id, m.log)
+	r := NewRoom(id, appID, m.log)
 	m.rooms[id] = r
-	m.bus.Publish(events.RoomCreated, &events.RoomCreatedData{RoomScope: events.RoomScope{RoomID: id}})
+	m.bus.Publish(events.RoomCreated, &events.RoomCreatedData{RoomScope: events.RoomScope{RoomID: id, AppID: appID}})
 	return r, nil
 }
 
@@ -86,7 +86,7 @@ func (m *Manager) Delete(id string) error {
 	}
 	wg.Wait()
 	r.Close()
-	m.bus.Publish(events.RoomDeleted, &events.RoomDeletedData{RoomScope: events.RoomScope{RoomID: id}})
+	m.bus.Publish(events.RoomDeleted, &events.RoomDeletedData{RoomScope: events.RoomScope{RoomID: id, AppID: r.AppID}})
 	return nil
 }
 
@@ -107,7 +107,7 @@ func (m *Manager) AddLeg(roomID, legID string) error {
 
 	r.AddLeg(l)
 	m.bus.Publish(events.LegJoinedRoom, &events.LegJoinedRoomData{
-		LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: roomID},
+		LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: roomID, AppID: l.AppID()},
 	})
 	return nil
 }
@@ -122,9 +122,9 @@ func (m *Manager) MoveLeg(fromRoomID, toRoomID, legID string) error {
 	m.mu.Lock()
 	toRoom, ok := m.rooms[toRoomID]
 	if !ok {
-		toRoom = NewRoom(toRoomID, m.log)
+		toRoom = NewRoom(toRoomID, "", m.log)
 		m.rooms[toRoomID] = toRoom
-		m.bus.Publish(events.RoomCreated, &events.RoomCreatedData{RoomScope: events.RoomScope{RoomID: toRoomID}})
+		m.bus.Publish(events.RoomCreated, &events.RoomCreatedData{RoomScope: events.RoomScope{RoomID: toRoomID, AppID: toRoom.AppID}})
 	}
 	m.mu.Unlock()
 
@@ -135,10 +135,10 @@ func (m *Manager) MoveLeg(fromRoomID, toRoomID, legID string) error {
 	toRoom.AddLeg(l)
 
 	m.bus.Publish(events.LegLeftRoom, &events.LegLeftRoomData{
-		LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: fromRoomID},
+		LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: fromRoomID, AppID: l.AppID()},
 	})
 	m.bus.Publish(events.LegJoinedRoom, &events.LegJoinedRoomData{
-		LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: toRoomID},
+		LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: toRoomID, AppID: l.AppID()},
 	})
 	return nil
 }
@@ -164,8 +164,12 @@ func (m *Manager) RemoveLeg(roomID, legID string) error {
 	}
 
 	r.RemoveLeg(legID)
+	legAppID := ""
+	if l, ok := m.legMgr.Get(legID); ok {
+		legAppID = l.AppID()
+	}
 	m.bus.Publish(events.LegLeftRoom, &events.LegLeftRoomData{
-		LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: roomID},
+		LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: roomID, AppID: legAppID},
 	})
 	return nil
 }

--- a/internal/room/room.go
+++ b/internal/room/room.go
@@ -10,15 +10,17 @@ import (
 
 type Room struct {
 	ID           string
+	AppID        string
 	mu           sync.RWMutex
 	participants map[string]leg.Leg
 	mix          *mixer.Mixer
 	log          *slog.Logger
 }
 
-func NewRoom(id string, log *slog.Logger) *Room {
+func NewRoom(id, appID string, log *slog.Logger) *Room {
 	return &Room{
 		ID:           id,
+		AppID:        appID,
 		participants: make(map[string]leg.Leg),
 		mix:          mixer.New(log),
 		log:          log,

--- a/internal/room/room_test.go
+++ b/internal/room/room_test.go
@@ -45,6 +45,8 @@ func (m *mockLeg) Answer(ctx context.Context) error             { return nil }
 func (m *mockLeg) Context() context.Context                     { return context.Background() }
 func (m *mockLeg) RoomID() string                               { return m.roomID }
 func (m *mockLeg) SetRoomID(id string)                          { m.roomID = id }
+func (m *mockLeg) AppID() string                                { return "" }
+func (m *mockLeg) SetAppID(string)                              {}
 func (m *mockLeg) IsMuted() bool                                { return m.muted }
 func (m *mockLeg) SetMuted(v bool)                              { m.muted = v }
 func (m *mockLeg) IsDeaf() bool                                 { return m.deaf }
@@ -65,7 +67,7 @@ func newTestLog() *slog.Logger { return slog.Default() }
 // --- Room tests ---
 
 func TestRoom_AddLeg(t *testing.T) {
-	r := NewRoom("r1", newTestLog())
+	r := NewRoom("r1", "", newTestLog())
 	l := newMockLeg("leg-1")
 
 	r.AddLeg(l)
@@ -79,7 +81,7 @@ func TestRoom_AddLeg(t *testing.T) {
 }
 
 func TestRoom_AddMultipleLegs(t *testing.T) {
-	r := NewRoom("r1", newTestLog())
+	r := NewRoom("r1", "", newTestLog())
 	r.AddLeg(newMockLeg("a"))
 	r.AddLeg(newMockLeg("b"))
 	r.AddLeg(newMockLeg("c"))
@@ -90,7 +92,7 @@ func TestRoom_AddMultipleLegs(t *testing.T) {
 }
 
 func TestRoom_RemoveLeg(t *testing.T) {
-	r := NewRoom("r1", newTestLog())
+	r := NewRoom("r1", "", newTestLog())
 	l := newMockLeg("leg-1")
 	r.AddLeg(l)
 
@@ -105,12 +107,12 @@ func TestRoom_RemoveLeg(t *testing.T) {
 }
 
 func TestRoom_RemoveLeg_Nonexistent(t *testing.T) {
-	r := NewRoom("r1", newTestLog())
+	r := NewRoom("r1", "", newTestLog())
 	r.RemoveLeg("nonexistent") // should not panic
 }
 
 func TestRoom_DetachLeg(t *testing.T) {
-	r := NewRoom("r1", newTestLog())
+	r := NewRoom("r1", "", newTestLog())
 	l := newMockLeg("leg-1")
 	r.AddLeg(l)
 
@@ -130,7 +132,7 @@ func TestRoom_DetachLeg(t *testing.T) {
 }
 
 func TestRoom_DetachLeg_NotFound(t *testing.T) {
-	r := NewRoom("r1", newTestLog())
+	r := NewRoom("r1", "", newTestLog())
 	_, ok := r.DetachLeg("nonexistent")
 	if ok {
 		t.Error("expected false")
@@ -138,7 +140,7 @@ func TestRoom_DetachLeg_NotFound(t *testing.T) {
 }
 
 func TestRoom_Participants(t *testing.T) {
-	r := NewRoom("r1", newTestLog())
+	r := NewRoom("r1", "", newTestLog())
 	r.AddLeg(newMockLeg("a"))
 	r.AddLeg(newMockLeg("b"))
 
@@ -149,7 +151,7 @@ func TestRoom_Participants(t *testing.T) {
 }
 
 func TestRoom_Close(t *testing.T) {
-	r := NewRoom("r1", newTestLog())
+	r := NewRoom("r1", "", newTestLog())
 	l := newMockLeg("leg-1")
 	r.AddLeg(l)
 
@@ -164,7 +166,7 @@ func TestRoom_Close(t *testing.T) {
 }
 
 func TestRoom_Mixer(t *testing.T) {
-	r := NewRoom("r1", newTestLog())
+	r := NewRoom("r1", "", newTestLog())
 	if r.Mixer() == nil {
 		t.Fatal("expected non-nil mixer")
 	}
@@ -176,7 +178,7 @@ func TestManager_Create(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, newTestBus(), newTestLog())
 
-	r, err := mgr.Create("")
+	r, err := mgr.Create("", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -189,7 +191,7 @@ func TestManager_Create_CustomID(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, newTestBus(), newTestLog())
 
-	r, err := mgr.Create("my-room")
+	r, err := mgr.Create("my-room", "")
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -202,8 +204,8 @@ func TestManager_Create_Duplicate(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, newTestBus(), newTestLog())
 
-	mgr.Create("r1")
-	_, err := mgr.Create("r1")
+	mgr.Create("r1", "")
+	_, err := mgr.Create("r1", "")
 	if err == nil {
 		t.Error("expected error for duplicate room")
 	}
@@ -213,7 +215,7 @@ func TestManager_Get(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, newTestBus(), newTestLog())
 
-	mgr.Create("r1")
+	mgr.Create("r1", "")
 
 	r, ok := mgr.Get("r1")
 	if !ok {
@@ -238,8 +240,8 @@ func TestManager_List(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, newTestBus(), newTestLog())
 
-	mgr.Create("a")
-	mgr.Create("b")
+	mgr.Create("a", "")
+	mgr.Create("b", "")
 
 	rooms := mgr.List()
 	if len(rooms) != 2 {
@@ -251,7 +253,7 @@ func TestManager_Delete(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, newTestBus(), newTestLog())
 
-	mgr.Create("r1")
+	mgr.Create("r1", "")
 
 	if err := mgr.Delete("r1"); err != nil {
 		t.Fatalf("Delete: %v", err)
@@ -276,7 +278,7 @@ func TestManager_AddLeg(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, bus, newTestLog())
 
-	mgr.Create("r1")
+	mgr.Create("r1", "")
 	l := newMockLeg("leg-1")
 	legMgr.Add(l)
 
@@ -304,7 +306,7 @@ func TestManager_AddLeg_RoomNotFound(t *testing.T) {
 func TestManager_AddLeg_LegNotFound(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, newTestBus(), newTestLog())
-	mgr.Create("r1")
+	mgr.Create("r1", "")
 
 	err := mgr.AddLeg("r1", "nonexistent")
 	if err == nil {
@@ -315,7 +317,7 @@ func TestManager_AddLeg_LegNotFound(t *testing.T) {
 func TestManager_AddLeg_NotConnected(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, newTestBus(), newTestLog())
-	mgr.Create("r1")
+	mgr.Create("r1", "")
 
 	l := newMockLeg("leg-1")
 	l.state = leg.StateRinging
@@ -332,7 +334,7 @@ func TestManager_RemoveLeg(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, bus, newTestLog())
 
-	mgr.Create("r1")
+	mgr.Create("r1", "")
 	l := newMockLeg("leg-1")
 	legMgr.Add(l)
 	mgr.AddLeg("r1", "leg-1")
@@ -353,7 +355,7 @@ func TestManager_FindLegRoom(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, bus, newTestLog())
 
-	mgr.Create("r1")
+	mgr.Create("r1", "")
 	l := newMockLeg("leg-1")
 	legMgr.Add(l)
 	mgr.AddLeg("r1", "leg-1")
@@ -382,8 +384,8 @@ func TestManager_MoveLeg(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, bus, newTestLog())
 
-	mgr.Create("r1")
-	mgr.Create("r2")
+	mgr.Create("r1", "")
+	mgr.Create("r2", "")
 	l := newMockLeg("leg-1")
 	legMgr.Add(l)
 	mgr.AddLeg("r1", "leg-1")
@@ -406,14 +408,14 @@ func TestManager_MoveLeg(t *testing.T) {
 func TestManager_Events(t *testing.T) {
 	bus := newTestBus()
 	var eventTypes []events.EventType
-	bus.Subscribe(func(e events.Event) {
+	_ = bus.Subscribe(func(e events.Event) {
 		eventTypes = append(eventTypes, e.Type)
 	})
 
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, bus, newTestLog())
 
-	mgr.Create("r1")
+	mgr.Create("r1", "")
 
 	found := false
 	for _, et := range eventTypes {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1800,6 +1800,16 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Error'
+    /events/ws:
+        get:
+            operationId: wsEvents
+            summary: WebSocket event stream
+            description: Upgrades to a WebSocket connection and streams all events in real-time as JSON text frames. The JSON shape is identical to webhook payloads. The server sends a `{"type":"connected"}` message on connect, followed by events and periodic `{"type":"ping"}` keepalives. Clients may send `{"type":"pong"}` or `{"type":"stop"}` to close gracefully. Unknown message types receive an error response with the echoed `request_id` (reserved for future commands).
+            tags:
+                - Events
+            responses:
+                '101':
+                    description: WebSocket upgrade successful. Server sends events as JSON text frames.
     /webrtc/offer:
         post:
             operationId: webrtcOffer
@@ -1993,6 +2003,9 @@ components:
                 held:
                     type: boolean
                     description: Whether the call is on hold (SIP legs only)
+                app_id:
+                    type: string
+                    description: Application identifier for event stream filtering.
                 sip_headers:
                     type: object
                     additionalProperties:
@@ -2015,6 +2028,9 @@ components:
                 id:
                     type: string
                     description: Room identifier
+                app_id:
+                    type: string
+                    description: Application identifier for event stream filtering.
                 participants:
                     type: array
                     items:
@@ -2133,6 +2149,9 @@ components:
                     type: boolean
                     description: If false, this leg will not receive DTMF digits broadcast from other legs in the same room. Defaults to true.
                     default: true
+                app_id:
+                    type: string
+                    description: Application identifier. Carried through to all events for this leg. Use to filter the WebSocket event stream by app.
             required:
                 - type
                 - uri
@@ -2149,6 +2168,9 @@ components:
                 webhook_secret:
                     type: string
                     description: HMAC-SHA256 signing secret for the per-room webhook.
+                app_id:
+                    type: string
+                    description: Application identifier. Carried through to all events for this room. Use to filter the WebSocket event stream by app.
             required:
                 - id
         DTMFRequest:
@@ -2512,6 +2534,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     leg_type:
                                         type: string
                                         description: Leg type (e.g. sip_inbound, sip_outbound)
@@ -2542,6 +2566,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     leg_type:
                                         type: string
                                         description: Leg type (e.g. sip_outbound)
@@ -2558,6 +2584,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     leg_type:
                                         type: string
                                         description: Leg type (e.g. sip_inbound, sip_outbound, webrtc)
@@ -2574,6 +2602,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     cdr:
                                         type: object
                                         properties:
@@ -2649,6 +2679,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
     leg.left_room:
         post:
             summary: Leg removed from a room
@@ -2665,6 +2697,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
     leg.muted:
         post:
             summary: Leg muted
@@ -2678,6 +2712,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
     leg.unmuted:
         post:
             summary: Leg unmuted
@@ -2691,6 +2727,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
     leg.hold:
         post:
             summary: Leg put on hold (local or remote)
@@ -2704,6 +2742,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     leg_type:
                                         type: string
                                         description: 'Hold direction: "local" (we put them on hold) or "remote" (they put us on hold)'
@@ -2720,6 +2760,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     leg_type:
                                         type: string
                                         description: 'Hold direction: "local" or "remote"'
@@ -2736,6 +2778,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     digit:
                                         type: string
                                         description: DTMF digit received
@@ -2755,6 +2799,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier (present only when the leg is in a room)
+                                    app_id:
+                                        type: string
     speaking.stopped:
         post:
             summary: Participant stopped speaking
@@ -2771,6 +2817,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier (present only when the leg is in a room)
+                                    app_id:
+                                        type: string
     playback.started:
         post:
             summary: Playback began
@@ -2787,6 +2835,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     playback_id:
                                         type: string
                                         description: Playback identifier
@@ -2806,6 +2856,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     playback_id:
                                         type: string
                                         description: Playback identifier
@@ -2825,6 +2877,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     playback_id:
                                         type: string
                                         description: Playback identifier
@@ -2847,6 +2901,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     tts_id:
                                         type: string
                                         description: TTS playback identifier
@@ -2866,6 +2922,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     tts_id:
                                         type: string
                                         description: TTS playback identifier
@@ -2885,6 +2943,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     tts_id:
                                         type: string
                                         description: TTS playback identifier
@@ -2907,6 +2967,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     file:
                                         type: string
                                         description: Recording file path or S3 URI
@@ -2926,6 +2988,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     file:
                                         type: string
                                         description: Recording file path or S3 URI
@@ -2951,6 +3015,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     file:
                                         type: string
     recording.resumed:
@@ -2969,6 +3035,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     file:
                                         type: string
     leg.transfer_initiated:
@@ -2984,6 +3052,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     kind:
                                         type: string
                                         description: 'Transfer kind: "blind" or "attended"'
@@ -3006,6 +3076,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     kind:
                                         type: string
                                         description: 'Transfer kind: "blind" or "attended"'
@@ -3031,6 +3103,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     status_code:
                                         type: integer
                                         description: Provisional SIP status from the NOTIFY sipfrag
@@ -3050,6 +3124,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     status_code:
                                         type: integer
                                         description: Final 2xx SIP status from the NOTIFY sipfrag
@@ -3069,6 +3145,8 @@ x-webhooks:
                                     leg_id:
                                         type: string
                                         description: Leg identifier
+                                    app_id:
+                                        type: string
                                     status_code:
                                         type: integer
                                         description: Final non-2xx SIP status (when applicable)
@@ -3091,6 +3169,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
     room.deleted:
         post:
             summary: Room deleted
@@ -3104,6 +3184,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
     stt.text:
         post:
             summary: Speech-to-text transcript
@@ -3120,6 +3202,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     text:
                                         type: string
                                         description: Transcribed text
@@ -3142,6 +3226,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     conversation_id:
                                         type: string
                                         description: Provider-assigned conversation identifier
@@ -3161,6 +3247,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
     agent.user_transcript:
         post:
             summary: User speech transcribed by agent
@@ -3177,6 +3265,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     text:
                                         type: string
                                         description: User speech text
@@ -3196,6 +3286,8 @@ x-webhooks:
                                     room_id:
                                         type: string
                                         description: Room identifier
+                                    app_id:
+                                        type: string
                                     text:
                                         type: string
                                         description: Agent response text

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1800,10 +1800,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Error'
-    /events/ws:
+    /vsi:
         get:
-            operationId: wsEvents
-            summary: WebSocket event stream
+            operationId: vsi
+            summary: VoiceBlender Streaming Interface (VSI)
             description: Upgrades to a WebSocket connection and streams all events in real-time as JSON text frames. The JSON shape is identical to webhook payloads. The server sends a `{"type":"connected"}` message on connect, followed by events and periodic `{"type":"ping"}` keepalives. Clients may send `{"type":"pong"}` or `{"type":"stop"}` to close gracefully. Unknown message types receive an error response with the echoed `request_id` (reserved for future commands).
             tags:
                 - Events

--- a/tests/integration/call_test.go
+++ b/tests/integration/call_test.go
@@ -145,7 +145,7 @@ func newTestInstanceFull(t *testing.T, name string, mutate func(*config.Config),
 	time.Sleep(200 * time.Millisecond)
 
 	ec := newEventCollector()
-	bus.Subscribe(ec.handle)
+	_ = bus.Subscribe(ec.handle)
 
 	inst := &testInstance{
 		name:      name,

--- a/tests/integration/metrics_test.go
+++ b/tests/integration/metrics_test.go
@@ -103,7 +103,7 @@ func newTestInstanceWithMetrics(t *testing.T, name string) *testInstance {
 	time.Sleep(200 * time.Millisecond)
 
 	ec := newEventCollector()
-	bus.Subscribe(ec.handle)
+	_ = bus.Subscribe(ec.handle)
 
 	inst := &testInstance{
 		name:      name,

--- a/tests/integration/ws_events_test.go
+++ b/tests/integration/ws_events_test.go
@@ -1,0 +1,229 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+)
+
+// wsEventFrame is a generic JSON envelope received over the event WebSocket.
+type wsEventFrame struct {
+	Type       string `json:"type"`
+	LegID      string `json:"leg_id,omitempty"`
+	AppID      string `json:"app_id,omitempty"`
+	RequestID  string `json:"request_id,omitempty"`
+	InstanceID string `json:"instance_id,omitempty"`
+}
+
+func dialEventsWS(t *testing.T, inst *testInstance) net.Conn {
+	return dialEventsWSFiltered(t, inst, "")
+}
+
+func dialEventsWSFiltered(t *testing.T, inst *testInstance, appIDFilter string) net.Conn {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	url := fmt.Sprintf("ws://%s/v1/events/ws", inst.httpAddr)
+	if appIDFilter != "" {
+		url += "?app_id=" + appIDFilter
+	}
+	conn, _, _, err := ws.Dial(ctx, url)
+	if err != nil {
+		t.Fatalf("dial events ws: %v", err)
+	}
+	return conn
+}
+
+func readWSFrame(t *testing.T, conn net.Conn, timeout time.Duration) wsEventFrame {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(timeout))
+	data, err := wsutil.ReadServerText(conn)
+	if err != nil {
+		t.Fatalf("read ws frame: %v", err)
+	}
+	var f wsEventFrame
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("unmarshal ws frame: %v (%s)", err, data)
+	}
+	return f
+}
+
+func TestWSEvents_ConnectedAndEvents(t *testing.T) {
+	instA := newTestInstance(t, "ws-a")
+	instB := newTestInstance(t, "ws-b")
+
+	conn := dialEventsWS(t, instA)
+	defer conn.Close()
+
+	// First frame should be {"type":"connected"}.
+	f := readWSFrame(t, conn, 5*time.Second)
+	if f.Type != "connected" {
+		t.Fatalf("first frame type = %q, want connected", f.Type)
+	}
+
+	// Originate a call to trigger events.
+	resp := httpPost(t, instA.baseURL()+"/v1/legs", map[string]interface{}{
+		"type":   "sip",
+		"uri":    fmt.Sprintf("sip:test@127.0.0.1:%d", instB.sipPort),
+		"codecs": []string{"PCMU"},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create leg: status %d", resp.StatusCode)
+	}
+	var lv legView
+	decodeJSON(t, resp, &lv)
+
+	// Read frames until we get a leg.ringing event.
+	deadline := time.Now().Add(5 * time.Second)
+	found := false
+	for time.Now().Before(deadline) {
+		f = readWSFrame(t, conn, 5*time.Second)
+		if f.Type == "leg.ringing" && f.LegID == lv.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("did not receive leg.ringing event over WebSocket")
+	}
+}
+
+func TestWSEvents_UnknownCommand(t *testing.T) {
+	inst := newTestInstance(t, "ws-cmd")
+	conn := dialEventsWS(t, inst)
+	defer conn.Close()
+
+	// Consume the "connected" frame.
+	readWSFrame(t, conn, 5*time.Second)
+
+	// Send an unknown command with request_id.
+	msg, _ := json.Marshal(map[string]string{
+		"type":       "do_something",
+		"request_id": "req-1",
+	})
+	if err := wsutil.WriteClientText(conn, msg); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Read back the error response.
+	f := readWSFrame(t, conn, 5*time.Second)
+	if f.Type != "error" {
+		t.Errorf("type = %q, want error", f.Type)
+	}
+	if f.RequestID != "req-1" {
+		t.Errorf("request_id = %q, want req-1", f.RequestID)
+	}
+}
+
+func TestWSEvents_StopCommand(t *testing.T) {
+	inst := newTestInstance(t, "ws-stop")
+	conn := dialEventsWS(t, inst)
+	defer conn.Close()
+
+	readWSFrame(t, conn, 5*time.Second)
+
+	msg, _ := json.Marshal(map[string]string{"type": "stop"})
+	if err := wsutil.WriteClientText(conn, msg); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// After stop, the server should close the connection. Next read should fail.
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, err := wsutil.ReadServerText(conn)
+	if err == nil {
+		t.Fatal("expected read error after stop, got nil")
+	}
+}
+
+func TestWSEvents_AppIDFilter(t *testing.T) {
+	instA := newTestInstance(t, "ws-filter-a")
+	instB := newTestInstance(t, "ws-filter-b")
+
+	// Client filtering for app_id=billing only.
+	connBilling := dialEventsWSFiltered(t, instA, "^billing$")
+	defer connBilling.Close()
+	readWSFrame(t, connBilling, 5*time.Second) // consume "connected"
+
+	// Client with no filter (receives everything).
+	connAll := dialEventsWS(t, instA)
+	defer connAll.Close()
+	readWSFrame(t, connAll, 5*time.Second) // consume "connected"
+
+	// Originate a leg with app_id=billing.
+	resp := httpPost(t, instA.baseURL()+"/v1/legs", map[string]interface{}{
+		"type":   "sip",
+		"uri":    fmt.Sprintf("sip:test@127.0.0.1:%d", instB.sipPort),
+		"codecs": []string{"PCMU"},
+		"app_id": "billing",
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create billing leg: status %d", resp.StatusCode)
+	}
+	var billingLeg legView
+	decodeJSON(t, resp, &billingLeg)
+
+	// Originate a leg with app_id=support.
+	resp2 := httpPost(t, instA.baseURL()+"/v1/legs", map[string]interface{}{
+		"type":   "sip",
+		"uri":    fmt.Sprintf("sip:test@127.0.0.1:%d", instB.sipPort),
+		"codecs": []string{"PCMU"},
+		"app_id": "support",
+	})
+	if resp2.StatusCode != http.StatusCreated {
+		t.Fatalf("create support leg: status %d", resp2.StatusCode)
+	}
+	var supportLeg legView
+	decodeJSON(t, resp2, &supportLeg)
+
+	// The unfiltered client should see events for both legs.
+	allSeen := map[string]bool{}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && len(allSeen) < 2 {
+		f := readWSFrame(t, connAll, 5*time.Second)
+		if f.Type == "leg.ringing" {
+			allSeen[f.LegID] = true
+		}
+	}
+	if !allSeen[billingLeg.ID] {
+		t.Error("unfiltered client missed billing leg.ringing")
+	}
+	if !allSeen[supportLeg.ID] {
+		t.Error("unfiltered client missed support leg.ringing")
+	}
+
+	// The billing-filtered client should only see billing events.
+	billingSeen := false
+	supportSeen := false
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		connBilling.SetReadDeadline(time.Now().Add(1 * time.Second))
+		data, err := wsutil.ReadServerText(connBilling)
+		if err != nil {
+			break
+		}
+		var f wsEventFrame
+		if json.Unmarshal(data, &f) == nil {
+			if f.LegID == billingLeg.ID {
+				billingSeen = true
+			}
+			if f.LegID == supportLeg.ID {
+				supportSeen = true
+			}
+		}
+	}
+	if !billingSeen {
+		t.Error("filtered client did not receive billing events")
+	}
+	if supportSeen {
+		t.Error("filtered client should NOT receive support events")
+	}
+}

--- a/tests/integration/ws_events_test.go
+++ b/tests/integration/ws_events_test.go
@@ -24,21 +24,21 @@ type wsEventFrame struct {
 	InstanceID string `json:"instance_id,omitempty"`
 }
 
-func dialEventsWS(t *testing.T, inst *testInstance) net.Conn {
-	return dialEventsWSFiltered(t, inst, "")
+func dialVSI(t *testing.T, inst *testInstance) net.Conn {
+	return dialVSIFiltered(t, inst, "")
 }
 
-func dialEventsWSFiltered(t *testing.T, inst *testInstance, appIDFilter string) net.Conn {
+func dialVSIFiltered(t *testing.T, inst *testInstance, appIDFilter string) net.Conn {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	url := fmt.Sprintf("ws://%s/v1/events/ws", inst.httpAddr)
+	url := fmt.Sprintf("ws://%s/v1/vsi", inst.httpAddr)
 	if appIDFilter != "" {
 		url += "?app_id=" + appIDFilter
 	}
 	conn, _, _, err := ws.Dial(ctx, url)
 	if err != nil {
-		t.Fatalf("dial events ws: %v", err)
+		t.Fatalf("dial vsi: %v", err)
 	}
 	return conn
 }
@@ -61,7 +61,7 @@ func TestWSEvents_ConnectedAndEvents(t *testing.T) {
 	instA := newTestInstance(t, "ws-a")
 	instB := newTestInstance(t, "ws-b")
 
-	conn := dialEventsWS(t, instA)
+	conn := dialVSI(t, instA)
 	defer conn.Close()
 
 	// First frame should be {"type":"connected"}.
@@ -99,7 +99,7 @@ func TestWSEvents_ConnectedAndEvents(t *testing.T) {
 
 func TestWSEvents_UnknownCommand(t *testing.T) {
 	inst := newTestInstance(t, "ws-cmd")
-	conn := dialEventsWS(t, inst)
+	conn := dialVSI(t, inst)
 	defer conn.Close()
 
 	// Consume the "connected" frame.
@@ -126,7 +126,7 @@ func TestWSEvents_UnknownCommand(t *testing.T) {
 
 func TestWSEvents_StopCommand(t *testing.T) {
 	inst := newTestInstance(t, "ws-stop")
-	conn := dialEventsWS(t, inst)
+	conn := dialVSI(t, inst)
 	defer conn.Close()
 
 	readWSFrame(t, conn, 5*time.Second)
@@ -144,17 +144,155 @@ func TestWSEvents_StopCommand(t *testing.T) {
 	}
 }
 
+func TestWSCommands_RoomLifecycle(t *testing.T) {
+	inst := newTestInstance(t, "ws-cmd")
+	conn := dialVSI(t, inst)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second) // consume "connected"
+
+	// create_room
+	send := func(typ string, payload interface{}) wsEventFrame {
+		t.Helper()
+		p, _ := json.Marshal(payload)
+		msg, _ := json.Marshal(map[string]interface{}{
+			"type":       typ,
+			"request_id": typ,
+			"payload":    json.RawMessage(p),
+		})
+		if err := wsutil.WriteClientText(conn, msg); err != nil {
+			t.Fatalf("write %s: %v", typ, err)
+		}
+		// Read frames until we get the result/error for this request_id.
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			f := readWSFrame(t, conn, 5*time.Second)
+			if f.RequestID == typ {
+				return f
+			}
+		}
+		t.Fatalf("no response for %s", typ)
+		return wsEventFrame{}
+	}
+
+	f := send("create_room", map[string]string{"id": "ws-room", "app_id": "test-app"})
+	if f.Type != "create_room.result" {
+		t.Fatalf("create_room type = %q, want create_room.result", f.Type)
+	}
+
+	// get_room
+	f = send("get_room", map[string]string{"id": "ws-room"})
+	if f.Type != "get_room.result" {
+		t.Fatalf("get_room type = %q", f.Type)
+	}
+
+	// list_rooms
+	sendRaw := func(typ string) wsEventFrame {
+		t.Helper()
+		msg, _ := json.Marshal(map[string]interface{}{
+			"type":       typ,
+			"request_id": typ,
+		})
+		if err := wsutil.WriteClientText(conn, msg); err != nil {
+			t.Fatalf("write %s: %v", typ, err)
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			f := readWSFrame(t, conn, 5*time.Second)
+			if f.RequestID == typ {
+				return f
+			}
+		}
+		t.Fatalf("no response for %s", typ)
+		return wsEventFrame{}
+	}
+
+	f = sendRaw("list_rooms")
+	if f.Type != "list_rooms.result" {
+		t.Fatalf("list_rooms type = %q", f.Type)
+	}
+
+	// delete_room
+	f = send("delete_room", map[string]string{"id": "ws-room"})
+	if f.Type != "delete_room.result" {
+		t.Fatalf("delete_room type = %q", f.Type)
+	}
+
+	// get_room on deleted room → error
+	f = send("get_room", map[string]string{"id": "ws-room"})
+	if f.Type != "error" {
+		t.Fatalf("get_room on deleted = %q, want error", f.Type)
+	}
+}
+
+func TestWSCommands_MuteLeg(t *testing.T) {
+	instA := newTestInstance(t, "ws-mute-a")
+	instB := newTestInstance(t, "ws-mute-b")
+
+	// Establish a call via HTTP first.
+	outboundID, _ := establishCall(t, instA, instB)
+
+	conn := dialVSI(t, instA)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second)
+
+	sendCmd := func(typ string, payload interface{}) wsEventFrame {
+		t.Helper()
+		p, _ := json.Marshal(payload)
+		msg, _ := json.Marshal(map[string]interface{}{
+			"type":       typ,
+			"request_id": typ,
+			"payload":    json.RawMessage(p),
+		})
+		if err := wsutil.WriteClientText(conn, msg); err != nil {
+			t.Fatalf("write %s: %v", typ, err)
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			f := readWSFrame(t, conn, 5*time.Second)
+			if f.RequestID == typ {
+				return f
+			}
+		}
+		t.Fatalf("no response for %s", typ)
+		return wsEventFrame{}
+	}
+
+	// mute_leg
+	f := sendCmd("mute_leg", map[string]string{"id": outboundID})
+	if f.Type != "mute_leg.result" {
+		t.Fatalf("mute type = %q", f.Type)
+	}
+
+	// get_leg — verify muted
+	f = sendCmd("get_leg", map[string]string{"id": outboundID})
+	if f.Type != "get_leg.result" {
+		t.Fatalf("get_leg type = %q", f.Type)
+	}
+
+	// mute on missing leg → error
+	f = sendCmd("mute_leg", map[string]string{"id": "nonexistent"})
+	if f.Type != "error" {
+		t.Fatalf("mute missing = %q, want error", f.Type)
+	}
+
+	// unknown command → error
+	f = sendCmd("fly_to_moon", map[string]string{})
+	if f.Type != "error" {
+		t.Fatalf("unknown cmd = %q, want error", f.Type)
+	}
+}
+
 func TestWSEvents_AppIDFilter(t *testing.T) {
 	instA := newTestInstance(t, "ws-filter-a")
 	instB := newTestInstance(t, "ws-filter-b")
 
 	// Client filtering for app_id=billing only.
-	connBilling := dialEventsWSFiltered(t, instA, "^billing$")
+	connBilling := dialVSIFiltered(t, instA, "^billing$")
 	defer connBilling.Close()
 	readWSFrame(t, connBilling, 5*time.Second) // consume "connected"
 
 	// Client with no filter (receives everything).
-	connAll := dialEventsWS(t, instA)
+	connAll := dialVSI(t, instA)
 	defer connAll.Close()
 	readWSFrame(t, connAll, 5*time.Second) // consume "connected"
 


### PR DESCRIPTION
VoiceBlender now supports a real-time WebSocket event stream at GET /v1/events/ws that delivers all events in the same JSON format as webhooks, eliminating the need for clients to run an HTTP server. For multi-tenant deployments, legs and rooms 
  can be tagged with an app_id (set at creation or via the X-App-ID SIP header on inbound calls), and WebSocket clients can filter events using a regex query parameter (?app_id=^billing$) to receive only events relevant to their application. The
  endpoint also notifies clients when events are dropped due to slow consumption, includes a ping/pong keepalive, and has a typed command dispatch structure ready for future bidirectional request support.  