### PR TITLE
Finalize a room recording on every path that empties a room

### DIFF
--- a/internal/api/legs.go
+++ b/internal/api/legs.go
@@ -611,12 +611,14 @@ func (s *Server) unholdLeg(w http.ResponseWriter, r *http.Request) {
 // Caller MUST publish LegDisconnected before any webhook is cleared.
 func (s *Server) cleanupLeg(l leg.Leg) {
 	if roomID := l.RoomID(); roomID != "" {
-		s.onLegLeavingRoomRecording(roomID, l.ID())
-		if err := s.RoomMgr.RemoveLeg(roomID, l.ID()); err != nil {
-			s.Log.Debug("remove leg from room on cleanup", "leg_id", l.ID(), "room_id", roomID, "error", err)
-		}
-		s.stopRoomAgentIfEmpty(roomID)
-		s.stopRoomRecordingIfEmpty(roomID)
+		// A failed removal is logged and swallowed: the rest of the teardown
+		// still has to run, so this never returns an error to abort on.
+		_ = s.roomScopedLegRemoval(roomID, l.ID(), func() error {
+			if err := s.RoomMgr.RemoveLeg(roomID, l.ID()); err != nil {
+				s.Log.Debug("remove leg from room on cleanup", "leg_id", l.ID(), "room_id", roomID, "error", err)
+			}
+			return nil
+		})
 	}
 
 	if err := l.Hangup(context.Background()); err != nil {

--- a/internal/api/recording.go
+++ b/internal/api/recording.go
@@ -806,17 +806,23 @@ func (s *Server) stopRoomRecordingIfEmpty(roomID string) {
 		return
 	}
 
+	s.finalizeRoomRecording(roomID, rm.AppID, "empty room")
+}
+
+// finalizeRoomRecording stops the room's recording and publishes
+// recording.finished, reporting whether there was one to stop.
+//
+// appID is a parameter rather than looked up here because every caller already
+// holds it: room delete snapshots it alongside the participants, and the
+// empty-room path already has the room in hand.
+func (s *Server) finalizeRoomRecording(roomID, appID, why string) bool {
 	location, mcResult, ok := s.cleanupRoomRecording(roomID)
 	if !ok {
-		return
+		return false
 	}
 
-	roomAppID := ""
-	if rm, ok := s.RoomMgr.Get(roomID); ok {
-		roomAppID = rm.AppID
-	}
 	evtData := &events.RecordingFinishedData{
-		LegRoomScope: events.LegRoomScope{RoomID: roomID, AppID: roomAppID},
+		LegRoomScope: events.LegRoomScope{RoomID: roomID, AppID: appID},
 		File:         location,
 	}
 	if mcResult != nil {
@@ -824,7 +830,8 @@ func (s *Server) stopRoomRecordingIfEmpty(roomID string) {
 		evtData.Channels = mcResult.Channels
 	}
 	s.Bus.Publish(events.RecordingFinished, evtData)
-	s.Log.Info("auto-stopped room recording (empty room)", "room_id", roomID, "file", location)
+	s.Log.Info("auto-stopped room recording", "room_id", roomID, "file", location, "reason", why)
+	return true
 }
 
 // onLegJoinedRoomRecording starts a per-participant recording if multi-channel

--- a/internal/api/room_scoped_cleanup_test.go
+++ b/internal/api/room_scoped_cleanup_test.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+)
+
+// startRoomWithRecording creates a room holding one leg and starts a real room
+// recording on it through the production path, returning a func reporting
+// whether recording.finished has been published for that room.
+//
+// The recorder is real rather than a seeded map entry, so these tests fail if
+// the recording is left running as well as if the map entry is left behind.
+func startRoomWithRecording(t *testing.T, s *Server, roomID, legID string) func() bool {
+	t.Helper()
+
+	var mu sync.Mutex
+	finished := false
+	s.Bus.Subscribe(func(e events.Event) {
+		if e.Type != events.RecordingFinished {
+			return
+		}
+		d, ok := e.Data.(*events.RecordingFinishedData)
+		if !ok || d.RoomID != roomID {
+			return
+		}
+		mu.Lock()
+		finished = true
+		mu.Unlock()
+	})
+
+	s.Config.RecordingDir = t.TempDir()
+
+	l := &apiMockLeg{id: legID, createdAt: time.Now()}
+	s.LegMgr.Add(l)
+	if _, err := s.RoomMgr.Create(roomID, "", 0); err != nil {
+		t.Fatalf("Create room: %v", err)
+	}
+	if err := s.RoomMgr.AddLeg(roomID, legID); err != nil {
+		t.Fatalf("AddLeg: %v", err)
+	}
+	if _, err := s.doStartRecordRoom(roomID, RecordRequest{}); err != nil {
+		t.Fatalf("start room recording: %v", err)
+	}
+
+	// Guard against the assertions passing on a recording that never started.
+	roomRecorders.Lock()
+	_, running := roomRecorders.m[roomID]
+	roomRecorders.Unlock()
+	if !running {
+		t.Fatal("precondition: no room recorder registered after starting one")
+	}
+
+	t.Cleanup(func() {
+		roomRecorders.Lock()
+		delete(roomRecorders.m, roomID)
+		roomRecorders.Unlock()
+	})
+
+	return func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return finished
+	}
+}
+
+func assertRecordingFinalized(t *testing.T, roomID string, wasFinished func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		roomRecorders.Lock()
+		_, left := roomRecorders.m[roomID]
+		roomRecorders.Unlock()
+		if !left {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("room recorder still registered: the recording was never " +
+				"finalized and nothing reaps it")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !wasFinished() {
+		t.Fatal("recording.finished was never published, so a client waiting " +
+			"on it waits forever")
+	}
+}
+
+// TestRemoveLastLegFinalizesRoomRecording covers DELETE /rooms/{id}/legs/{legID}.
+//
+// This path and a normal last-leg disconnect end in the same state — the room
+// still exists with no participants — but only the disconnect used to finalize
+// the recording. doRemoveLegFromRoom never called stopRoomRecordingIfEmpty at
+// all; it is not a guard that rejected the call, the call was simply absent.
+func TestRemoveLastLegFinalizesRoomRecording(t *testing.T) {
+	const roomID, legID = "r-remove-last", "leg-remove-last"
+
+	s := newTestServer(t)
+	wasFinished := startRoomWithRecording(t, s, roomID, legID)
+
+	if err := s.doRemoveLegFromRoom(roomID, legID); err != nil {
+		t.Fatalf("doRemoveLegFromRoom: %v", err)
+	}
+
+	assertRecordingFinalized(t, roomID, wasFinished)
+}
+
+// TestMoveLastLegOutFinalizesRoomRecording covers moving a room's last leg
+// into another room, which leaves the source room alive and empty.
+func TestMoveLastLegOutFinalizesRoomRecording(t *testing.T) {
+	const fromRoom, toRoom, legID = "r-move-from", "r-move-to", "leg-move"
+
+	s := newTestServer(t)
+	wasFinished := startRoomWithRecording(t, s, fromRoom, legID)
+
+	if _, err := s.RoomMgr.Create(toRoom, "", 0); err != nil {
+		t.Fatalf("Create destination room: %v", err)
+	}
+	if _, err := s.doAddLegToRoom(t.Context(), toRoom, AddLegRequest{LegID: legID}); err != nil {
+		t.Fatalf("move leg: %v", err)
+	}
+
+	assertRecordingFinalized(t, fromRoom, wasFinished)
+}
+
+// TestDeleteRoomFinalizesRoomRecording covers DELETE /rooms/{id}.
+//
+// This one cannot be fixed by routing through roomScopedLegRemoval: deleting
+// the room clears every participant's RoomID and drops the room from the
+// manager, so both the RoomID guard in cleanupLeg and the Get inside
+// stopRoomRecordingIfEmpty fail. doDeleteRoom has to finalize the recording
+// explicitly, the way it already does for the room agent.
+func TestDeleteRoomFinalizesRoomRecording(t *testing.T) {
+	const roomID, legID = "r-delete", "leg-delete"
+
+	s := newTestServer(t)
+	wasFinished := startRoomWithRecording(t, s, roomID, legID)
+
+	if err := s.doDeleteRoom(roomID); err != nil {
+		t.Fatalf("doDeleteRoom: %v", err)
+	}
+
+	assertRecordingFinalized(t, roomID, wasFinished)
+}

--- a/internal/api/rooms.go
+++ b/internal/api/rooms.go
@@ -78,11 +78,20 @@ func (s *Server) doDeleteRoom(id string) error {
 	// leg.disconnected per leg afterwards. RoomMgr.Delete hangs the legs up
 	// (sends BYE) but does not surface them as disconnect events on its own.
 	var participants []leg.Leg
+	appID := ""
 	if rm, ok := s.RoomMgr.Get(id); ok {
 		participants = rm.Participants()
+		appID = rm.AppID
 	}
 
 	s.cleanupRoomAgent(id)
+	// Deleting the room detaches every leg from it, so the per-leg cleanup
+	// below cannot reach the room-scoped teardown — RoomMgr.Delete clears each
+	// leg's RoomID, and the room is gone from the manager by then anyway. The
+	// agent is handled by the explicit call above; the recording needs the
+	// same treatment or it is never finalized and recording.finished never
+	// fires for a deleted room.
+	s.finalizeRoomRecording(id, appID, "room deleted")
 	s.Webhooks.ClearRoomWebhook(id)
 	if err := s.RoomMgr.Delete(id); err != nil {
 		return newAPIError(http.StatusNotFound, "%s", err.Error())
@@ -145,8 +154,9 @@ func (s *Server) doAddLegToRoom(ctx context.Context, roomID string, req AddLegRe
 		if fromRoomID == roomID {
 			return nil, newAPIError(http.StatusBadRequest, "leg already in this room")
 		}
-		s.onLegLeavingRoomRecording(fromRoomID, req.LegID)
-		if err := s.RoomMgr.MoveLeg(fromRoomID, roomID, req.LegID); err != nil {
+		if err := s.roomScopedLegRemoval(fromRoomID, req.LegID, func() error {
+			return s.RoomMgr.MoveLeg(fromRoomID, roomID, req.LegID)
+		}); err != nil {
 			return nil, newAPIError(http.StatusBadRequest, "%s", err.Error())
 		}
 		if req.Role != nil {
@@ -155,7 +165,6 @@ func (s *Server) doAddLegToRoom(ctx context.Context, roomID string, req AddLegRe
 			}
 		}
 		s.onLegJoinedRoom(roomID, req.LegID)
-		s.stopRoomAgentIfEmpty(fromRoomID)
 		return map[string]string{
 			"status": "moved",
 			"from":   fromRoomID,
@@ -208,12 +217,39 @@ func (s *Server) addLegToRoom(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
-func (s *Server) doRemoveLegFromRoom(roomID, legID string) error {
+// roomScopedLegRemoval runs the cleanup that hangs off the room a leg is
+// leaving, around the removal itself. Every path that takes a leg out of a
+// room must go through here: the per-participant recording channel has to be
+// closed while the leg is still in the room, and the room's agent and
+// recording can only be judged empty once it is gone.
+//
+// It exists because those three calls used to be written out by hand at each
+// call site, and the sites had drifted — two of them omitted the room
+// recording, so moving or removing a room's last leg left the recording
+// running on an empty room and never published recording.finished. Going
+// through one function makes an omission a compile error rather than
+// something each new path has to remember.
+//
+// remove may be nil when the caller has already removed the leg. It returns
+// remove's error unchanged so callers keep their own status mapping.
+func (s *Server) roomScopedLegRemoval(roomID, legID string, remove func() error) error {
 	s.onLegLeavingRoomRecording(roomID, legID)
-	if err := s.RoomMgr.RemoveLeg(roomID, legID); err != nil {
-		return newAPIError(http.StatusBadRequest, "%s", err.Error())
+	if remove != nil {
+		if err := remove(); err != nil {
+			return err
+		}
 	}
 	s.stopRoomAgentIfEmpty(roomID)
+	s.stopRoomRecordingIfEmpty(roomID)
+	return nil
+}
+
+func (s *Server) doRemoveLegFromRoom(roomID, legID string) error {
+	if err := s.roomScopedLegRemoval(roomID, legID, func() error {
+		return s.RoomMgr.RemoveLeg(roomID, legID)
+	}); err != nil {
+		return newAPIError(http.StatusBadRequest, "%s", err.Error())
+	}
 	return nil
 }
 


### PR DESCRIPTION
A room recording is stopped by `stopRoomRecordingIfEmpty`, and the only caller is `cleanupLeg`.
Three other paths take the last leg out of a room and none of them reach it:

| path | recording finalized today |
|---|---|
| last leg disconnects | yes |
| `DELETE /rooms/{id}/legs/{legID}` | no |
| moving a room's last leg away | no |
| `DELETE /rooms/{id}` | no |

The first two end in the same state as a normal disconnect — room alive, no participants — but
only the disconnect finalizes. The recorder stays in `roomRecorders` writing to an open file and
`recording.finished` is never published, so a client waiting on that event waits forever. Nothing
reaps it; the capture is recoverable only by calling the stop endpoint by hand.

Room delete needed a different fix. Deleting a room clears every participant's `RoomID` and drops
the room from the manager, so the per-leg cleanup that follows can no longer reach the room-scoped
teardown. It now finalizes the recording explicitly before the delete, the way it already did for
the room agent. The app ID is passed in rather than looked up because both callers already hold it.

The three cleanups that hang off a leg's room now sit behind `roomScopedLegRemoval`, so a new
removal path has one function to call instead of three to remember. Two of the three existing
sites had already drifted and omitted the recording — that's the bug above.

I found this while auditing something else, and verified it by driving each path against a real
recorder rather than by reading. Happy to split the helper out if you'd rather take just the
behaviour fix.

**Note if you also take `hardening/mixer-panic-isolation`:** the two branches share no files, so
they merge cleanly. That branch adds a mixer-panic teardown hook, which is a fourth leg-removal
path. It open-codes the same three cleanups rather than dropping any of them, so there is no
second bug — but once both are in, that hook should go through `roomScopedLegRemoval(roomID,
legID, nil)` instead, since the leg is already removed by then. I have that follow-up ready if you
want both.
