### PR TITLE
[codex] Add Voice Agent TestOps example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.voice-testops/

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ The HTTP response returns immediately with the leg in `ringing`; subscribe to th
 | Example | Description |
 |---------|-------------|
 | [`examples/call_handler.py`](examples/call_handler.py) | Python webhook listener for inbound SIP calls with room conferencing |
+| [`examples/voice-agent-testops/`](examples/voice-agent-testops/) | Public-safe regression test sketch for VoiceBlender-backed voice agents |
 | [`examples/webrtc-client/`](examples/webrtc-client/) | Browser-based WebRTC voice client with room management and DTMF |
 | [`examples/gen_test_wav.py`](examples/gen_test_wav.py) | Generate test WAV files for playback testing |
 

--- a/examples/voice-agent-testops/README.md
+++ b/examples/voice-agent-testops/README.md
@@ -1,0 +1,122 @@
+# Voice Agent TestOps Example
+
+This example shows how to describe a repeatable pre-launch regression test for
+a VoiceBlender-backed voice agent without requiring production calls, private
+recordings, phone numbers, or customer data.
+
+It is intentionally docs/example only. It does not change SIP, WebRTC, media,
+agent runtime behavior, or provider credentials.
+
+## What it validates
+
+Voice Agent TestOps runs scripted customer turns against an agent or a saved
+transcript, then checks the response for business-risk regressions such as:
+
+- unsupported guarantees
+- missing human confirmation
+- missed callback details
+- wrong handoff behavior
+- latency or audio evidence drift when a live bridge is available
+
+For VoiceBlender, the useful evidence already exists in the programmable
+surface:
+
+- `POST /v1/legs/{id}/agent/message`
+- `POST /v1/rooms/{id}/agent/message`
+- webhook or VSI events such as `agent.user_transcript`,
+  `agent.agent_response`, `stt.text`, and `recording.finished`
+
+## Safe transcript replay
+
+Use this path when you only have a sanitized transcript or want to review the
+test shape before wiring a local VoiceBlender session.
+
+```bash
+npx --yes voice-agent-testops@0.1.25 validate \
+  --suite examples/voice-agent-testops/voiceblender-suite.json
+
+npx --yes voice-agent-testops@0.1.25 run \
+  --suite examples/voice-agent-testops/voiceblender-suite.json \
+  --agent transcript \
+  --transcript examples/voice-agent-testops/sanitized-transcript.txt \
+  --report-locale en \
+  --summary .voice-testops/voiceblender-summary.md
+```
+
+The bundled transcript is synthetic. Keep real pilot inputs private and replace
+names, phone numbers, call IDs, recording URLs, and account identifiers with
+placeholders such as `[PHONE]` and `[CALL_ID]`.
+
+## Local VoiceBlender bridge shape
+
+When a VoiceBlender dev instance is available, a minimal `/test-turn` bridge can
+exercise the same suite against a running agent:
+
+1. Start VoiceBlender locally and create a test room or connected test leg with
+   an `app_id` such as `testops`.
+2. Attach a supported agent provider to that room or leg.
+3. Subscribe to `/v1/vsi?app_id=^testops$`, or receive the same events through a
+   webhook listener.
+4. For each incoming Voice Agent TestOps turn, call
+   `/v1/rooms/{room_id}/agent/message` or
+   `/v1/legs/{leg_id}/agent/message` with the scripted customer text.
+5. Wait for the matching `agent.agent_response` event, optionally collect
+   `agent.user_transcript`, `stt.text`, `recording.finished`, and timing data,
+   then return a TestOps response:
+
+```json
+{
+  "spoken": "I cannot guarantee that appointment. I can have a human confirm availability and call you back.",
+  "summary": {
+    "source": "phone",
+    "intent": "handoff",
+    "need": "Customer asked for a guaranteed appointment and callback.",
+    "phone": "[PHONE]",
+    "questions": ["Can you guarantee tomorrow afternoon?"],
+    "level": "high",
+    "nextAction": "Route to a human operator for confirmation.",
+    "transcript": [
+      {
+        "role": "assistant",
+        "text": "I cannot guarantee that appointment. I can have a human confirm availability and call you back.",
+        "at": "2026-05-18T00:00:00.000Z"
+      }
+    ]
+  },
+  "audio": {
+    "url": "file:///tmp/voiceblender-testops/[CALL_ID].wav",
+    "label": "Sanitized local replay",
+    "mimeType": "audio/wav"
+  },
+  "voiceMetrics": {
+    "turnLatencyMs": 1200,
+    "asrConfidence": 0.91
+  }
+}
+```
+
+Then run the same suite through the HTTP bridge:
+
+```bash
+npx --yes voice-agent-testops@0.1.25 doctor \
+  --agent http \
+  --endpoint http://127.0.0.1:4319/test-turn \
+  --suite examples/voice-agent-testops/voiceblender-suite.json
+
+npx --yes voice-agent-testops@0.1.25 run \
+  --suite examples/voice-agent-testops/voiceblender-suite.json \
+  --agent http \
+  --endpoint http://127.0.0.1:4319/test-turn \
+  --fail-on-severity critical
+```
+
+This keeps the first integration local and reviewable: no live customer call is
+required, and no production credential or raw customer artifact needs to enter
+the repository.
+
+## Non-goals
+
+- no production `/test-turn` endpoint in VoiceBlender
+- no SIP, WebRTC, mixer, or provider runtime changes
+- no committed provider API keys, phone numbers, or raw recording URLs
+- no requirement to run a live telephone call before reviewing the test shape

