### PR TITLE
SIP trunk management over VSI

### DIFF
--- a/API.md
+++ b/API.md
@@ -2438,7 +2438,7 @@ The WebSocket accepts bidirectional commands using the same naming as the REST A
 |---------|---------|-------------|
 | `list_legs` | *(none)* | List all legs |
 | `get_leg` | `{"id":"..."}` | Get a single leg |
-| `create_leg` | `CreateLegRequest` | Create a leg (not yet implemented over WS; use REST) |
+| `create_leg` | `CreateLegRequest` | Originate an outbound leg; returns the leg view. All types are supported (`sip`, `websocket`, `whatsapp`, `livekit_room`). For `livekit_room`, custom headers come from the request's `headers` map. |
 | `delete_leg` | `{"id":"..."}` | Hang up and delete a leg |
 | `answer_leg` | `{"id":"..."}` | Answer a ringing inbound leg |
 | `mute_leg` | `{"id":"..."}` | Mute a leg |
@@ -3090,7 +3090,7 @@ must also be URL-encoded).
 Responses: `204 No Content` on success; `404 Not Found` when the AOR (or
 the specified contact) does not exist.
 
-### VSI command
+### VSI commands
 
 The same listing is available over the VSI WebSocket:
 
@@ -3104,6 +3104,19 @@ Server replies:
 {"type": "list_sip_registrations.result", "request_id": "1",
  "data": {"bindings": [...]}}
 ```
+
+Force-unbind is available as `delete_sip_registration`. The AOR is sent plain
+(no URL-encoding, unlike the REST path); add `contact` to remove just one
+Contact:
+
+```json
+{"type": "delete_sip_registration", "request_id": "2",
+ "payload": {"aor": "sip:alice@vb.example"}}
+```
+
+Server replies `{"type": "delete_sip_registration.result", "request_id": "2",
+"data": {"status": "unbound"}}`, or an `error` frame with code `404` when the
+AOR (or contact) does not exist.
 
 The `sip.registration_active` / `sip.registration_expired` events flow
 through the standard webhook and VSI channels — see Event Types above.

--- a/TESTING.md
+++ b/TESTING.md
@@ -207,6 +207,13 @@ go test -tags integration -v -timeout 60s -run TestSIPInboundAuth ./tests/integr
 | `TestVSI_RTT_SendDelivers` | VSI `send_leg_rtt` over the `/v1/vsi` WebSocket delivers text to the remote leg (parity with REST `POST /rtt`) |
 | `TestVSI_RTT_AcceptRejectFlags` | VSI `accept_leg_rtt`/`reject_leg_rtt` toggle the receiver's `accept_text` flag; rejected legs suppress `rtt.received` events |
 | `TestVSI_RTT_SendOnNonNegotiatedLegReturns409` | VSI `send_leg_rtt` returns an error frame when RTT was never negotiated on the leg |
+| `TestVSI_CreateLeg_Originates` | Outbound SIP originate over the `/v1/vsi` WebSocket (`create_leg` type `sip`) returns a `create_leg.result` leg view; the callee receives the INVITE, answers, and both legs reach `connected` (parity with REST `POST /v1/legs`) |
+| `TestVSI_CreateLeg_InvalidURI` | VSI `create_leg` with an invalid SIP URI returns an `error` frame with code 400 (not a 501 or silent accept) |
+| `TestVSI_CreateLeg_WebSocket` | VSI `create_leg` type `websocket` dials an in-test echo server and the leg reaches `connected` (parity with REST `POST /v1/legs` type websocket) |
+| `TestVSI_CreateLeg_WebSocketValidation` | VSI `create_leg` type `websocket` with no `url` returns an `error` frame with code 400 |
+| `TestVSI_CreateLeg_WhatsAppValidation` | VSI `create_leg` type `whatsapp` with no `to` returns an `error` frame with code 400 (validation runs over VSI, not "unsupported leg type") |
+| `TestVSI_CreateLeg_LiveKitError` | VSI `create_leg` type `livekit_room` is dispatched and returns a real `error` frame (503 when LiveKit disabled — the default — or 400 for missing params), never a 501/unsupported |
+| `TestVSI_DeleteRegistration` | Over VSI: a raw client REGISTERs, `list_sip_registrations` shows the binding, `delete_sip_registration` unbinds it, the list goes empty, and an unknown-AOR delete returns an `error` frame with code 404 |
 | `TestVSI_WebRTC_FullFlow` | VSI `webrtc_offer` / `webrtc_get_candidates` / `webrtc_add_candidate` round-trip with a real pion client; leg appears in `list_legs` and emits `leg.connected` |
 | `TestVSI_WebRTC_OfferInvalidSDP` | VSI `webrtc_offer` with malformed SDP returns a 400 error frame |
 | `TestVSI_WebRTC_AddCandidateNotFound` | VSI `webrtc_add_candidate` for an unknown leg returns a 404 error frame |
@@ -247,7 +254,8 @@ go test -tags integration -v -timeout 60s -run TestSIPInboundAuth ./tests/integr
 | `TestSIPRegister_Expiry` | Short-expires REGISTER → TTL sweeper removes the binding and emits `sip.registration_expired` with `reason:ttl` |
 | `TestSIPRegister_Unregister` | REGISTER with `Contact: *` and `Expires: 0` removes all bindings with `reason:unregistered` |
 | `TestSIPRegister_ForceDelete` | `DELETE /v1/sip/registrations/{aor}` force-unbinds with `reason:forced` |
-| `TestSIPRegister_DialAOR` | After REGISTER, `POST /v1/legs {"type":"sip","to":"sip:alice@..."}` routes the outbound INVITE to the bound socket rather than the URI host |
+| `TestSIPRegister_DialAOR` | After REGISTER, `POST /v1/legs {"type":"sip","to":"sip:alice@..."}` routes the outbound INVITE to the bound socket (via a loose Route) while keeping the dialed AOR as the Request-URI |
+| `TestSIPRegister_CancelUnansweredRoutesToContact` | Deleting an unanswered outbound leg dialed to a registered AOR sends CANCEL to the registered contact (not the AOR host / VoiceBlender itself); the CANCEL Request-URI stays the dialed AOR per RFC 3261 §9.1 |
 | `TestSIPRegister_Fork` | AOR registered from two raw clients; `POST /v1/legs` parallel-forks (both clients receive an INVITE); the second client answers 200 OK, the first receives CANCEL and its INVITE transaction terminates (after Timer I = 5 s for UDP) |
 | `TestSIPInboundAuth_RegisterChallengeSuccess` | Consult enabled (webhook set); REGISTER parks → `sip.registration_attempt` event → `POST /v1/sip/registrations/attempts/{id}/challenge` → `401`; credentialed re-REGISTER (same Call-ID) verifies → `200 OK` and a live binding |
 | `TestSIPInboundAuth_RegisterChallengeWrongPassword` | Same challenge flow but the retry signs with a wrong password → `403 Forbidden` and no binding is created |
@@ -261,6 +269,8 @@ go test -tags integration -v -timeout 60s -run TestSIPInboundAuth ./tests/integr
 | `TestTrunk_SIPRegister_OutboundCallUsesTrunk` | After REGISTER, `POST /v1/legs {"type":"sip","to":"sip:bob@<registrar>","from":"alice"}` auto-attaches the trunk's credentials and adds a `Route: <registrar_uri;lr>` header on the outbound INVITE (verified at the fake registrar) |
 | `TestTrunk_TypeIPIP_NotImplemented` | `POST /v1/sip/trunks {"type":"ip_ip",...}` returns 501 Not Implemented (the type is reserved in the schema but not yet wired) |
 | `TestTrunk_TypeUnknown_BadRequest` | `POST /v1/sip/trunks {"type":"bogus"}` returns 400 with an "unknown trunk type" error |
+| `TestVSI_Trunk_Lifecycle` | Full trunk lifecycle over the `/v1/vsi` WebSocket: `create_sip_trunk` → `list_sip_trunks` → `get_sip_trunk` → `delete_sip_trunk`; the trunk REGISTERs at the fake registrar, list/get return it without leaking `password`, and a get after delete returns an error frame |
+| `TestVSI_Trunk_CreateValidationError` | `create_sip_trunk` with a missing `sip_register` block returns a VSI `error` frame with code 400 (not silently accepted) |
 | `TestSIPUpdate_SessionTimerRefresh` | In-dialog UPDATE (RFC 3311) with no body and a `Session-Expires` header is accepted with 200 OK and the `Session-Expires` value is echoed (RFC 4028 §10) — guards against the legacy 405 Method Not Allowed response for session-timer refreshes |
 | `TestSIPUpdate_OutOfDialogRejected` | UPDATE that doesn't match any active dialog gets 481 Call/Transaction Does Not Exist (RFC 3311 §5.2), not 405 |
 | `TestLiveKit_PublishLegLifecycle` | Gated on `LIVEKIT_TEST_*` env vars. `POST /v1/legs type=livekit_room` creates a `livekit_publish` leg with the correct `livekit_identity` / `livekit_room` headers; `DELETE` tears it down with `leg.disconnected`. |

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -302,6 +302,10 @@ channels:
                 $ref: '#/components/messages/list_sip_registrations'
             list_sip_registrations.result:
                 $ref: '#/components/messages/list_sip_registrationsResult'
+            delete_sip_registration:
+                $ref: '#/components/messages/delete_sip_registration'
+            delete_sip_registration.result:
+                $ref: '#/components/messages/delete_sip_registrationResult'
             challenge_leg:
                 $ref: '#/components/messages/challenge_leg'
             challenge_leg.result:
@@ -482,7 +486,7 @@ operations:
         channel:
             $ref: '#/channels/vsi'
         summary: Originate an outbound leg
-        description: Currently returns a 501 error directing clients to use POST /v1/legs. Reserved for the future when the originate flow is fully extracted into a do* helper.
+        description: 'Originates an outbound leg, mirroring POST /v1/legs, and returns the leg view. Supports all leg types: "sip", "websocket", "whatsapp", and "livekit_room". For "livekit_room", custom headers come from the request''s `headers` map (there is no HTTP request over the WebSocket).'
         messages:
             - $ref: '#/channels/vsi/messages/create_leg'
         reply:
@@ -1389,6 +1393,19 @@ operations:
                 $ref: '#/channels/vsi'
             messages:
                 - $ref: '#/channels/vsi/messages/list_sip_registrations.result'
+                - $ref: '#/channels/vsi/messages/error'
+    recv_delete_sip_registration:
+        action: receive
+        channel:
+            $ref: '#/channels/vsi'
+        summary: Force-unbind an AOR (or a single contact under it)
+        messages:
+            - $ref: '#/channels/vsi/messages/delete_sip_registration'
+        reply:
+            channel:
+                $ref: '#/channels/vsi'
+            messages:
+                - $ref: '#/channels/vsi/messages/delete_sip_registration.result'
                 - $ref: '#/channels/vsi/messages/error'
     recv_challenge_leg:
         action: receive
@@ -4071,6 +4088,36 @@ components:
                         $ref: '#/components/schemas/RegistrationsResponse'
                 required:
                     - type
+        delete_sip_registration:
+            name: delete_sip_registration
+            title: Force-unbind an AOR (or a single contact under it)
+            summary: Force-unbind an AOR (or a single contact under it)
+            payload:
+                type: object
+                properties:
+                    type:
+                        const: delete_sip_registration
+                    request_id:
+                        type: string
+                        description: Echoed back on the matching .result/error frame; clients use it to correlate.
+                    payload:
+                        $ref: '#/components/schemas/deleteRegistrationPayload'
+                required:
+                    - type
+        delete_sip_registrationResult:
+            name: delete_sip_registrationResult
+            title: Force-unbind an AOR (or a single contact under it) — success response
+            payload:
+                type: object
+                properties:
+                    type:
+                        const: delete_sip_registration.result
+                    request_id:
+                        type: string
+                    data:
+                        $ref: '#/components/schemas/vsiStatusResponse'
+                required:
+                    - type
         challenge_leg:
             name: challenge_leg
             title: Send a 401 digest challenge on a ringing inbound SIP leg (INVITE)
@@ -4279,7 +4326,7 @@ components:
                     request_id:
                         type: string
                     data:
-                        $ref: '#/components/schemas/vsiStatusResponse'
+                        $ref: '#/components/schemas/TrunkView'
                 required:
                     - type
         delete_sip_trunk:
@@ -5367,6 +5414,15 @@ components:
                     type: string
             required:
                 - id
+        deleteRegistrationPayload:
+            type: object
+            properties:
+                aor:
+                    type: string
+                contact:
+                    type: string
+            required:
+                - aor
         dtmfPayload:
             type: object
             properties:

--- a/internal/api/legs.go
+++ b/internal/api/legs.go
@@ -750,14 +750,25 @@ func (s *Server) createLeg(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, req CreateLegRequest) {
+	view, err := s.doCreateSIPOutboundLeg(req)
+	if err != nil {
+		handleAPIError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, view)
+}
+
+// doCreateSIPOutboundLeg performs the synchronous validation + leg setup for an
+// outbound SIP originate and kicks off the async INVITE, returning the leg view.
+// Shared by the REST handler and the VSI create_leg dispatch.
+func (s *Server) doCreateSIPOutboundLeg(req CreateLegRequest) (LegView, error) {
 	target := req.To
 	if target == "" {
 		target = req.URI
 	}
 	recipient := sip.Uri{}
 	if err := sip.ParseUri(target, &recipient); err != nil {
-		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid SIP URI: %v", err))
-		return
+		return LegView{}, newAPIError(http.StatusBadRequest, "invalid SIP URI: %v", err)
 	}
 
 	// Parse codec overrides from request.
@@ -765,8 +776,7 @@ func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, re
 	for _, name := range req.Codecs {
 		ct := codec.CodecTypeFromName(name)
 		if ct == codec.CodecUnknown {
-			writeError(w, http.StatusBadRequest, fmt.Sprintf("unknown codec: %s", name))
-			return
+			return LegView{}, newAPIError(http.StatusBadRequest, "unknown codec: %s", name)
 		}
 		codecs = append(codecs, ct)
 	}
@@ -775,8 +785,7 @@ func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, re
 	if req.RoomID != "" {
 		if _, ok := s.RoomMgr.Get(req.RoomID); !ok {
 			if _, err := s.RoomMgr.Create(req.RoomID, req.AppID, s.Config.DefaultSampleRate); err != nil {
-				writeError(w, http.StatusInternalServerError, fmt.Sprintf("create room: %v", err))
-				return
+				return LegView{}, newAPIError(http.StatusInternalServerError, "create room: %v", err)
 			}
 		}
 	}
@@ -819,8 +828,7 @@ func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, re
 		var err error
 		startAMD, err = s.prepareAMD(l, req.AMD)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
-			return
+			return LegView{}, newAPIError(http.StatusBadRequest, "%s", err.Error())
 		}
 	} else {
 		startAMD = func() {}
@@ -988,7 +996,7 @@ func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, re
 		}
 	}()
 
-	writeJSON(w, http.StatusCreated, toLegView(l))
+	return toLegView(l), nil
 }
 
 // HandleInboundCall is called from the SIP engine for inbound INVITE requests.

--- a/internal/api/livekit_leg.go
+++ b/internal/api/livekit_leg.go
@@ -29,13 +29,25 @@ const (
 // room. Model B: the VB room mixer drives audio for everyone; there is no
 // bespoke sum-mixer.
 func (s *Server) createLiveKitRoomLeg(w http.ResponseWriter, r *http.Request, req CreateLegRequest) {
-	if !s.Config.LiveKitEnabled {
-		writeError(w, http.StatusServiceUnavailable, "LiveKit is not enabled (set LIVEKIT_ENABLED=true)")
+	view, err := s.doCreateLiveKitRoomLeg(r.Context(), captureCustomHeaders(r.Header), req)
+	if err != nil {
+		handleAPIError(w, err)
 		return
 	}
+	writeJSON(w, http.StatusCreated, view)
+}
+
+// doCreateLiveKitRoomLeg opens the LiveKit connection, registers the publish
+// leg, and returns its view. Shared by the REST handler and VSI create_leg.
+// The caller supplies the base ctx (wrapped here with the 20s connect timeout)
+// and any custom headers to attach to the publish leg — over VSI these come
+// from context.Background() and req.Headers respectively.
+func (s *Server) doCreateLiveKitRoomLeg(ctx context.Context, headers map[string]string, req CreateLegRequest) (LegView, error) {
+	if !s.Config.LiveKitEnabled {
+		return LegView{}, newAPIError(http.StatusServiceUnavailable, "LiveKit is not enabled (set LIVEKIT_ENABLED=true)")
+	}
 	if req.LiveKit == nil {
-		writeError(w, http.StatusBadRequest, "type=livekit_room requires `livekit` parameters")
-		return
+		return LegView{}, newAPIError(http.StatusBadRequest, "type=livekit_room requires `livekit` parameters")
 	}
 	p := req.LiveKit
 
@@ -44,14 +56,12 @@ func (s *Server) createLiveKitRoomLeg(w http.ResponseWriter, r *http.Request, re
 		url = s.Config.LiveKitURL
 	}
 	if url == "" {
-		writeError(w, http.StatusBadRequest, "LiveKit URL is required (set LIVEKIT_URL or pass livekit.url)")
-		return
+		return LegView{}, newAPIError(http.StatusBadRequest, "LiveKit URL is required (set LIVEKIT_URL or pass livekit.url)")
 	}
 
 	token, err := s.resolveLiveKitToken(p)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
+		return LegView{}, newAPIError(http.StatusBadRequest, "%s", err.Error())
 	}
 
 	bitrate := p.OpusBitrate
@@ -63,30 +73,26 @@ func (s *Server) createLiveKitRoomLeg(w http.ResponseWriter, r *http.Request, re
 		Log:         s.Log,
 	}
 	if err := cfg.Validate(); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
+		return LegView{}, newAPIError(http.StatusBadRequest, "%s", err.Error())
 	}
 
 	if req.RoomID != "" {
 		if _, ok := s.RoomMgr.Get(req.RoomID); !ok {
 			if _, err := s.RoomMgr.Create(req.RoomID, req.AppID, s.Config.DefaultSampleRate); err != nil {
-				writeError(w, http.StatusInternalServerError, fmt.Sprintf("create room: %v", err))
-				return
+				return LegView{}, newAPIError(http.StatusInternalServerError, "create room: %v", err)
 			}
 		}
 	}
 
-	headers := captureCustomHeaders(r.Header)
-
-	// NewTransport is synchronous: any failure here returns a clean HTTP
-	// response with no events emitted and no leg registered. We pass
-	// empty callbacks first; SetCallbacks runs once we have the publish
-	// leg to close over. The brief window where OnTrack may fire before
-	// callbacks are set is handled by Transport.fireRemoteAudioTrack —
-	// it drains the pcm reader rather than blocking.
-	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	// NewTransport is synchronous: any failure here returns a clean error
+	// with no events emitted and no leg registered. We pass empty callbacks
+	// first; SetCallbacks runs once we have the publish leg to close over.
+	// The brief window where OnTrack may fire before callbacks are set is
+	// handled by Transport.fireRemoteAudioTrack — it drains the pcm reader
+	// rather than blocking.
+	connectCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
-	tr, err := lkmedia.NewTransport(ctx, cfg,
+	tr, err := lkmedia.NewTransport(connectCtx, cfg,
 		lkmedia.SignalConfig{URL: url, Token: token, Log: s.Log},
 		lkmedia.PeerConfig{
 			RTPPortMin: s.Config.RTPPortMin,
@@ -96,8 +102,7 @@ func (s *Server) createLiveKitRoomLeg(w http.ResponseWriter, r *http.Request, re
 	)
 	if err != nil {
 		s.Log.Warn("livekit transport connect failed", "error", err)
-		writeError(w, http.StatusBadGateway, fmt.Sprintf("livekit connect: %v", err))
-		return
+		return LegView{}, newAPIError(http.StatusBadGateway, "livekit connect: %v", err)
 	}
 
 	publishLeg := leg.NewLiveKitPublishLeg(tr, headers, cfg.SampleRate, s.Log)
@@ -144,7 +149,7 @@ func (s *Server) createLiveKitRoomLeg(w http.ResponseWriter, r *http.Request, re
 
 	go conn.watch(unsubHears)
 
-	writeJSON(w, http.StatusCreated, toLegView(publishLeg))
+	return toLegView(publishLeg), nil
 }
 
 // resolveLiveKitToken returns the JWT to use for this leg-create request.

--- a/internal/api/sip_registrations.go
+++ b/internal/api/sip_registrations.go
@@ -67,28 +67,34 @@ func (s *Server) listRegistrations(w http.ResponseWriter, r *http.Request) {
 // only that one Contact under the AOR is removed; otherwise every Contact
 // is force-unbound.
 func (s *Server) deleteRegistration(w http.ResponseWriter, r *http.Request) {
-	reg := s.SIPEngine.Registrar()
-	if reg == nil {
-		writeError(w, http.StatusNotFound, "registrar not enabled")
-		return
-	}
 	raw := chi.URLParam(r, "aor")
 	aor, err := url.PathUnescape(raw)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid AOR encoding")
 		return
 	}
-	if c := r.URL.Query().Get("contact"); c != "" {
-		if ok := reg.UnbindContact(aor, c, "forced"); !ok {
-			writeError(w, http.StatusNotFound, "contact not found")
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-	if n := reg.UnbindAll(aor, "forced"); n == 0 {
-		writeError(w, http.StatusNotFound, "AOR not found")
+	if err := s.doDeleteRegistration(aor, r.URL.Query().Get("contact")); err != nil {
+		handleAPIError(w, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// doDeleteRegistration force-unbinds an AOR (or a single contact under it).
+// Shared by the REST handler and the VSI delete_sip_registration command.
+func (s *Server) doDeleteRegistration(aor, contact string) error {
+	reg := s.SIPEngine.Registrar()
+	if reg == nil {
+		return newAPIError(http.StatusNotFound, "registrar not enabled")
+	}
+	if contact != "" {
+		if ok := reg.UnbindContact(aor, contact, "forced"); !ok {
+			return newAPIError(http.StatusNotFound, "contact not found")
+		}
+		return nil
+	}
+	if n := reg.UnbindAll(aor, "forced"); n == 0 {
+		return newAPIError(http.StatusNotFound, "AOR not found")
+	}
+	return nil
 }

--- a/internal/api/sip_registrations_test.go
+++ b/internal/api/sip_registrations_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"testing"
+
+	sipmod "github.com/VoiceBlender/voiceblender/internal/sip"
+)
+
+// A zero-value engine has no registrar wired, so doDeleteRegistration must
+// report 404 "registrar not enabled" rather than panicking. The registrar-
+// backed paths (happy, contact-specific, unknown AOR) are covered end-to-end
+// by tests/integration/sip_registration_vsi_test.go with a live registrar.
+func TestDoDeleteRegistration_RegistrarDisabled(t *testing.T) {
+	s := &Server{SIPEngine: &sipmod.Engine{}}
+	err := s.doDeleteRegistration("sip:alice@vb.test", "")
+	if err == nil {
+		t.Fatal("expected error when registrar is not enabled")
+	}
+	ae, ok := err.(*apiError)
+	if !ok {
+		t.Fatalf("error type = %T, want *apiError", err)
+	}
+	if ae.Code != 404 {
+		t.Errorf("code = %d, want 404", ae.Code)
+	}
+}

--- a/internal/api/sip_trunks.go
+++ b/internal/api/sip_trunks.go
@@ -23,55 +23,43 @@ type TrunksListResponse struct {
 	Trunks []sipmod.TrunkView `json:"trunks"`
 }
 
-// createTrunk handles POST /v1/sip/trunks. Synchronously validates and
-// registers the trunk in the manager, then kicks off the async REGISTER
-// loop. Returns 202 Accepted.
-func (s *Server) createTrunk(w http.ResponseWriter, r *http.Request) {
-	var req CreateTrunkRequest
-	if err := decodeJSON(r, &req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON")
-		return
-	}
+// doCreateTrunk validates the request, registers the trunk, and starts the
+// async REGISTER loop. Shared by the REST handler and the VSI dispatcher.
+func (s *Server) doCreateTrunk(req CreateTrunkRequest) (CreateTrunkResponse, error) {
 	switch req.Type {
 	case string(sipmod.TrunkTypeSIPRegister):
-		s.createSIPRegisterTrunk(w, r, req)
+		return s.doCreateSIPRegisterTrunk(req)
 	case string(sipmod.TrunkTypeIPIP):
-		writeError(w, http.StatusNotImplemented, "trunk type 'ip_ip' not yet implemented")
+		return CreateTrunkResponse{}, newAPIError(http.StatusNotImplemented, "trunk type 'ip_ip' not yet implemented")
 	case "":
-		writeError(w, http.StatusBadRequest, "type is required")
+		return CreateTrunkResponse{}, newAPIError(http.StatusBadRequest, "type is required")
 	default:
-		writeError(w, http.StatusBadRequest, "unknown trunk type: "+req.Type)
+		return CreateTrunkResponse{}, newAPIError(http.StatusBadRequest, "unknown trunk type: %s", req.Type)
 	}
 }
 
-func (s *Server) createSIPRegisterTrunk(w http.ResponseWriter, r *http.Request, req CreateTrunkRequest) {
+func (s *Server) doCreateSIPRegisterTrunk(req CreateTrunkRequest) (CreateTrunkResponse, error) {
 	spec := req.SIPRegister
 	if spec == nil {
-		writeError(w, http.StatusBadRequest, "sip_register block is required when type=sip_register")
-		return
+		return CreateTrunkResponse{}, newAPIError(http.StatusBadRequest, "sip_register block is required when type=sip_register")
 	}
 	if spec.RegistrarURI == "" {
-		writeError(w, http.StatusBadRequest, "sip_register.registrar_uri is required")
-		return
+		return CreateTrunkResponse{}, newAPIError(http.StatusBadRequest, "sip_register.registrar_uri is required")
 	}
 	if spec.AOR == "" {
-		writeError(w, http.StatusBadRequest, "sip_register.aor is required")
-		return
+		return CreateTrunkResponse{}, newAPIError(http.StatusBadRequest, "sip_register.aor is required")
 	}
 	if spec.Password == "" {
-		writeError(w, http.StatusBadRequest, "sip_register.password is required")
-		return
+		return CreateTrunkResponse{}, newAPIError(http.StatusBadRequest, "sip_register.password is required")
 	}
 
 	var registrarURI sip.Uri
 	if err := sip.ParseUri(spec.RegistrarURI, &registrarURI); err != nil {
-		writeError(w, http.StatusBadRequest, "sip_register.registrar_uri is invalid: "+err.Error())
-		return
+		return CreateTrunkResponse{}, newAPIError(http.StatusBadRequest, "sip_register.registrar_uri is invalid: %s", err.Error())
 	}
 	var aorURI sip.Uri
 	if err := sip.ParseUri(spec.AOR, &aorURI); err != nil {
-		writeError(w, http.StatusBadRequest, "sip_register.aor is invalid: "+err.Error())
-		return
+		return CreateTrunkResponse{}, newAPIError(http.StatusBadRequest, "sip_register.aor is invalid: %s", err.Error())
 	}
 
 	id := uuid.NewString()
@@ -93,46 +81,41 @@ func (s *Server) createSIPRegisterTrunk(w http.ResponseWriter, r *http.Request, 
 		RequestedExpiresSeconds: spec.ExpiresSeconds,
 	})
 	s.SIPEngine.Trunks().Add(trunk)
-	// The trunk lifecycle outlives the HTTP request — using r.Context()
-	// would cancel the REGISTER loop as soon as the 202 is returned.
+	// The trunk lifecycle outlives the request that created it — using a
+	// request-scoped context would cancel the REGISTER loop immediately.
 	trunk.Start(context.Background())
 
-	writeJSON(w, http.StatusAccepted, CreateTrunkResponse{
+	return CreateTrunkResponse{
 		ID:     id,
 		Type:   string(sipmod.TrunkTypeSIPRegister),
 		Status: string(sipmod.TrunkStatusRegistering),
-	})
+	}, nil
 }
 
-// listTrunks handles GET /v1/sip/trunks.
-func (s *Server) listTrunks(w http.ResponseWriter, r *http.Request) {
+// doListTrunks returns a snapshot of every configured trunk.
+func (s *Server) doListTrunks() TrunksListResponse {
 	trunks := s.SIPEngine.Trunks().List()
 	views := make([]sipmod.TrunkView, 0, len(trunks))
 	for _, t := range trunks {
 		views = append(views, t.Snapshot())
 	}
-	writeJSON(w, http.StatusOK, TrunksListResponse{Trunks: views})
+	return TrunksListResponse{Trunks: views}
 }
 
-// getTrunk handles GET /v1/sip/trunks/{id}.
-func (s *Server) getTrunk(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+// doGetTrunk returns a single trunk snapshot or a 404 apiError.
+func (s *Server) doGetTrunk(id string) (sipmod.TrunkView, error) {
 	t := s.SIPEngine.Trunks().Get(id)
 	if t == nil {
-		writeError(w, http.StatusNotFound, "trunk not found")
-		return
+		return sipmod.TrunkView{}, newAPIError(http.StatusNotFound, "trunk not found")
 	}
-	writeJSON(w, http.StatusOK, t.Snapshot())
+	return t.Snapshot(), nil
 }
 
-// deleteTrunk handles DELETE /v1/sip/trunks/{id}. Returns 202 Accepted and
-// performs the unregister + cleanup asynchronously.
-func (s *Server) deleteTrunk(w http.ResponseWriter, r *http.Request) {
-	id := chi.URLParam(r, "id")
+// doDeleteTrunk unregisters and removes the trunk asynchronously.
+func (s *Server) doDeleteTrunk(id string) error {
 	t := s.SIPEngine.Trunks().Get(id)
 	if t == nil {
-		writeError(w, http.StatusNotFound, "trunk not found")
-		return
+		return newAPIError(http.StatusNotFound, "trunk not found")
 	}
 	go func() {
 		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -140,5 +123,45 @@ func (s *Server) deleteTrunk(w http.ResponseWriter, r *http.Request) {
 		_ = t.Stop(stopCtx)
 		s.SIPEngine.Trunks().Remove(id)
 	}()
+	return nil
+}
+
+// createTrunk handles POST /v1/sip/trunks. Returns 202 Accepted.
+func (s *Server) createTrunk(w http.ResponseWriter, r *http.Request) {
+	var req CreateTrunkRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	res, err := s.doCreateTrunk(req)
+	if err != nil {
+		handleAPIError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, res)
+}
+
+// listTrunks handles GET /v1/sip/trunks.
+func (s *Server) listTrunks(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.doListTrunks())
+}
+
+// getTrunk handles GET /v1/sip/trunks/{id}.
+func (s *Server) getTrunk(w http.ResponseWriter, r *http.Request) {
+	view, err := s.doGetTrunk(chi.URLParam(r, "id"))
+	if err != nil {
+		handleAPIError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, view)
+}
+
+// deleteTrunk handles DELETE /v1/sip/trunks/{id}. Returns 202 Accepted and
+// performs the unregister + cleanup asynchronously.
+func (s *Server) deleteTrunk(w http.ResponseWriter, r *http.Request) {
+	if err := s.doDeleteTrunk(chi.URLParam(r, "id")); err != nil {
+		handleAPIError(w, err)
+		return
+	}
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/internal/api/vsi_meta.go
+++ b/internal/api/vsi_meta.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/VoiceBlender/voiceblender/internal/events"
+	sipmod "github.com/VoiceBlender/voiceblender/internal/sip"
 )
 
 // VSICommandMeta describes a single command accepted on the /v1/vsi
@@ -61,10 +62,12 @@ func VSICommandsMetadata() []VSICommandMeta {
 		// ── Leg lifecycle ───────────────────────────────────────────────
 		{
 			Name: "create_leg", Summary: "Originate an outbound leg",
-			Description: "Currently returns a 501 error directing clients to use POST /v1/legs. " +
-				"Reserved for the future when the originate flow is fully extracted into a do* helper.",
+			Description: "Originates an outbound leg, mirroring POST /v1/legs, and returns the leg " +
+				"view. Supports all leg types: \"sip\", \"websocket\", \"whatsapp\", and " +
+				"\"livekit_room\". For \"livekit_room\", custom headers come from the request's " +
+				"`headers` map (there is no HTTP request over the WebSocket).",
 			PayloadType: CreateLegRequest{}, ResultType: LegView{},
-			ErrorCodes: []int{400, 501},
+			ErrorCodes: []int{400, 500, 502, 503},
 		},
 		{
 			Name: "answer_leg", Summary: "Answer a ringing inbound leg",
@@ -186,6 +189,7 @@ func VSICommandsMetadata() []VSICommandMeta {
 
 		// ── SIP Registrations ───────────────────────────────────────────
 		{Name: "list_sip_registrations", Summary: "List active SIP AOR registrations", ResultType: RegistrationsResponse{}},
+		{Name: "delete_sip_registration", Summary: "Force-unbind an AOR (or a single contact under it)", PayloadType: deleteRegistrationPayload{}, ResultType: vsiStatusResponse{}, ErrorCodes: []int{404}},
 
 		// ── Inbound auth (digest challenge) ─────────────────────────────
 		{Name: "challenge_leg", Summary: "Send a 401 digest challenge on a ringing inbound SIP leg (INVITE)", PayloadType: challengeLegPayload{}, ResultType: vsiStatusResponse{}, ErrorCodes: []int{400, 404, 409}},
@@ -196,7 +200,7 @@ func VSICommandsMetadata() []VSICommandMeta {
 		// ── SIP Trunks (outbound registrations) ─────────────────────────
 		{Name: "create_sip_trunk", Summary: "Create an outbound SIP trunk (REGISTER or static peering)", PayloadType: CreateTrunkRequest{}, ResultType: CreateTrunkResponse{}, ErrorCodes: []int{400, 501}},
 		{Name: "list_sip_trunks", Summary: "List configured SIP trunks", ResultType: TrunksListResponse{}},
-		{Name: "get_sip_trunk", Summary: "Get a single SIP trunk", PayloadType: idPayload{}, ResultType: vsiStatusResponse{}, ErrorCodes: []int{404}},
+		{Name: "get_sip_trunk", Summary: "Get a single SIP trunk", PayloadType: idPayload{}, ResultType: sipmod.TrunkView{}, ErrorCodes: []int{404}},
 		{Name: "delete_sip_trunk", Summary: "Unregister and remove a SIP trunk", PayloadType: idPayload{}, ResultType: vsiStatusResponse{}, ErrorCodes: []int{404}},
 	}
 }

--- a/internal/api/vsi_meta_test.go
+++ b/internal/api/vsi_meta_test.go
@@ -1,6 +1,10 @@
 package api
 
-import "testing"
+import (
+	"os"
+	"regexp"
+	"testing"
+)
 
 // TestVSIMetadata_AllNewCommandsRegistered guards REST/VSI parity. Every
 // REST endpoint that has a VSI equivalent must appear in VSICommandsMetadata,
@@ -26,6 +30,10 @@ func TestVSIMetadata_AllNewCommandsRegistered(t *testing.T) {
 		"room_agent_message", "room_agent_stop",
 		// Inbound auth (digest challenge)
 		"challenge_leg", "challenge_registration", "accept_registration", "reject_registration",
+		// SIP trunks (outbound registrations)
+		"create_sip_trunk", "list_sip_trunks", "get_sip_trunk", "delete_sip_trunk",
+		// SIP registrations
+		"delete_sip_registration",
 	}
 	registered := make(map[string]VSICommandMeta)
 	for _, cmd := range VSICommandsMetadata() {
@@ -39,6 +47,155 @@ func TestVSIMetadata_AllNewCommandsRegistered(t *testing.T) {
 		}
 		if cmd.Summary == "" {
 			t.Errorf("VSI command %q has empty Summary", name)
+		}
+	}
+}
+
+// TestVSIMetadata_EveryCommandHasDispatchCase guards against advertising a
+// command in the metadata (and therefore in asyncapi.yaml) without a matching
+// handler in the WS dispatcher — the dispatcher falls through to "unknown
+// command" and clients get a runtime error for a command the spec promises.
+func TestVSIMetadata_EveryCommandHasDispatchCase(t *testing.T) {
+	src, err := os.ReadFile("ws_commands.go")
+	if err != nil {
+		t.Fatalf("read ws_commands.go: %v", err)
+	}
+	handled := make(map[string]bool)
+	for _, m := range regexp.MustCompile(`case "([a-z_]+)":`).FindAllStringSubmatch(string(src), -1) {
+		handled[m[1]] = true
+	}
+	for _, cmd := range VSICommandsMetadata() {
+		if !handled[cmd.Name] {
+			t.Errorf("VSI command %q is in VSICommandsMetadata but has no dispatch case in ws_commands.go", cmd.Name)
+		}
+	}
+}
+
+// restOnlyRoutes are REST endpoints with no VSI equivalent by design: protocol
+// upgrades (the connection itself is the transport) and infra endpoints.
+var restOnlyRoutes = map[string]bool{
+	"Get /metrics":        true, // Prometheus scrape
+	"Get /legs/websocket": true, // inbound WebSocket media upgrade (wsLeg)
+	"Connect /legs/moq":   true, // WebTransport/HTTP3 upgrade (moqLeg)
+	"Get /rooms/{id}/ws":  true, // inbound WebSocket room upgrade (wsRoom)
+	"Get /vsi":            true, // the VSI WebSocket endpoint itself
+}
+
+// routeToVSICommand maps every actionable REST route ("<Method> <path>") to the
+// VSI command that mirrors it. Kept explicit (rather than derived) so it reads
+// as a parity contract.
+var routeToVSICommand = map[string]string{
+	"Post /legs":                                      "create_leg",
+	"Get /legs":                                       "list_legs",
+	"Get /legs/{id}":                                  "get_leg",
+	"Post /legs/{id}/answer":                          "answer_leg",
+	"Post /legs/{id}/early-media":                     "leg_early_media",
+	"Post /legs/{id}/ring":                            "leg_ring",
+	"Post /legs/{id}/challenge":                       "challenge_leg",
+	"Post /legs/{id}/mute":                            "mute_leg",
+	"Delete /legs/{id}/mute":                          "unmute_leg",
+	"Post /legs/{id}/deaf":                            "deaf_leg",
+	"Delete /legs/{id}/deaf":                          "undeaf_leg",
+	"Post /legs/{id}/hold":                            "hold_leg",
+	"Delete /legs/{id}/hold":                          "unhold_leg",
+	"Post /legs/{id}/transfer":                        "leg_transfer",
+	"Delete /legs/{id}":                               "delete_leg",
+	"Post /legs/{id}/dtmf":                            "send_leg_dtmf",
+	"Post /legs/{id}/dtmf/accept":                     "accept_leg_dtmf",
+	"Post /legs/{id}/dtmf/reject":                     "reject_leg_dtmf",
+	"Post /legs/{id}/rtt":                             "send_leg_rtt",
+	"Post /legs/{id}/rtt/accept":                      "accept_leg_rtt",
+	"Post /legs/{id}/rtt/reject":                      "reject_leg_rtt",
+	"Post /legs/{id}/play":                            "leg_play_start",
+	"Delete /legs/{id}/play/{playbackID}":             "leg_play_stop",
+	"Patch /legs/{id}/play/{playbackID}":              "leg_play_volume",
+	"Post /legs/{id}/tts":                             "leg_tts",
+	"Post /legs/{id}/record":                          "leg_record_start",
+	"Delete /legs/{id}/record":                        "leg_record_stop",
+	"Post /legs/{id}/record/pause":                    "leg_record_pause",
+	"Post /legs/{id}/record/resume":                   "leg_record_resume",
+	"Post /legs/{id}/stt":                             "leg_stt_start",
+	"Delete /legs/{id}/stt":                           "leg_stt_stop",
+	"Post /legs/{id}/agent/elevenlabs":                "leg_agent_elevenlabs",
+	"Post /legs/{id}/agent/vapi":                      "leg_agent_vapi",
+	"Post /legs/{id}/agent/pipecat":                   "leg_agent_pipecat",
+	"Post /legs/{id}/agent/deepgram":                  "leg_agent_deepgram",
+	"Post /legs/{id}/agent/message":                   "leg_agent_message",
+	"Delete /legs/{id}/agent":                         "leg_agent_stop",
+	"Post /legs/{id}/amd":                             "leg_amd_start",
+	"Post /legs/{id}/ice-candidates":                  "webrtc_add_candidate",
+	"Get /legs/{id}/ice-candidates":                   "webrtc_get_candidates",
+	"Patch /legs/{id}/role":                           "set_leg_role",
+	"Post /rooms":                                     "create_room",
+	"Get /rooms":                                      "list_rooms",
+	"Get /rooms/{id}":                                 "get_room",
+	"Delete /rooms/{id}":                              "delete_room",
+	"Post /rooms/{id}/legs":                           "add_leg_to_room",
+	"Delete /rooms/{id}/legs/{legID}":                 "remove_leg_from_room",
+	"Post /rooms/{id}/bridges":                        "bridge_create",
+	"Get /rooms/{id}/bridges":                         "bridge_list",
+	"Get /rooms/{id}/bridges/{bridgeID}":              "bridge_get",
+	"Patch /rooms/{id}/bridges/{bridgeID}":            "bridge_update",
+	"Delete /rooms/{id}/bridges/{bridgeID}":           "bridge_delete",
+	"Get /rooms/{id}/routing":                         "room_routing_get",
+	"Put /rooms/{id}/routing":                         "room_routing_set",
+	"Patch /rooms/{id}/routing":                       "room_routing_update",
+	"Post /rooms/{id}/play":                           "room_play_start",
+	"Delete /rooms/{id}/play/{playbackID}":            "room_play_stop",
+	"Patch /rooms/{id}/play/{playbackID}":             "room_play_volume",
+	"Post /rooms/{id}/tts":                            "room_tts",
+	"Post /rooms/{id}/record":                         "room_record_start",
+	"Delete /rooms/{id}/record":                       "room_record_stop",
+	"Post /rooms/{id}/record/pause":                   "room_record_pause",
+	"Post /rooms/{id}/record/resume":                  "room_record_resume",
+	"Post /rooms/{id}/stt":                            "room_stt_start",
+	"Delete /rooms/{id}/stt":                          "room_stt_stop",
+	"Post /rooms/{id}/agent/elevenlabs":               "room_agent_elevenlabs",
+	"Post /rooms/{id}/agent/vapi":                     "room_agent_vapi",
+	"Post /rooms/{id}/agent/pipecat":                  "room_agent_pipecat",
+	"Post /rooms/{id}/agent/deepgram":                 "room_agent_deepgram",
+	"Post /rooms/{id}/agent/message":                  "room_agent_message",
+	"Delete /rooms/{id}/agent":                        "room_agent_stop",
+	"Get /sip/registrations":                          "list_sip_registrations",
+	"Delete /sip/registrations/{aor}":                 "delete_sip_registration",
+	"Post /sip/registrations/attempts/{id}/challenge": "challenge_registration",
+	"Post /sip/registrations/attempts/{id}/accept":    "accept_registration",
+	"Post /sip/registrations/attempts/{id}/reject":    "reject_registration",
+	"Post /sip/trunks":                                "create_sip_trunk",
+	"Get /sip/trunks":                                 "list_sip_trunks",
+	"Get /sip/trunks/{id}":                            "get_sip_trunk",
+	"Delete /sip/trunks/{id}":                         "delete_sip_trunk",
+	"Post /webrtc/offer":                              "webrtc_offer",
+}
+
+// TestVSIRESTParity fails when a REST route registered in server.go is neither
+// mapped to a VSI command nor explicitly marked REST-only. This forces the
+// author of a new REST endpoint to make a deliberate choice — add the mirroring
+// VSI command (and map it here) or allowlist it — rather than silently leaving
+// the WebSocket surface behind.
+func TestVSIRESTParity(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatalf("read server.go: %v", err)
+	}
+	registered := make(map[string]bool)
+	for _, cmd := range VSICommandsMetadata() {
+		registered[cmd.Name] = true
+	}
+	routeRe := regexp.MustCompile(`r\.(Get|Post|Put|Patch|Delete|Connect)\("([^"]+)"`)
+	for _, m := range routeRe.FindAllStringSubmatch(string(src), -1) {
+		route := m[1] + " " + m[2]
+		if restOnlyRoutes[route] {
+			continue
+		}
+		cmd, ok := routeToVSICommand[route]
+		if !ok {
+			t.Errorf("REST route %q has no VSI command mapping and is not marked REST-only "+
+				"(add it to routeToVSICommand or restOnlyRoutes)", route)
+			continue
+		}
+		if !registered[cmd] {
+			t.Errorf("REST route %q maps to VSI command %q which is not in VSICommandsMetadata", route, cmd)
 		}
 	}
 }

