### PR TITLE
Port init-race and test data-race fixes from Mliviu79's fork

### DIFF
--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -330,9 +330,15 @@ func TestWebhookRegistry_Delivery(t *testing.T) {
 }
 
 func TestWebhookRegistry_HMAC(t *testing.T) {
-	var sigHeader string
+	// The signature is captured on the httptest server goroutine and asserted
+	// on the test goroutine; hand it over via a channel so the read is
+	// synchronized with the write (buffered + non-blocking send tolerates retries).
+	sigCh := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sigHeader = r.Header.Get("X-Signature-256")
+		select {
+		case sigCh <- r.Header.Get("X-Signature-256"):
+		default:
+		}
 		w.WriteHeader(200)
 	}))
 	defer srv.Close()
@@ -344,7 +350,12 @@ func TestWebhookRegistry_HMAC(t *testing.T) {
 
 	bus.Publish(RoomDeleted, &RoomDeletedData{RoomScope: RoomScope{RoomID: "r1"}})
 
-	time.Sleep(500 * time.Millisecond)
+	var sigHeader string
+	select {
+	case sigHeader = <-sigCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for webhook delivery")
+	}
 
 	if sigHeader == "" {
 		t.Fatal("expected X-Signature-256 header")

--- a/internal/lkmedia/transport.go
+++ b/internal/lkmedia/transport.go
@@ -174,14 +174,10 @@ func NewTransport(ctx context.Context, cfg Config, signalCfg SignalConfig, peer 
 	}
 	t.cb.Store(&cb)
 
-	pub, sub, localTrack, err := t.buildPeerConnections(join.IceServers)
-	if err != nil {
+	if err := t.buildPeerConnections(join.IceServers); err != nil {
 		t.cleanup(err, "livekit_pc_setup_failed")
 		return nil, err
 	}
-	t.publisher = pub
-	t.subscriber = sub
-	t.localTrack = localTrack
 	t.localCID = "voiceblender-audio-" + uuid.New().String()
 
 	go t.signalLoop()
@@ -216,14 +212,14 @@ var dialSignal = func(ctx context.Context, cfg SignalConfig) (*SignalClient, err
 // buildPeerConnections wires up the publisher + subscriber pion PCs and
 // the local audio track. The MediaEngine registers Opus at PT 111 (the
 // LiveKit-conventional payload type for audio).
-func (t *Transport) buildPeerConnections(serverICE []*livekit.ICEServer) (*webrtc.PeerConnection, *webrtc.PeerConnection, *webrtc.TrackLocalStaticSample, error) {
+func (t *Transport) buildPeerConnections(serverICE []*livekit.ICEServer) error {
 	ice := mergeICEServers(t.peer.ICEServers, serverICE)
 	pcCfg := webrtc.Configuration{ICEServers: ice}
 
 	se := webrtc.SettingEngine{}
 	if t.peer.RTPPortMin > 0 && t.peer.RTPPortMax > 0 {
 		if err := se.SetEphemeralUDPPortRange(uint16(t.peer.RTPPortMin), uint16(t.peer.RTPPortMax)); err != nil {
-			return nil, nil, nil, fmt.Errorf("set port range: %w", err)
+			return fmt.Errorf("set port range: %w", err)
 		}
 	}
 
@@ -239,7 +235,7 @@ func (t *Transport) buildPeerConnections(serverICE []*livekit.ICEServer) (*webrt
 	// finally kicks the participant with NEGOTIATE_FAILED. The OnTrack
 	// handler still discards anything non-Opus.
 	if err := me.RegisterDefaultCodecs(); err != nil {
-		return nil, nil, nil, fmt.Errorf("register default codecs: %w", err)
+		return fmt.Errorf("register default codecs: %w", err)
 	}
 	// Negotiate the RFC 6464 audio-level extension on the publisher side
 	// so LK's ActiveSpeakerUpdate has data to work from.
@@ -247,7 +243,7 @@ func (t *Transport) buildPeerConnections(serverICE []*livekit.ICEServer) (*webrt
 		webrtc.RTPHeaderExtensionCapability{URI: sdp.AudioLevelURI},
 		webrtc.RTPCodecTypeAudio,
 	); err != nil {
-		return nil, nil, nil, fmt.Errorf("register audio-level extension: %w", err)
+		return fmt.Errorf("register audio-level extension: %w", err)
 	}
 
 	ir := &interceptor.Registry{}
@@ -261,12 +257,12 @@ func (t *Transport) buildPeerConnections(serverICE []*livekit.ICEServer) (*webrt
 
 	publisher, err := api.NewPeerConnection(pcCfg)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("new publisher PC: %w", err)
+		return fmt.Errorf("new publisher PC: %w", err)
 	}
 	subscriber, err := api.NewPeerConnection(pcCfg)
 	if err != nil {
 		_ = publisher.Close()
-		return nil, nil, nil, fmt.Errorf("new subscriber PC: %w", err)
+		return fmt.Errorf("new subscriber PC: %w", err)
 	}
 
 	localTrack, err := webrtc.NewTrackLocalStaticSample(
@@ -276,15 +272,22 @@ func (t *Transport) buildPeerConnections(serverICE []*livekit.ICEServer) (*webrt
 	if err != nil {
 		_ = publisher.Close()
 		_ = subscriber.Close()
-		return nil, nil, nil, fmt.Errorf("new local track: %w", err)
+		return fmt.Errorf("new local track: %w", err)
 	}
 	if _, err := publisher.AddTransceiverFromTrack(localTrack, webrtc.RTPTransceiverInit{
 		Direction: webrtc.RTPTransceiverDirectionSendonly,
 	}); err != nil {
 		_ = publisher.Close()
 		_ = subscriber.Close()
-		return nil, nil, nil, fmt.Errorf("add transceiver: %w", err)
+		return fmt.Errorf("add transceiver: %w", err)
 	}
+
+	// Assign the handles before registering OnNegotiationNeeded below: pion
+	// may fire onPublisherNegotiationNeeded from its own goroutine the moment
+	// the handler is set, and that callback reads t.publisher.
+	t.publisher = publisher
+	t.subscriber = subscriber
+	t.localTrack = localTrack
 
 	publisher.OnICECandidate(func(c *webrtc.ICECandidate) {
 		if c == nil {
@@ -315,7 +318,7 @@ func (t *Transport) buildPeerConnections(serverICE []*livekit.ICEServer) (*webrt
 
 	publisher.OnNegotiationNeeded(t.onPublisherNegotiationNeeded)
 
-	return publisher, subscriber, localTrack, nil
+	return nil
 }
 
 // signalLoop consumes typed events from the signaling client and reacts.

--- a/internal/playback/player_test.go
+++ b/internal/playback/player_test.go
@@ -10,10 +10,30 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/zaf/g711"
 )
+
+// syncBuffer is a goroutine-safe io.Writer used by the cancel-context tests,
+// where a watcher goroutine polls Len() while the player writes frames.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Len()
+}
 
 // buildWAV constructs a minimal WAV file in memory with the given parameters.
 func buildWAV(format uint16, channels uint16, sampleRate uint32, bitsPerSample uint16, audioData []byte) []byte {
@@ -582,7 +602,7 @@ func TestStreamWAV_CancelContext(t *testing.T) {
 	p := NewPlayer(slog.Default())
 
 	// Cancel after writing starts
-	var output bytes.Buffer
+	var output syncBuffer
 	go func() {
 		// Wait a bit then cancel
 		for output.Len() == 0 {
@@ -758,7 +778,7 @@ func TestStreamMP3_CancelContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	p := NewPlayer(slog.Default())
 
-	var output bytes.Buffer
+	var output syncBuffer
 	go func() {
 		for output.Len() == 0 {
 			// spin until first frame written
@@ -887,7 +907,7 @@ func TestRepeat_InfiniteStopsOnCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	p := NewPlayer(slog.Default())
 
-	var output bytes.Buffer
+	var output syncBuffer
 	go func() {
 		// Wait until a few frames have been written, then cancel.
 		for output.Len() < 320*2 {

--- a/internal/speaking/detector_test.go
+++ b/internal/speaking/detector_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -224,9 +225,11 @@ func TestDetector_StopEmitsSpeakingStopped(t *testing.T) {
 func TestDetector_MuteSuppressesSpeaking(t *testing.T) {
 	var mu sync.Mutex
 	var evts []Event
-	muted := false
+	// muted is read from the detector's tick goroutine and written from this
+	// test goroutine, so it must be accessed atomically.
+	var muted atomic.Bool
 
-	det := New("leg-3", 16000, func() bool { return muted }, func(e Event) {
+	det := New("leg-3", 16000, func() bool { return muted.Load() }, func(e Event) {
 		mu.Lock()
 		evts = append(evts, e)
 		mu.Unlock()
@@ -242,7 +245,7 @@ func TestDetector_MuteSuppressesSpeaking(t *testing.T) {
 	}
 
 	// Mute the leg — should emit speaking stopped
-	muted = true
+	muted.Store(true)
 
 	// Feed more loud frames while muted — should not emit speaking started
 	for i := 0; i < OnFrames+5; i++ {


### PR DESCRIPTION
Cherry-picks the lkmedia transport init-race fix (assign publisher/ subscriber/localTrack before registering OnNegotiationNeeded, closing the window where pion could invoke the callback and read a nil t.publisher) and three test data-race fixes: channel handover in the webhook HMAC test, atomic.Bool for the muted flag in the speaking detector test, and a mutex-guarded syncBuffer in the playback cancel-context tests.

Source: https://github.com/VoiceBlender/voiceblender/compare/master...Mliviu79:voiceblender:master