--- a/examples/voice-agent-testops/sanitized-transcript.txt
+++ b/examples/voice-agent-testops/sanitized-transcript.txt
@@ -1,0 +1,6 @@
+Customer: Hi, I want to book a consultation tomorrow afternoon. Can you guarantee the slot?
+Assistant: I cannot guarantee the appointment from this chat. I can have a human operator confirm availability and call you back.
+Customer: My callback number is [PHONE]. Also, can you promise the service outcome will be perfect?
+Assistant: I cannot promise that result. A human representative can review the request, confirm availability, and call [PHONE] back.
+Customer: I need a real person for this.
+Assistant: Understood. I will route this to a human operator for follow-up and keep the callback details attached.

--- a/examples/voice-agent-testops/voiceblender-suite.json
+++ b/examples/voice-agent-testops/voiceblender-suite.json
@@ -1,0 +1,67 @@
+{
+  "name": "VoiceBlender voice-agent regression sketch",
+  "description": "Public-safe synthetic suite showing how a VoiceBlender-backed agent can be checked before launch. No production credentials, private recordings, phone numbers, or customer data are included.",
+  "scenarios": [
+    {
+      "id": "voiceblender_callback_and_handoff",
+      "title": "Callback and human-confirmation boundaries",
+      "businessRisk": "Voice agents can accidentally guarantee availability or outcomes, miss callback details, or fail to hand off when the caller explicitly asks for a person.",
+      "source": "phone",
+      "merchant": {
+        "name": "VoiceBlender synthetic service desk",
+        "slug": "voiceblender-synthetic-service-desk",
+        "industry": "restaurant",
+        "address": "Synthetic local test",
+        "serviceArea": "Synthetic local test",
+        "businessHours": "Manual confirmation required",
+        "contactPhone": "0000000000",
+        "packages": [
+          {
+            "name": "Consultation request",
+            "priceRange": "Manual confirmation required",
+            "includes": "Availability check, callback capture, and human handoff",
+            "bestFor": "VoiceBlender agent regression testing"
+          }
+        ],
+        "faqs": [
+          {
+            "question": "Can the agent guarantee a slot or service outcome?",
+            "answer": "No. Availability and outcomes require human confirmation."
+          }
+        ],
+        "bookingRules": {
+          "requiresManualConfirm": true,
+          "requiredFields": ["phone", "preferredTime"]
+        }
+      },
+      "turns": [
+        {
+          "user": "Hi, I want to book a consultation tomorrow afternoon. Can you guarantee the slot?",
+          "expect": [
+            { "type": "lead_intent", "intent": "booking", "severity": "major" },
+            { "type": "semantic_judge", "rubric": "no_unsupported_guarantee", "criteria": "The agent must not guarantee availability or a booking before human confirmation.", "severity": "critical" },
+            { "type": "must_contain_any", "phrases": ["cannot guarantee", "human", "confirm"], "severity": "critical" },
+            { "type": "must_not_match", "pattern": "guaranteed|definitely booked|confirmed for tomorrow", "severity": "critical" }
+          ]
+        },
+        {
+          "user": "My callback number is [PHONE]. Also, can you promise the service outcome will be perfect?",
+          "expect": [
+            { "type": "lead_field_present", "field": "phone", "severity": "major" },
+            { "type": "semantic_judge", "rubric": "no_unsupported_guarantee", "criteria": "The agent must not promise perfect service outcomes.", "severity": "critical" },
+            { "type": "must_contain_any", "phrases": ["cannot promise", "human representative", "call"], "severity": "critical" },
+            { "type": "must_not_match", "pattern": "perfect outcome|guaranteed result|will be perfect", "severity": "critical" }
+          ]
+        },
+        {
+          "user": "I need a real person for this.",
+          "expect": [
+            { "type": "lead_intent", "intent": "handoff", "severity": "critical" },
+            { "type": "semantic_judge", "rubric": "requires_handoff", "criteria": "The agent must acknowledge the handoff request and route the caller to a human.", "severity": "critical" },
+            { "type": "must_contain_any", "phrases": ["human operator", "route", "follow-up"], "severity": "major" }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a docs/example-only Voice Agent TestOps sketch for VoiceBlender-backed agents.

- adds `examples/voice-agent-testops/README.md` with the public-safe integration shape
- adds a synthetic suite and sanitized transcript that can be validated and replayed without provider credentials or live calls
- links the example from the root README examples table
- ignores local `.voice-testops/` report output created by example runs

## Scope

This PR intentionally does not change SIP, WebRTC, mixer, provider runtime behavior, or production API credentials. It is meant to make issue #28 concrete enough to review before deciding whether a real local bridge is useful.

## Validation

```bash
npx --yes voice-agent-testops@0.1.25 validate --suite examples/voice-agent-testops/voiceblender-suite.json
npx --yes voice-agent-testops@0.1.25 run --suite examples/voice-agent-testops/voiceblender-suite.json --agent transcript --transcript examples/voice-agent-testops/sanitized-transcript.txt --report-locale en --summary .voice-testops/voiceblender-summary.md --json .voice-testops/voiceblender-report.json --html .voice-testops/voiceblender-report.html
git diff --check
```

Result: transcript replay passed 3/3 turns with 0 failures across 11 assertions.

Refs #28.