--- a/internal/api/whatsapp.go
+++ b/internal/api/whatsapp.go
@@ -162,28 +162,35 @@ func (s *Server) handleWhatsAppInbound(call *sipmod.InboundCall) {
 }
 
 func (s *Server) createWhatsAppOutboundLeg(w http.ResponseWriter, r *http.Request, req CreateLegRequest) {
-	if req.To == "" {
-		writeError(w, http.StatusBadRequest, "'to' is required")
+	view, err := s.doCreateWhatsAppOutboundLeg(req)
+	if err != nil {
+		handleAPIError(w, err)
 		return
+	}
+	writeJSON(w, http.StatusCreated, view)
+}
+
+// doCreateWhatsAppOutboundLeg validates, sets up WebRTC media, and starts an
+// outbound WhatsApp leg, returning the leg view. Shared by the REST handler and
+// VSI create_leg.
+func (s *Server) doCreateWhatsAppOutboundLeg(req CreateLegRequest) (LegView, error) {
+	if req.To == "" {
+		return LegView{}, newAPIError(http.StatusBadRequest, "'to' is required")
 	}
 	if req.From == "" {
-		writeError(w, http.StatusBadRequest, "'from' is required (business phone number, E.164)")
-		return
+		return LegView{}, newAPIError(http.StatusBadRequest, "'from' is required (business phone number, E.164)")
 	}
 	if req.Auth == nil || req.Auth.Password == "" {
-		writeError(w, http.StatusBadRequest, "'auth.password' is required (Meta-issued digest password)")
-		return
+		return LegView{}, newAPIError(http.StatusBadRequest, "'auth.password' is required (Meta-issued digest password)")
 	}
 	if s.SIPEngine.TLSPort() == 0 {
-		writeError(w, http.StatusServiceUnavailable, "SIP TLS not configured on this instance")
-		return
+		return LegView{}, newAPIError(http.StatusServiceUnavailable, "SIP TLS not configured on this instance")
 	}
 
 	if req.RoomID != "" {
 		if _, ok := s.RoomMgr.Get(req.RoomID); !ok {
 			if _, err := s.RoomMgr.Create(req.RoomID, req.AppID, s.Config.DefaultSampleRate); err != nil {
-				writeError(w, http.StatusInternalServerError, "create room: "+err.Error())
-				return
+				return LegView{}, newAPIError(http.StatusInternalServerError, "create room: %s", err.Error())
 			}
 		}
 	}
@@ -197,22 +204,19 @@ func (s *Server) createWhatsAppOutboundLeg(w http.ResponseWriter, r *http.Reques
 		Log:         s.Log,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to create PCMedia")
-		return
+		return LegView{}, newAPIError(http.StatusInternalServerError, "failed to create PCMedia")
 	}
 
 	pc := media.PC()
 	offer, err := pc.CreateOffer(nil)
 	if err != nil {
 		media.Close()
-		writeError(w, http.StatusInternalServerError, "failed to create offer")
-		return
+		return LegView{}, newAPIError(http.StatusInternalServerError, "failed to create offer")
 	}
 	gatherDone := webrtc.GatheringCompletePromise(pc)
 	if err := pc.SetLocalDescription(offer); err != nil {
 		media.Close()
-		writeError(w, http.StatusInternalServerError, "failed to set local description")
-		return
+		return LegView{}, newAPIError(http.StatusInternalServerError, "failed to set local description")
 	}
 
 	l := leg.NewWhatsAppOutboundPendingLeg(media, req.From, req.To, s.Log)
@@ -228,9 +232,9 @@ func (s *Server) createWhatsAppOutboundLeg(w http.ResponseWriter, r *http.Reques
 		From:     req.From,
 	})
 
-	writeJSON(w, http.StatusCreated, legViewFrom(l))
-
 	go s.driveWhatsAppOutbound(l, media, gatherDone, req)
+
+	return legViewFrom(l), nil
 }
 
 func (s *Server) driveWhatsAppOutbound(l *leg.WhatsAppLeg, media *leg.PCMedia, gatherDone <-chan struct{}, req CreateLegRequest) {

--- a/internal/api/ws_commands.go
+++ b/internal/api/ws_commands.go
@@ -210,6 +210,14 @@ type rejectRegistrationPayload struct {
 	RegistrationRejectRequest
 }
 
+// deleteRegistrationPayload force-unbinds an AOR (or a single contact under it)
+// for delete_sip_registration. AOR is sent plain (no URL-encoding, unlike the
+// REST path param).
+type deleteRegistrationPayload struct {
+	AOR     string `json:"aor"`
+	Contact string `json:"contact,omitempty"`
+}
+
 func (s *Server) wsHandleCommand(lw *wsLockedWriter, msg vsiInMsg) {
 	switch msg.Type {
 
@@ -959,6 +967,16 @@ func (s *Server) wsHandleCommand(lw *wsLockedWriter, msg vsiInMsg) {
 			}
 		}
 		s.wsCommandResult(lw, msg, RegistrationsResponse{Bindings: views})
+	case "delete_sip_registration":
+		var p deleteRegistrationPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		if err := s.doDeleteRegistration(p.AOR, p.Contact); err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, map[string]string{"status": "unbound"})
 
 	// ── Inbound auth (challenge INVITE / REGISTER) ──────────────────
 	case "challenge_leg":
@@ -1001,6 +1019,42 @@ func (s *Server) wsHandleCommand(lw *wsLockedWriter, msg vsiInMsg) {
 			return
 		}
 		s.wsCommandResult(lw, msg, map[string]string{"status": "rejecting"})
+
+	// ── SIP Trunks (outbound registrations) ─────────────────────────
+	case "create_sip_trunk":
+		var p CreateTrunkRequest
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		res, err := s.doCreateTrunk(p)
+		if err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, res)
+	case "list_sip_trunks":
+		s.wsCommandResult(lw, msg, s.doListTrunks())
+	case "get_sip_trunk":
+		var p idPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		view, err := s.doGetTrunk(p.ID)
+		if err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, view)
+	case "delete_sip_trunk":
+		var p idPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		if err := s.doDeleteTrunk(p.ID); err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, map[string]string{"status": "deleting"})
 
 	default:
 		s.vsiSendResponse(lw, msg.RequestID, "error",
@@ -1049,17 +1103,31 @@ func (s *Server) wsCommandError(lw *wsLockedWriter, msg vsiInMsg, err error) {
 	})
 }
 
-// wsCreateLeg is a placeholder for create_leg over WS. It calls the HTTP-based
-// createSIPOutboundLeg flow synchronously. Full do* extraction of the complex
-// originate flow is deferred to Phase 2.
+// wsCreateLeg handles create_leg over the VSI WebSocket, mirroring POST /v1/legs.
 func (s *Server) wsCreateLeg(lw *wsLockedWriter, msg vsiInMsg, req CreateLegRequest) {
+	var (
+		view LegView
+		err  error
+	)
 	switch req.Type {
 	case "sip":
-		// For now, return an error directing clients to use the REST API for
-		// leg creation until the complex originate flow is extracted into a
-		// do* method.
-		s.wsCommandError(lw, msg, newAPIError(501, "create_leg over WS not yet implemented; use POST /v1/legs"))
+		view, err = s.doCreateSIPOutboundLeg(req)
+	case "websocket":
+		view, err = s.doCreateWebSocketOutboundLeg(req)
+	case "whatsapp":
+		view, err = s.doCreateWhatsAppOutboundLeg(req)
+	case "livekit_room":
+		// No HTTP request over VSI: use a background context (the helper
+		// still applies the 20s connect timeout) and custom headers from
+		// the request body's headers map.
+		view, err = s.doCreateLiveKitRoomLeg(context.Background(), req.Headers, req)
 	default:
 		s.wsCommandError(lw, msg, newAPIError(400, "unsupported leg type: %s", req.Type))
+		return
 	}
+	if err != nil {
+		s.wsCommandError(lw, msg, err)
+		return
+	}
+	s.wsCommandResult(lw, msg, view)
 }

--- a/internal/api/ws_leg.go
+++ b/internal/api/ws_leg.go
@@ -114,21 +114,29 @@ func (s *Server) wsLeg(w http.ResponseWriter, r *http.Request) {
 // resulting leg. Responds 201 immediately; the dial completes
 // asynchronously and publishes LegConnected or LegDisconnected.
 func (s *Server) createWebSocketOutboundLeg(w http.ResponseWriter, r *http.Request, req CreateLegRequest) {
-	if req.URL == "" {
-		writeError(w, http.StatusBadRequest, "url is required for type=websocket")
+	view, err := s.doCreateWebSocketOutboundLeg(req)
+	if err != nil {
+		handleAPIError(w, err)
 		return
+	}
+	writeJSON(w, http.StatusCreated, view)
+}
+
+// doCreateWebSocketOutboundLeg validates and starts an outbound WebSocket leg,
+// returning the leg view. Shared by the REST handler and VSI create_leg.
+func (s *Server) doCreateWebSocketOutboundLeg(req CreateLegRequest) (LegView, error) {
+	if req.URL == "" {
+		return LegView{}, newAPIError(http.StatusBadRequest, "url is required for type=websocket")
 	}
 	cfg, err := wsCfgFromCreateReq(req, s.Log)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
+		return LegView{}, newAPIError(http.StatusBadRequest, "%s", err.Error())
 	}
 
 	if req.RoomID != "" {
 		if _, ok := s.RoomMgr.Get(req.RoomID); !ok {
 			if _, err := s.RoomMgr.Create(req.RoomID, req.AppID, s.Config.DefaultSampleRate); err != nil {
-				writeError(w, http.StatusInternalServerError, fmt.Sprintf("create room: %v", err))
-				return
+				return LegView{}, newAPIError(http.StatusInternalServerError, "create room: %v", err)
 			}
 		}
 	}
@@ -157,7 +165,7 @@ func (s *Server) createWebSocketOutboundLeg(w http.ResponseWriter, r *http.Reque
 
 	go s.runWSOutboundDial(l, req, cfg)
 
-	writeJSON(w, http.StatusCreated, toLegView(l))
+	return toLegView(l), nil
 }
 
 func (s *Server) runWSOutboundDial(l *leg.WebSocketLeg, req CreateLegRequest, cfg wsmedia.Config) {

--- a/internal/sip/engine.go
+++ b/internal/sip/engine.go
@@ -1197,15 +1197,27 @@ func (e *Engine) Invite(ctx context.Context, recipient sip.Uri, opts InviteOptio
 		req.AppendHeader(sip.NewHeader("Route", "<"+routeURI.String()+">"))
 	}
 
-	// Optional single-destination override (e.g. a single-contact AOR lookup
-	// produced one ForkTarget). Sets the transport-layer destination without
-	// touching the Request-URI.
+	// Single-contact AOR resolution produced one ForkTarget: pin the transport
+	// destination to the bound contact socket while leaving the Request-URI as
+	// the dialed AOR. RFC 3261 §9.1 requires a CANCEL to reuse the INVITE's
+	// Request-URI and be sent to the same next hop; sipgo builds the CANCEL
+	// from the INVITE but does NOT preserve SetDestination — it only copies
+	// Route headers — so without a Route the CANCEL would re-resolve the AOR
+	// host (possibly ourselves). We therefore add a loose Route to the contact
+	// socket, which both directs the INVITE and survives onto the CANCEL. A
+	// trunk Route (opts.RouteURI) already provides this, so skip it then.
 	if len(opts.ForkTargets) == 1 {
 		t := opts.ForkTargets[0]
 		if t.Transport != "" {
 			req.SetTransport(strings.ToUpper(t.Transport))
 		}
 		if t.Socket != "" {
+			if opts.RouteURI == nil {
+				host, port := splitHostPort(t.Socket)
+				contactRoute := sip.Uri{Scheme: "sip", Host: host, Port: port, UriParams: sip.NewParams()}
+				contactRoute.UriParams.Add("lr", "")
+				req.AppendHeader(sip.NewHeader("Route", "<"+contactRoute.String()+">"))
+			}
 			req.SetDestination(t.Socket)
 		}
 	}

--- a/tests/integration/create_leg_types_vsi_test.go
+++ b/tests/integration/create_leg_types_vsi_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+	"github.com/VoiceBlender/voiceblender/internal/wsmedia"
+)
+
+// TestVSI_CreateLeg_WebSocket originates an outbound WebSocket leg over the VSI
+// WebSocket (create_leg type "websocket") against an in-test echo server and
+// confirms it reaches connected.
+func TestVSI_CreateLeg_WebSocket(t *testing.T) {
+	inst := newTestInstance(t, "vsi-createleg-ws")
+
+	srvCfg := wsmedia.Config{SampleRate: 16000, WireFormat: wsmedia.WireBinary, Log: slog.Default()}
+	if err := srvCfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		c := srvCfg
+		c.Log = slog.Default()
+		tr, _, err := wsmedia.UpgradeServer(w, r, c)
+		if err != nil {
+			return
+		}
+		// Audio loopback so the server transport has a valid reader to send.
+		pr, pw := io.Pipe()
+		go func() {
+			defer pw.Close()
+			ar := tr.AudioReader()
+			buf := make([]byte, c.FrameBytesPCM())
+			for {
+				if _, err := io.ReadFull(ar, buf); err != nil {
+					return
+				}
+				if _, err := pw.Write(buf); err != nil {
+					return
+				}
+			}
+		}()
+		tr.Start(pr)
+		<-tr.Done()
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	conn := dialVSI(t, inst)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second)
+
+	f := vsiSend(t, conn, "create_leg", "ws-1", map[string]any{
+		"type":        "websocket",
+		"url":         wsURL,
+		"sample_rate": 16000,
+		"wire_format": "binary",
+	})
+	if f.Type != "create_leg.result" {
+		t.Fatalf("type = %q, want create_leg.result (data=%s)", f.Type, f.Data)
+	}
+	var v legView
+	if err := json.Unmarshal(f.Data, &v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if v.ID == "" {
+		t.Fatal("empty leg id")
+	}
+	inst.collector.waitForMatch(t, events.LegConnected, func(e events.Event) bool {
+		return e.Data.GetLegID() == v.ID
+	}, 3*time.Second)
+}
+
+// TestVSI_CreateLeg_WebSocketValidation confirms a missing url surfaces a VSI
+// error frame (400), not a silent accept.
+func TestVSI_CreateLeg_WebSocketValidation(t *testing.T) {
+	inst := newTestInstance(t, "vsi-createleg-ws-bad")
+	conn := dialVSI(t, inst)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second)
+
+	f := vsiSend(t, conn, "create_leg", "ws-bad", map[string]any{"type": "websocket"})
+	assertVSIErrorCode(t, f, 400)
+}
+
+// TestVSI_CreateLeg_WhatsAppValidation confirms whatsapp validation runs over
+// VSI (missing 'to' → 400) rather than the old "unsupported leg type" error.
+func TestVSI_CreateLeg_WhatsAppValidation(t *testing.T) {
+	inst := newTestInstance(t, "vsi-createleg-wa-bad")
+	conn := dialVSI(t, inst)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second)
+
+	f := vsiSend(t, conn, "create_leg", "wa-bad", map[string]any{"type": "whatsapp"})
+	assertVSIErrorCode(t, f, 400)
+}
+
+// TestVSI_CreateLeg_LiveKitError confirms livekit_room is dispatched over VSI
+// and surfaces a real error frame (503 when LiveKit is disabled — the default
+// test config — or 400 for missing params when enabled), never a 501/unsupported.
+func TestVSI_CreateLeg_LiveKitError(t *testing.T) {
+	inst := newTestInstance(t, "vsi-createleg-lk-bad")
+	conn := dialVSI(t, inst)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second)
+
+	f := vsiSend(t, conn, "create_leg", "lk-bad", map[string]any{"type": "livekit_room"})
+	if f.Type != "error" {
+		t.Fatalf("type = %q, want error (data=%s)", f.Type, f.Data)
+	}
+	var e struct {
+		Code int `json:"code"`
+	}
+	if err := json.Unmarshal(f.Data, &e); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if e.Code != 400 && e.Code != 503 {
+		t.Errorf("code = %d, want 400 or 503", e.Code)
+	}
+}
+
+func assertVSIErrorCode(t *testing.T, f vsiResultFrame, want int) {
+	t.Helper()
+	if f.Type != "error" {
+		t.Fatalf("type = %q, want error (data=%s)", f.Type, f.Data)
+	}
+	var e struct {
+		Code int `json:"code"`
+	}
+	if err := json.Unmarshal(f.Data, &e); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if e.Code != want {
+		t.Errorf("code = %d, want %d", e.Code, want)
+	}
+}

--- a/tests/integration/create_leg_vsi_test.go
+++ b/tests/integration/create_leg_vsi_test.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestVSI_CreateLeg_Originates drives an outbound SIP originate over the
+// /v1/vsi WebSocket (create_leg) instead of POST /v1/legs, and confirms the
+// call connects end-to-end. Guards against create_leg being advertised over
+// VSI while the dispatcher returns 501.
+func TestVSI_CreateLeg_Originates(t *testing.T) {
+	caller := newTestInstance(t, "vsi-createleg-caller")
+	callee := newTestInstance(t, "vsi-createleg-callee")
+
+	conn := dialVSI(t, caller)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second) // consume "connected"
+
+	f := vsiSend(t, conn, "create_leg", "orig-1", map[string]interface{}{
+		"type":   "sip",
+		"uri":    fmt.Sprintf("sip:test@127.0.0.1:%d", callee.sipPort),
+		"codecs": []string{"PCMU"},
+	})
+	if f.Type != "create_leg.result" {
+		t.Fatalf("type = %q, want create_leg.result (data=%s)", f.Type, f.Data)
+	}
+	var v legView
+	if err := json.Unmarshal(f.Data, &v); err != nil {
+		t.Fatalf("decode create_leg result: %v", err)
+	}
+	if v.ID == "" {
+		t.Fatal("create_leg returned empty leg id")
+	}
+
+	in := waitForInboundLeg(t, callee.baseURL(), 5*time.Second)
+	ans := httpPost(t, fmt.Sprintf("%s/v1/legs/%s/answer", callee.baseURL(), in.ID), nil)
+	ans.Body.Close()
+
+	waitForLegState(t, caller.baseURL(), v.ID, "connected", 5*time.Second)
+	waitForLegState(t, callee.baseURL(), in.ID, "connected", 5*time.Second)
+}
+
+// TestVSI_CreateLeg_InvalidURI verifies a bad originate surfaces a VSI error
+// frame (not a silent accept or a 501).
+func TestVSI_CreateLeg_InvalidURI(t *testing.T) {
+	inst := newTestInstance(t, "vsi-createleg-baduri")
+
+	conn := dialVSI(t, inst)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second)
+
+	f := vsiSend(t, conn, "create_leg", "bad-1", map[string]interface{}{
+		"type": "sip",
+		"uri":  "not-a-sip-uri",
+	})
+	if f.Type != "error" {
+		t.Fatalf("type = %q, want error", f.Type)
+	}
+	var e struct {
+		Code int `json:"code"`
+	}
+	if err := json.Unmarshal(f.Data, &e); err != nil {
+		t.Fatalf("decode error data: %v", err)
+	}
+	if e.Code != 400 {
+		t.Errorf("code = %d, want 400", e.Code)
+	}
+}

--- a/tests/integration/sip_register_test.go
+++ b/tests/integration/sip_register_test.go
@@ -34,6 +34,9 @@ type rawSIPClient struct {
 
 	// Inbound INVITE delivery for AOR-dial tests.
 	invites chan inviteEvent
+	// Inbound CANCEL delivery — lets tests assert a CANCEL actually reached
+	// this contact (rather than being misrouted to the AOR host).
+	cancels chan *sip.Request
 }
 
 type inviteEvent struct {
@@ -80,6 +83,7 @@ func newRawSIPClient(t *testing.T, ua string) *rawSIPClient {
 		host:    "127.0.0.1",
 		port:    port,
 		invites: make(chan inviteEvent, 8),
+		cancels: make(chan *sip.Request, 8),
 	}
 
 	srv.OnInvite(func(req *sip.Request, tx sip.ServerTransaction) {
@@ -88,6 +92,15 @@ func newRawSIPClient(t *testing.T, ua string) *rawSIPClient {
 		// (e.g. parallel fork) rely on this.
 		ring := sip.NewResponseFromRequest(req, sip.StatusRinging, "Ringing", nil)
 		_ = tx.Respond(ring)
+
+		// A matching CANCEL is handled at the transaction layer (sipgo does not
+		// call the server's OnCancel request handler for it), so record it here.
+		tx.OnCancel(func(r *sip.Request) {
+			select {
+			case c.cancels <- r:
+			default:
+			}
+		})
 
 		done := make(chan struct{})
 		select {
@@ -443,12 +456,61 @@ func TestSIPRegister_DialAOR(t *testing.T) {
 
 	// raw client receives the INVITE on its own listener.
 	e := cli.waitInvite(t, 3*time.Second)
-	// Confirm Request-URI host is the AOR's host (URI unchanged), but the
-	// transport delivered the packet to our port — which is the test contract.
+	// The Request-URI is left as the dialed AOR (the transport delivered the
+	// packet to our port via a loose Route to the contact socket). Preserving
+	// the Request-URI keeps CANCEL/ACK — which reuse it per RFC 3261 §9.1 —
+	// pointing at the AOR the caller asked for.
 	if e.req.Recipient.Host != "vb.test" {
-		t.Errorf("Recipient.Host = %q, want vb.test", e.req.Recipient.Host)
+		t.Errorf("Recipient.Host = %q, want vb.test (dialed AOR preserved)", e.req.Recipient.Host)
 	}
 	cli.answerInvite(t, e)
+}
+
+// TestSIPRegister_CancelUnansweredRoutesToContact reproduces the bug where
+// deleting an unanswered outbound leg dialed to a registered AOR sent CANCEL to
+// the AOR host (potentially VoiceBlender itself) instead of the contact. The
+// contact must receive the CANCEL.
+func TestSIPRegister_CancelUnansweredRoutesToContact(t *testing.T) {
+	inst := newTestInstance(t, "reg-cancel")
+	cli := newRawSIPClient(t, "alice-ua")
+
+	cli.sendRegister(t, inst.sipPort, "alice", cli.contactURI("alice"), 600)
+	inst.collector.waitForMatch(t, events.SIPRegistrationActive, nil, 1*time.Second)
+
+	createResp := httpPost(t, inst.baseURL()+"/v1/legs", map[string]interface{}{
+		"type":   "sip",
+		"to":     "sip:alice@vb.test",
+		"from":   "support",
+		"codecs": []string{"PCMU"},
+	})
+	if createResp.StatusCode != http.StatusCreated {
+		t.Fatalf("create leg: %d", createResp.StatusCode)
+	}
+	var lv legView
+	decodeJSON(t, createResp, &lv)
+
+	// Contact receives the INVITE (and auto-replies 180 Ringing) but never
+	// answers.
+	cli.waitInvite(t, 3*time.Second)
+
+	// Delete the unanswered leg → VB must CANCEL the outbound INVITE.
+	delResp := httpDelete(t, inst.baseURL()+"/v1/legs/"+lv.ID)
+	delResp.Body.Close()
+
+	select {
+	case req := <-cli.cancels:
+		if req.Method != sip.CANCEL {
+			t.Fatalf("got %s, want CANCEL", req.Method)
+		}
+		// RFC 3261 §9.1: the CANCEL Request-URI must be identical to the
+		// INVITE's — i.e. the dialed AOR — even though it was delivered to the
+		// contact socket (the same next hop as the INVITE).
+		if req.Recipient.Host != "vb.test" {
+			t.Errorf("CANCEL Request-URI host = %q, want vb.test (dialed AOR)", req.Recipient.Host)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("contact never received CANCEL — it was misrouted to the AOR host")
+	}
 }
 
 func TestSIPRegister_Fork(t *testing.T) {

--- a/tests/integration/sip_registration_vsi_test.go
+++ b/tests/integration/sip_registration_vsi_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+)
+
+// TestVSI_DeleteRegistration exercises the delete_sip_registration command over
+// the /v1/vsi WebSocket: a raw client REGISTERs, list_sip_registrations shows
+// the binding, delete_sip_registration unbinds it, the list goes empty, and a
+// delete for an unknown AOR returns an error frame.
+func TestVSI_DeleteRegistration(t *testing.T) {
+	inst := newTestInstance(t, "vsi-delreg")
+	cli := newRawSIPClient(t, "test-ua")
+
+	if resp := cli.sendRegister(t, inst.sipPort, "alice", cli.contactURI("alice"), 600); resp.StatusCode != 200 {
+		t.Fatalf("REGISTER status = %d", resp.StatusCode)
+	}
+	inst.collector.waitForMatch(t, events.SIPRegistrationActive, nil, time.Second)
+
+	conn := dialVSI(t, inst)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second) // consume "connected"
+
+	// list shows the binding
+	listed := vsiSend(t, conn, "list_sip_registrations", "l1", nil)
+	if listed.Type != "list_sip_registrations.result" {
+		t.Fatalf("list type = %q", listed.Type)
+	}
+	if !strings.Contains(string(listed.Data), "sip:alice@vb.test") {
+		t.Fatalf("list result missing the binding: %s", listed.Data)
+	}
+
+	// delete the AOR
+	del := vsiSend(t, conn, "delete_sip_registration", "d1", map[string]string{"aor": "sip:alice@vb.test"})
+	if del.Type != "delete_sip_registration.result" {
+		t.Fatalf("delete type = %q (data=%s)", del.Type, del.Data)
+	}
+
+	// list is now empty
+	listed2 := vsiSend(t, conn, "list_sip_registrations", "l2", nil)
+	var lr struct {
+		Bindings []struct {
+			AOR string `json:"aor"`
+		} `json:"bindings"`
+	}
+	if err := json.Unmarshal(listed2.Data, &lr); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(lr.Bindings) != 0 {
+		t.Errorf("bindings after delete = %d, want 0", len(lr.Bindings))
+	}
+
+	// unknown AOR → error frame with 404
+	miss := vsiSend(t, conn, "delete_sip_registration", "d2", map[string]string{"aor": "sip:nobody@vb.test"})
+	if miss.Type != "error" {
+		t.Fatalf("delete-unknown type = %q, want error", miss.Type)
+	}
+	var e struct {
+		Code int `json:"code"`
+	}
+	if err := json.Unmarshal(miss.Data, &e); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if e.Code != 404 {
+		t.Errorf("code = %d, want 404", e.Code)
+	}
+}

--- a/tests/integration/sip_trunks_vsi_test.go
+++ b/tests/integration/sip_trunks_vsi_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+)
+
+// TestVSI_Trunk_Lifecycle drives the full outbound-trunk lifecycle over the
+// VSI WebSocket (create → list → get → delete), mirroring the REST happy path.
+// It guards against the trunk commands being advertised in the metadata /
+// asyncapi spec without a working dispatch handler.
+func TestVSI_Trunk_Lifecycle(t *testing.T) {
+	inst := newTestInstance(t, "vsi-trunk")
+	reg := newRawSIPRegistrar(t, rawRegistrarOpts{grantExpires: 120})
+
+	conn := dialVSI(t, inst)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second) // consume "connected"
+
+	// create_sip_trunk
+	created := vsiSend(t, conn, "create_sip_trunk", "create-1", map[string]interface{}{
+		"type": "sip_register",
+		"sip_register": map[string]interface{}{
+			"registrar_uri":   fmt.Sprintf("sip:127.0.0.1:%d", reg.port),
+			"aor":             "sip:alice@vb.test",
+			"password":        "secret",
+			"expires_seconds": 600,
+		},
+	})
+	if created.Type != "create_sip_trunk.result" {
+		t.Fatalf("create type = %q, want create_sip_trunk.result", created.Type)
+	}
+	var createData struct {
+		ID     string `json:"id"`
+		Type   string `json:"type"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(created.Data, &createData); err != nil {
+		t.Fatalf("decode create data: %v", err)
+	}
+	if createData.ID == "" {
+		t.Fatal("create_sip_trunk returned empty id")
+	}
+	if createData.Type != "sip_register" {
+		t.Errorf("type = %q, want sip_register", createData.Type)
+	}
+	id := createData.ID
+
+	// The trunk registers with the fake registrar and the lifecycle event fires.
+	inst.collector.waitForMatch(t, events.SIPOutboundRegistrationActive, nil, 3*time.Second)
+	if reg.registerCount() < 1 {
+		t.Fatal("fake registrar did not receive REGISTER")
+	}
+
+	// list_sip_trunks contains the trunk and never leaks the password.
+	listed := vsiSend(t, conn, "list_sip_trunks", "list-1", nil)
+	if listed.Type != "list_sip_trunks.result" {
+		t.Fatalf("list type = %q, want list_sip_trunks.result", listed.Type)
+	}
+	if !strings.Contains(string(listed.Data), id) {
+		t.Errorf("list result missing trunk %s: %s", id, listed.Data)
+	}
+	if strings.Contains(strings.ToLower(string(listed.Data)), "\"password\"") {
+		t.Errorf("list result leaks password: %s", listed.Data)
+	}
+
+	// get_sip_trunk returns the single trunk.
+	got := vsiSend(t, conn, "get_sip_trunk", "get-1", map[string]string{"id": id})
+	if got.Type != "get_sip_trunk.result" {
+		t.Fatalf("get type = %q, want get_sip_trunk.result", got.Type)
+	}
+	if !strings.Contains(string(got.Data), id) {
+		t.Errorf("get result missing trunk %s: %s", id, got.Data)
+	}
+
+	// delete_sip_trunk acknowledges, then a subsequent get returns an error.
+	deleted := vsiSend(t, conn, "delete_sip_trunk", "del-1", map[string]string{"id": id})
+	if deleted.Type != "delete_sip_trunk.result" {
+		t.Fatalf("delete type = %q, want delete_sip_trunk.result", deleted.Type)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		missing := vsiSend(t, conn, "get_sip_trunk", "get-2", map[string]string{"id": id})
+		if missing.Type == "error" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("get after delete still succeeds: %s", missing.Type)
+		}
+		time.Sleep(75 * time.Millisecond)
+	}
+}
+
+// TestVSI_Trunk_CreateValidationError verifies a bad create surfaces a VSI
+// error frame rather than being silently accepted.
+func TestVSI_Trunk_CreateValidationError(t *testing.T) {
+	inst := newTestInstance(t, "vsi-trunk-badreq")
+
+	conn := dialVSI(t, inst)
+	defer conn.Close()
+	readWSFrame(t, conn, 5*time.Second)
+
+	// Missing sip_register block for a sip_register trunk.
+	f := vsiSend(t, conn, "create_sip_trunk", "bad-1", map[string]interface{}{
+		"type": "sip_register",
+	})
+	if f.Type != "error" {
+		t.Fatalf("type = %q, want error", f.Type)
+	}
+	var e struct {
+		Code int `json:"code"`
+	}
+	if err := json.Unmarshal(f.Data, &e); err != nil {
+		t.Fatalf("decode error data: %v", err)
+	}
+	if e.Code != 400 {
+		t.Errorf("code = %d, want 400", e.Code)
+	}
+}


### PR DESCRIPTION
SIP trunk management over VSI
create_leg over VSI — full leg-type coverage
delete_sip_registration VSI command
REST↔VSI parity guards
CANCEL routing fix for registered endpoints (bug fix)