### PR TITLE
Contain a mixer IO panic to the participant that caused it

### DIFF
--- a/API.md
+++ b/API.md
@@ -3012,6 +3012,7 @@ The `leg.disconnected` event uses a `cdr` object for disconnect reason and timin
 | `room_deleted` | Leg was in a room that was deleted via `DELETE /v1/rooms/{id}` |
 | `transfer_completed` | Leg ended because a transfer it initiated reached terminal 2xx |
 | `rejected` | Inbound leg rejected by API via `DELETE /v1/legs/{id}` with `reason` (also see other reason values from the rejection mapping table) |
+| `mixer_panic` | The leg's audio path failed inside the mixer and the leg was torn down. The leg had already left its room (`leg.left_room`); it is deaf and mute at this point, so it is hung up rather than left connected. Its room, and any other legs in it, are unaffected |
 
 ---
 

--- a/cmd/openapi-gen/main.go
+++ b/cmd/openapi-gen/main.go
@@ -772,14 +772,6 @@ func webhookNestedSchema(t reflect.Type, nullable bool, parentFieldName string) 
 		if desc, ok := webhookNestedFieldDescs[descKey]; ok {
 			fieldSchema.set("description", desc)
 		}
-		// Apply disconnect reason enum.
-		if typeName == "CallCDR" && jsonName == "reason" {
-			enumSeq := newSeq()
-			for _, v := range api.DisconnectReasonEnum {
-				enumSeq.add(v)
-			}
-			fieldSchema.set("enum", enumSeq)
-		}
 		props.set(jsonName, fieldSchema)
 		if !omit {
 			requiredSeq.add(jsonName)

--- a/internal/api/legs_panic_test.go
+++ b/internal/api/legs_panic_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+)
+
+// panicReader panics on its first Read, standing in for a leg whose inbound
+// audio path blows up inside the mixer's readLoop.
+type panicReader struct{}
+
+func (panicReader) Read(p []byte) (int, error) { panic("simulated read panic") }
+
+// panicAudioLeg is an apiMockLeg with a real, panicking audio path.
+// apiMockLeg hardcodes AudioReader() to nil, which the mixer never reads from,
+// so the overrides are what let the panic come through the real mixer — the
+// whole point of the test.
+type panicAudioLeg struct {
+	*apiMockLeg
+}
+
+func (p *panicAudioLeg) AudioReader() io.Reader { return panicReader{} }
+func (p *panicAudioLeg) AudioWriter() io.Writer { return io.Discard }
+func (p *panicAudioLeg) SampleRate() int        { return 16000 }
+
+// TestPanickedLegPublishesDisconnect drives a mixer IO panic through the real
+// wiring NewServer installs — real leg.Manager, real room.Manager, real bus —
+// and asserts the API layer finishes the teardown the room layer started.
+//
+// Before the callback existed, such a leg emitted leg.left_room and nothing
+// else: no CDR, an unended span, and it stayed in the leg manager forever, so
+// GET /v1/legs/{id} kept serving a dead leg.
+func TestPanickedLegPublishesDisconnect(t *testing.T) {
+	s := newTestServer(t)
+
+	var mu sync.Mutex
+	var gotReason string
+	var gotDisconnect bool
+	s.Bus.Subscribe(func(e events.Event) {
+		if e.Type != events.LegDisconnected {
+			return
+		}
+		d, ok := e.Data.(*events.LegDisconnectedData)
+		if !ok || d.LegID != "panic-leg" {
+			return
+		}
+		mu.Lock()
+		gotDisconnect = true
+		gotReason = d.CDR.Reason
+		mu.Unlock()
+	})
+
+	l := &panicAudioLeg{apiMockLeg: &apiMockLeg{id: "panic-leg", createdAt: time.Now()}}
+	s.LegMgr.Add(l)
+	if _, err := s.RoomMgr.Create("r1", "", 0); err != nil {
+		t.Fatalf("Create room: %v", err)
+	}
+	if err := s.RoomMgr.AddLeg("r1", "panic-leg"); err != nil {
+		t.Fatalf("AddLeg: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		mu.Lock()
+		done := gotDisconnect
+		mu.Unlock()
+		if done {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no leg.disconnected published for a leg killed by a mixer IO panic")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	reason := gotReason
+	mu.Unlock()
+	if reason != "mixer_panic" {
+		t.Fatalf("cdr.reason = %q, want %q", reason, "mixer_panic")
+	}
+
+	// cleanupLeg must have run too, or the leg leaks in the leg manager and
+	// GET /v1/legs/{id} keeps serving it.
+	if _, ok := s.LegMgr.Get("panic-leg"); ok {
+		t.Fatal("panicked leg still registered in the leg manager")
+	}
+}

--- a/internal/api/legs_panic_test.go
+++ b/internal/api/legs_panic_test.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
 	"io"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/VoiceBlender/voiceblender/internal/agent"
 	"github.com/VoiceBlender/voiceblender/internal/events"
 )
 
@@ -88,5 +90,109 @@ func TestPanickedLegPublishesDisconnect(t *testing.T) {
 	// GET /v1/legs/{id} keeps serving it.
 	if _, ok := s.LegMgr.Get("panic-leg"); ok {
 		t.Fatal("panicked leg still registered in the leg manager")
+	}
+}
+
+// stoppableProvider is a do-nothing agent.Provider that records whether Stop
+// was called, standing in for a live vendor session on a room agent.
+type stoppableProvider struct {
+	mu      sync.Mutex
+	stopped bool
+}
+
+func (p *stoppableProvider) Start(context.Context, io.Reader, io.Writer, string,
+	agent.Options, agent.Callbacks) error {
+	return nil
+}
+func (p *stoppableProvider) Stop() {
+	p.mu.Lock()
+	p.stopped = true
+	p.mu.Unlock()
+}
+func (p *stoppableProvider) Running() bool          { return false }
+func (p *stoppableProvider) ConversationID() string { return "" }
+func (p *stoppableProvider) InjectMessage(context.Context, string) error {
+	return nil
+}
+
+func (p *stoppableProvider) wasStopped() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.stopped
+}
+
+// TestPanickedLastLegRunsRoomScopedCleanup pins the room-scoped half of the
+// mixer-panic teardown.
+//
+// The room layer clears the leg's RoomID as part of removing it, so by the time
+// the API hook runs, cleanupLeg's room block no longer fires. Every other
+// leg-removal path reaches the room-scoped cleanup through that block, which
+// left the panic path as the only one that skipped it: the room's agent stayed
+// in roomAgents with its vendor session live, against a room with no legs left.
+// Nothing reaps it — Manager.Delete has one caller, DELETE /v1/rooms/{id} — so
+// a billed websocket stayed open until someone deleted the room by hand.
+//
+// The hook now carries the roomID for exactly this reason.
+func TestPanickedLastLegRunsRoomScopedCleanup(t *testing.T) {
+	const roomID = "r-panic-cleanup"
+
+	s := newTestServer(t)
+
+	if _, err := s.RoomMgr.Create(roomID, "", 0); err != nil {
+		t.Fatalf("Create room: %v", err)
+	}
+
+	// Stand a room agent up directly in the registry: the assertion is about
+	// the teardown path, not about how the agent got there.
+	prov := &stoppableProvider{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelled := make(chan struct{})
+	go func() { <-ctx.Done(); close(cancelled) }()
+
+	roomAgents.Lock()
+	roomAgents.m[roomID] = &agentInfo{
+		session:  prov,
+		sourceID: "agent-" + roomID,
+		roomID:   roomID,
+		cancel:   cancel,
+	}
+	roomAgents.Unlock()
+	t.Cleanup(func() {
+		roomAgents.Lock()
+		delete(roomAgents.m, roomID)
+		roomAgents.Unlock()
+		cancel()
+	})
+
+	l := &panicAudioLeg{apiMockLeg: &apiMockLeg{id: "panic-last-leg", createdAt: time.Now()}}
+	s.LegMgr.Add(l)
+	if err := s.RoomMgr.AddLeg(roomID, "panic-last-leg"); err != nil {
+		t.Fatalf("AddLeg: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		roomAgents.Lock()
+		_, still := roomAgents.m[roomID]
+		roomAgents.Unlock()
+		if !still {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("room agent still registered after the room's last leg died " +
+				"in a mixer IO panic: its vendor session leaks until the room is " +
+				"deleted by hand")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !prov.wasStopped() {
+		t.Fatal("room agent deregistered but its vendor session was never stopped")
+	}
+
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("room agent's context was never cancelled")
 	}
 }

--- a/internal/api/openapi_meta.go
+++ b/internal/api/openapi_meta.go
@@ -221,6 +221,7 @@ var DisconnectReasonEnum = []string{
 	"busy", "unavailable", "not_found", "forbidden", "unauthorized", "timeout",
 	"cancelled", "not_acceptable", "service_unavailable", "declined",
 	"rtp_timeout", "session_expired", "invite_failed", "connect_failed", "ice_failure",
+	"mixer_panic",
 }
 
 // QualityDescription is the description for the quality object in leg.disconnected.

--- a/internal/api/openapi_meta.go
+++ b/internal/api/openapi_meta.go
@@ -1,6 +1,10 @@
 package api
 
-import sipmod "github.com/VoiceBlender/voiceblender/internal/sip"
+import (
+	"strings"
+
+	sipmod "github.com/VoiceBlender/voiceblender/internal/sip"
+)
 
 // RouteMeta describes a single API endpoint for OpenAPI generation.
 type RouteMeta struct {
@@ -205,7 +209,7 @@ func WebhookFieldDescriptions() map[string]string {
 // fields in webhook events (e.g. cdr.reason, cdr.duration_total).
 func WebhookNestedFieldDescriptions() map[string]string {
 	return map[string]string{
-		"CallCDR.reason":                   "Disconnect reason. Common SIP failures are mapped to named reasons; unmapped 4xx/5xx/6xx codes appear as sip_{code}.",
+		"CallCDR.reason":                   disconnectReasonDescription(),
 		"CallCDR.duration_total":           "Seconds from leg creation to disconnect",
 		"CallCDR.duration_answered":        "Seconds from answer to disconnect (0 if never answered)",
 		"CallQuality.mos_score":            "Mean Opinion Score (1.0–5.0) estimated via simplified E-model (ITU-T G.107) from packet loss and jitter",
@@ -215,13 +219,62 @@ func WebhookNestedFieldDescriptions() map[string]string {
 	}
 }
 
-// DisconnectReasonEnum lists all possible disconnect reason values.
-var DisconnectReasonEnum = []string{
-	"api_hangup", "remote_bye", "caller_cancel", "ring_timeout", "max_duration",
-	"busy", "unavailable", "not_found", "forbidden", "unauthorized", "timeout",
-	"cancelled", "not_acceptable", "service_unavailable", "declined",
-	"rtp_timeout", "session_expired", "invite_failed", "connect_failed", "ice_failure",
+// KnownDisconnectReasons lists the disconnect reasons the code can produce
+// today, grouped by the path that produces them. The value set is open: an
+// unmapped SIP failure yields sip_{code} for any 4xx/5xx/6xx code, so this
+// list documents the named reasons rather than constraining the field.
+// TestKnownDisconnectReasonsTest keeps it in step with the producing code.
+var KnownDisconnectReasons = []string{
+	// Lifecycle and API-driven teardown.
+	"api_hangup", "room_deleted", "remote_bye", "caller_cancel",
+	"max_duration", "session_expired", "rtp_timeout",
+	// DELETE /legs/{id} rejection reasons (rejectionMapping).
+	"busy", "declined", "rejected", "unavailable", "not_found", "forbidden",
+	"server_error",
+	// Outbound INVITE failures (inviteFailureReason).
+	"ring_timeout", "unauthorized", "timeout", "cancelled", "not_acceptable",
+	"service_unavailable", "invite_failed", "connect_failed",
+	// Inbound authentication.
+	"challenged",
+	// Transfer.
+	"transfer_completed", "transfer_originate_failed", "transfer_connect_failed",
+	// WhatsApp.
+	"bad_answer",
+	// Room mixer teardown.
 	"mixer_panic",
+	// WebSocket legs (classifyWSReason, classifyWSDialError).
+	"hangup", "peer_slow", "connection_reset", "ws_error", "ws_dial_failed",
+	// MoQ legs.
+	"moq_error",
+	// WebRTC/ICE.
+	"ice_failure", "ice_failed", "ice_disconnected",
+	// LiveKit legs (lkmedia leaveReasonString and signal close paths).
+	"livekit_client_initiated", "livekit_duplicate_identity",
+	"livekit_server_shutdown", "livekit_kicked", "livekit_room_deleted",
+	"livekit_state_mismatch", "livekit_join_failure", "livekit_migration",
+	"livekit_signal_close", "livekit_room_closed", "livekit_user_unavailable",
+	"livekit_user_rejected", "livekit_token_expired", "livekit_media_failure",
+	"livekit_disconnected", "livekit_client_closed", "livekit_signal_closed",
+	"livekit_signal_error",
+	// LiveKit transport teardown (lkmedia Transport.cleanup), surfaced
+	// through Transport.CloseReason().
+	"livekit_pc_setup_failed", "livekit_add_track_failed",
+	"livekit_publisher_failed", "livekit_subscriber_failed",
+	"livekit_signal_loop_exit", "livekit_set_remote_desc_failed",
+	"livekit_create_answer_failed", "livekit_set_local_desc_failed",
+	"livekit_signal_send_failed", "livekit_set_publisher_remote_failed",
+	// LiveKit participant legs torn down under the umbrella leg.
+	"livekit_participant_left",
+}
+
+// disconnectReasonDescription documents the known reasons inline, since
+// cdr.reason carries no enum.
+func disconnectReasonDescription() string {
+	return "Disconnect reason. Common SIP failures are mapped to named " +
+		"reasons; unmapped 4xx/5xx/6xx codes appear as sip_{code}. This is " +
+		"an open set — treat an unrecognized value as a new reason rather " +
+		"than an error. Known values: " +
+		strings.Join(KnownDisconnectReasons, ", ") + "."
 }
 
 // QualityDescription is the description for the quality object in leg.disconnected.

--- a/internal/api/openapi_meta_test.go
+++ b/internal/api/openapi_meta_test.go
@@ -1,0 +1,289 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// reasonProducers are functions whose returned string literals become a
+// cdr.reason. Their results reach publishDisconnect through a local
+// variable, so scanning the call sites alone cannot see them.
+var reasonProducers = map[string]bool{
+	"inviteFailureReason": true,
+	"classifyWSReason":    true,
+	"classifyWSDialError": true,
+	"leaveReasonString":   true,
+}
+
+// reasonConsts are constants published as a cdr.reason from another package
+// through a callback, which likewise hides them from the call sites.
+var reasonConsts = map[string]bool{
+	"legPanicReason": true,
+}
+
+// reasonSinks map a function name to the index of its argument that becomes
+// a cdr.reason. publishDisconnect publishes it directly; the others forward
+// it across a function boundary, so a literal at their call sites never
+// appears next to publishDisconnect: Transport.cleanup stores the argument
+// as the close reason that liveKitConn.watch later reads via CloseReason()
+// and publishes, and disconnectParticipantLeg passes it straight through.
+var reasonSinks = map[string]int{
+	"publishDisconnect":        1,
+	"cleanup":                  1,
+	"disconnectParticipantLeg": 1,
+}
+
+// collectPublishedReasons walks the non-test sources under root and returns
+// every reason string literal it can attribute to the code, mapped to the
+// file it came from. It reads three shapes: a literal passed to a
+// reasonSinks function, a literal assigned to the variable such a call
+// passes, and a literal returned by a reasonProducers function or bound to
+// a reasonConsts constant.
+//
+// It deliberately under-reports rather than guesses: reasons composed at
+// runtime (fmt.Sprintf("sip_%d", …), "ice_"+state) and reasons supplied by
+// the caller in a request body have no literal to find. So this proves every
+// reason it *does* find is documented; it cannot prove the reverse.
+func collectPublishedReasons(t *testing.T, root string) map[string]string {
+	t.Helper()
+	found := map[string]string{}
+	fset := token.NewFileSet()
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if name := info.Name(); name == "vendor" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return perr
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.FuncDecl:
+				if reasonProducers[node.Name.Name] {
+					for _, lit := range returnedStringLits(node) {
+						found[lit] = path
+					}
+				}
+				for _, lit := range publishedInFunc(node) {
+					found[lit] = path
+				}
+			case *ast.ValueSpec:
+				for i, name := range node.Names {
+					if !reasonConsts[name.Name] || i >= len(node.Values) {
+						continue
+					}
+					if lit, ok := stringLit(node.Values[i]); ok {
+						found[lit] = path
+					}
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return found
+}
+
+// publishedInFunc returns the reason literals a single function hands to a
+// reasonSinks function, following one level of local variable assignment.
+func publishedInFunc(fn *ast.FuncDecl) []string {
+	var lits, vars []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		idx, ok := reasonSinks[sel.Sel.Name]
+		if !ok || idx >= len(call.Args) {
+			return true
+		}
+		if lit, ok := stringLit(call.Args[idx]); ok {
+			lits = append(lits, lit)
+			return true
+		}
+		if id, ok := call.Args[idx].(*ast.Ident); ok {
+			vars = append(vars, id.Name)
+		}
+		return true
+	})
+	for _, name := range vars {
+		lits = append(lits, assignedStringLits(fn, name)...)
+	}
+	return lits
+}
+
+// assignedStringLits returns the string literals assigned to name in fn.
+func assignedStringLits(fn *ast.FuncDecl, name string) []string {
+	var lits []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, lhs := range as.Lhs {
+			id, ok := lhs.(*ast.Ident)
+			if !ok || id.Name != name || i >= len(as.Rhs) {
+				continue
+			}
+			if lit, ok := stringLit(as.Rhs[i]); ok {
+				lits = append(lits, lit)
+			}
+		}
+		return true
+	})
+	return lits
+}
+
+// returnedStringLits returns the string literals fn can return.
+func returnedStringLits(fn *ast.FuncDecl) []string {
+	var lits []string
+	ast.Inspect(fn, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		for _, r := range ret.Results {
+			if lit, ok := stringLit(r); ok {
+				lits = append(lits, lit)
+			}
+		}
+		return true
+	})
+	return lits
+}
+
+func stringLit(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	v, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return v, true
+}
+
+// mappingValue returns the value node for key in a mapping node, or nil.
+func mappingValue(n *yaml.Node, key string) *yaml.Node {
+	if n.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			return n.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// findSchemasByDescription returns every mapping node carrying exactly the
+// given description, wherever it sits in the document.
+func findSchemasByDescription(n *yaml.Node, desc string) []*yaml.Node {
+	var out []*yaml.Node
+	if n.Kind == yaml.MappingNode {
+		if d := mappingValue(n, "description"); d != nil && d.Value == desc {
+			out = append(out, n)
+		}
+	}
+	for _, c := range n.Content {
+		out = append(out, findSchemasByDescription(c, desc)...)
+	}
+	return out
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	return root
+}
+
+// TestKnownDisconnectReasonsTest guards the documented list against the code
+// that publishes reasons. mixer_panic reaches the CDR only through a room
+// callback, so a list edited by hand drops it without anything noticing.
+func TestKnownDisconnectReasonsTest(t *testing.T) {
+	known := map[string]bool{}
+	for _, r := range KnownDisconnectReasons {
+		if known[r] {
+			t.Errorf("KnownDisconnectReasons lists %q twice", r)
+		}
+		known[r] = true
+	}
+
+	published := collectPublishedReasons(t, repoRoot(t))
+	if len(published) < 20 {
+		t.Fatalf("found only %d reasons in the source; the scan is broken, not the list", len(published))
+	}
+	for reason, path := range published {
+		if !known[reason] {
+			t.Errorf("%s publishes reason %q, missing from KnownDisconnectReasons", path, reason)
+		}
+	}
+	for _, r := range []string{"mixer_panic", "room_deleted", "transfer_completed", "bad_answer", "challenged"} {
+		if !known[r] {
+			t.Errorf("KnownDisconnectReasons is missing %q", r)
+		}
+	}
+}
+
+// TestCDRReasonSpecIsOpen asserts the generated spec, not the Go list: the
+// enum must be gone, and the description must carry the known values so the
+// documentation survives opening the field.
+func TestCDRReasonSpecIsOpen(t *testing.T) {
+	specPath := filepath.Join(repoRoot(t), "openapi.yaml")
+	raw, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse openapi.yaml: %v", err)
+	}
+
+	desc := disconnectReasonDescription()
+	schemas := findSchemasByDescription(&doc, desc)
+	if len(schemas) == 0 {
+		t.Fatalf("openapi.yaml does not carry the cdr.reason description; run go generate ./internal/api/")
+	}
+	for _, s := range schemas {
+		if enum := mappingValue(s, "enum"); enum != nil {
+			t.Errorf("cdr.reason is still constrained by an enum of %d values", len(enum.Content))
+		}
+	}
+	for _, r := range KnownDisconnectReasons {
+		if !strings.Contains(desc, r) {
+			t.Errorf("description omits known reason %q", r)
+		}
+	}
+	if !strings.Contains(desc, "sip_{code}") {
+		t.Error("description no longer documents the sip_{code} open set")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -93,6 +93,22 @@ func NewServer(
 		pendingRefers:  newPendingReferStore(),
 		regAttempts:    newRegisterAttemptStore(),
 	}
+	// A leg whose mixer IO loop panicked is torn down inside the room layer,
+	// which cannot finish the job: the CDR, the OTel span, the per-leg webhook
+	// and the leg-manager entry are all API-layer state, and room cannot import
+	// api. Without this the leg emits leg.left_room and nothing else — no
+	// leg.disconnected, an unended span, and it stays in LegMgr, so
+	// GET /v1/legs/{id} keeps serving a dead leg forever.
+	//
+	// This is the leg-scoped half only. tearDownPanickedLeg's RemoveLeg has
+	// already cleared the leg's RoomID by the time this runs, so cleanupLeg's
+	// room block is skipped — which is what stops a second leg.left_room, and
+	// which also means the room-scoped cleanup does not run here.
+	roomMgr.SetOnLegPanicTeardown(func(l leg.Leg, reason string) {
+		s.cleanupLeg(l)
+		s.publishDisconnect(l, reason)
+	})
+
 	s.routes()
 	return s
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -100,11 +100,21 @@ func NewServer(
 	// leg.disconnected, an unended span, and it stays in LegMgr, so
 	// GET /v1/legs/{id} keeps serving a dead leg forever.
 	//
-	// This is the leg-scoped half only. tearDownPanickedLeg's RemoveLeg has
-	// already cleared the leg's RoomID by the time this runs, so cleanupLeg's
-	// room block is skipped — which is what stops a second leg.left_room, and
-	// which also means the room-scoped cleanup does not run here.
-	roomMgr.SetOnLegPanicTeardown(func(l leg.Leg, reason string) {
+	// tearDownPanickedLeg's RemoveLeg has already cleared the leg's RoomID by
+	// the time this runs, so cleanupLeg's room block is skipped. That is what
+	// stops a second leg.left_room — but it also skips the room-scoped cleanup,
+	// so this path has to run that half itself off the roomID the hook carries.
+	// Every other leg-removal path reaches it through cleanupLeg; without this
+	// the panic path would be the only one that silently drops it, stranding
+	// the room's agent session and its recording on an empty room.
+	roomMgr.SetOnLegPanicTeardown(func(l leg.Leg, roomID, reason string) {
+		if roomID != "" {
+			// Same order as cleanupLeg's room block, minus the RemoveLeg the
+			// room layer already did.
+			s.onLegLeavingRoomRecording(roomID, l.ID())
+			s.stopRoomAgentIfEmpty(roomID)
+			s.stopRoomRecordingIfEmpty(roomID)
+		}
 		s.cleanupLeg(l)
 		s.publishDisconnect(l, reason)
 	})

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -468,6 +468,7 @@ func (m *Mixer) recoverTick() {
 // readLoop continuously reads PCM frames from a participant's Reader
 // and buffers them for the mix loop. Blocks on IO (RTP receive).
 func (m *Mixer) readLoop(p *Participant) {
+	defer m.recoverParticipant(p, "readLoop")
 	buf := make([]byte, m.frameSizeBytes)
 	for {
 		select {
@@ -510,6 +511,7 @@ func (m *Mixer) readLoop(p *Participant) {
 // and writes to the participant's Writer. Blocks on IO (RTP send).
 // This runs on its own goroutine so the mix tick never blocks.
 func (m *Mixer) writeLoop(p *Participant) {
+	defer m.recoverParticipant(p, "writeLoop")
 	for {
 		select {
 		case <-m.stopCh:

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -123,6 +123,12 @@ type Mixer struct {
 	hookMu             sync.Mutex
 	onParticipantPanic func(participantID, loop string)
 
+	// tickPanics counts recovered mixTick panics; tickPanicLastLog is the
+	// unix-nanos of the last one logged. Both drive recoverTick's rate limit
+	// and are atomic so it stays lock-free on the mix loop's hot path.
+	tickPanics       atomic.Uint64
+	tickPanicLastLog atomic.Int64
+
 	comfortNoise *comfortnoise.Generator
 }
 
@@ -504,18 +510,51 @@ func (m *Mixer) recoverParticipant(p *Participant, loop string) {
 	}
 }
 
+// tickPanicLogInterval bounds how often a repeating mixTick panic is logged
+// after the first occurrence.
+const tickPanicLogInterval = 5 * time.Second
+
 // recoverTick logs a panic from a single mixTick invocation and lets the
 // mix loop continue to the next tick. Must be deferred at the per-tick call
 // site (mixLoop's ticker case), never around mixLoop itself — recovering the
 // loop would stop the whole room instead of skipping one tick. Frame
 // contents are deliberately not logged.
+//
+// Logging is rate-limited because a deterministically panicking frame recurs
+// every tick: at Ptime cadence that is ~50 multi-KB stack traces a second,
+// forever. The first panic carries the full stack — that is the one worth
+// diagnosing — and subsequent ones collapse into at most one stackless line
+// per tickPanicLogInterval carrying the running total.
 func (m *Mixer) recoverTick() {
-	if r := recover(); r != nil {
+	r := recover()
+	if r == nil {
+		return
+	}
+
+	total := m.tickPanics.Add(1)
+	if total == 1 {
+		m.tickPanicLastLog.Store(time.Now().UnixNano())
 		m.log.Error("mixTick panic, skipping tick",
 			"panic", r,
 			"stack", string(debug.Stack()),
 		)
+		return
 	}
+
+	now := time.Now().UnixNano()
+	last := m.tickPanicLastLog.Load()
+	if now-last < int64(tickPanicLogInterval) {
+		return
+	}
+	// Whichever caller wins the swap logs the summary; the rest stay silent
+	// until the next interval.
+	if !m.tickPanicLastLog.CompareAndSwap(last, now) {
+		return
+	}
+	m.log.Error("mixTick panic, skipping tick (repeating)",
+		"panic", r,
+		"total_panics", total,
+	)
 }
 
 // readLoop continuously reads PCM frames from a participant's Reader

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -420,16 +420,16 @@ func (m *Mixer) RemoveParticipant(id string) {
 	m.removeParticipant(id)
 }
 
-// removeParticipant detaches a participant and reports whether this call was
-// the one that removed it. The map delete under m.mu is the exactly-once
-// gate: concurrent callers race on the lookup, but only the goroutine that
-// observed ok == true owns teardown, so close(p.done) can never double-close
-// and any caller-side follow-up (see recoverParticipant) fires once even if
-// both IO loops fail for the same participant.
+// removeParticipant detaches whatever participant is registered under id and
+// reports whether this call was the one that removed it. The map delete under
+// m.mu is the exactly-once gate: concurrent callers race on the lookup, but
+// only the goroutine that observed ok == true owns teardown, so close(p.done)
+// can never double-close.
 //
-// Teardown itself runs outside m.mu: guard.Close and the Reader's Close are
-// foreign code — the reader in particular is arbitrary third-party IO — and
-// the mixer lock is never held across a call out of this package.
+// This resolves the ID to an instance, so it removes whichever participant is
+// registered *now* — the right semantics for RemoveParticipant's callers, who
+// mean "whatever is under this ID". A caller that holds a specific instance
+// and must not evict its successor wants removeParticipantIf instead.
 func (m *Mixer) removeParticipant(id string) bool {
 	m.mu.Lock()
 	p, ok := m.participants[id]
@@ -442,6 +442,40 @@ func (m *Mixer) removeParticipant(id string) bool {
 		return false
 	}
 
+	m.teardownParticipant(p)
+	return true
+}
+
+// removeParticipantIf detaches p only if p is still the instance registered
+// under p.ID, and reports whether this call was the one that removed it.
+//
+// AddParticipant overwrites m.participants[id] without stopping the previous
+// instance's loops, so an orphaned loop can outlive its replacement. Keying
+// teardown on the ID alone would let that orphan evict the live successor and
+// escalate — via the panic hook — into hanging up a healthy call. Matching on
+// the pointer makes the delete elect one owner per participant *instance*.
+func (m *Mixer) removeParticipantIf(p *Participant) bool {
+	m.mu.Lock()
+	cur, ok := m.participants[p.ID]
+	if !ok || cur != p {
+		m.mu.Unlock()
+		return false
+	}
+	delete(m.participants, p.ID)
+	m.mu.Unlock()
+
+	m.teardownParticipant(p)
+	return true
+}
+
+// teardownParticipant releases p's IO and stops its loops. Reachable only via
+// a map delete that returned ok, which is what makes close(p.done) exactly
+// once.
+//
+// It runs outside m.mu: guard.Close and the Reader's/Writer's Close are
+// foreign code — the reader in particular is arbitrary third-party IO — and
+// the mixer lock is never held across a call out of this package.
+func (m *Mixer) teardownParticipant(p *Participant) {
 	if p.guard != nil {
 		p.guard.Close() // prevent any further writes to the network
 	}
@@ -453,7 +487,6 @@ func (m *Mixer) removeParticipant(id string) bool {
 		_ = rc.Close()
 	}
 	close(p.done) // signal readLoop/writeLoop to stop
-	return true
 }
 
 func (m *Mixer) ParticipantCount() int {
@@ -488,10 +521,15 @@ func (m *Mixer) Stop() {
 // The panicking goroutine is not restarted.
 //
 // Removing the participant from the mixer is only half of teardown: the owner
-// still has the leg registered and would leave a live call connected but deaf
-// and mute. removeParticipant's returned bool is the exactly-once gate — if
-// both IO loops panic for the same participant, only one of them notifies the
-// owner. The hook is read under hookMu but invoked with no lock held.
+// still has the participant registered and would leave a live call connected
+// but deaf and mute. removeParticipantIf's returned bool is the exactly-once
+// gate — if both IO loops panic for the same participant, only one of them
+// notifies the owner. The hook is read under hookMu but invoked with no lock
+// held.
+//
+// The removal is identity-scoped, not ID-scoped: this goroutine's participant
+// may already have been replaced under the same ID, and a dead loop must never
+// tear down its live successor.
 func (m *Mixer) recoverParticipant(p *Participant, loop string) {
 	if r := recover(); r != nil {
 		m.log.Error(loop+" panic",
@@ -499,7 +537,7 @@ func (m *Mixer) recoverParticipant(p *Participant, loop string) {
 			"panic", r,
 			"stack", string(debug.Stack()),
 		)
-		if m.removeParticipant(p.ID) {
+		if m.removeParticipantIf(p) {
 			m.hookMu.Lock()
 			hook := m.onParticipantPanic
 			m.hookMu.Unlock()

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -468,27 +468,45 @@ func (m *Mixer) removeParticipantIf(p *Participant) bool {
 	return true
 }
 
+// closeWriterForPanic closes p's writer if it can be closed, so that an owner
+// parked on the read end observes EOF and runs its own teardown.
+//
+// This belongs to the panic path alone. Muting the guard stops writes but
+// tells the owner nothing, and the mixer is a leaf: it cannot call the API
+// layer. For a participant whose owner is not the room layer — a WebSocket
+// client, an agent, a playback or TTS source — EOF on the writer is the only
+// notification it will ever get that its participant died.
+//
+// An ordinary removal must not come through here. There the participant is
+// alive and its owner keeps using it: Room.DetachLeg hands the leg to
+// Manager.MoveLeg, which adds it to another room. Closing the writer on that
+// path closes a ws/MoQ leg's egress pipe, which is exactly what Hangup does,
+// so the leg would arrive at its new room already dead.
+func (m *Mixer) closeWriterForPanic(p *Participant) {
+	if p.guard == nil {
+		return
+	}
+	if wc, ok := p.guard.w.(io.Closer); ok {
+		_ = wc.Close()
+	}
+}
+
 // teardownParticipant releases p's IO and stops its loops. Reachable only via
 // a map delete that returned ok, which is what makes close(p.done) exactly
 // once.
 //
-// It runs outside m.mu: guard.Close and the Reader's/Writer's Close are
-// foreign code — the reader in particular is arbitrary third-party IO — and
-// the mixer lock is never held across a call out of this package.
+// It does not close p's writer. A removal is not a hangup: the room layer
+// detaches a leg to move it between rooms and expects to hand back a live leg,
+// and a leg's writer is often the leg's own egress pipe, so closing it here
+// would end the call. Only the panic path closes the writer — see
+// closeWriterForPanic.
+//
+// It runs outside m.mu: guard.Close and the Reader's Close are foreign code —
+// the reader in particular is arbitrary third-party IO — and the mixer lock is
+// never held across a call out of this package.
 func (m *Mixer) teardownParticipant(p *Participant) {
 	if p.guard != nil {
 		p.guard.Close() // prevent any further writes to the network
-		// Muting the guard stops writes but tells the owner nothing: an owner
-		// parked on the read end of the writer it handed us would wait for
-		// audio that is never coming again. If that writer is an io.Closer,
-		// close it so the owner observes EOF and runs its own teardown. This
-		// is the only notification a participant whose owner is not the room
-		// layer (a WebSocket client, say) ever gets — the mixer is a leaf and
-		// cannot call them. Owner-initiated removals have already closed it;
-		// every writer reaching here is idempotent on Close.
-		if wc, ok := p.guard.w.(io.Closer); ok {
-			_ = wc.Close()
-		}
 	}
 	// Closing p.done alone does not unblock readLoop when it is parked
 	// inside p.Reader.Read (the select runs only between iterations).
@@ -549,6 +567,7 @@ func (m *Mixer) recoverParticipant(p *Participant, loop string) {
 			"stack", string(debug.Stack()),
 		)
 		if m.removeParticipantIf(p) {
+			m.closeWriterForPanic(p)
 			m.hookMu.Lock()
 			hook := m.onParticipantPanic
 			m.hookMu.Unlock()

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -433,6 +434,35 @@ func (m *Mixer) Stop() {
 	m.stopped = true
 	m.mu.Unlock()
 	close(m.stopCh)
+}
+
+// recoverParticipant logs a panic on a per-participant IO loop (readLoop or
+// writeLoop) and removes the participant, mirroring SIPLeg.recoverLoop. The
+// panicking goroutine is not restarted; RemoveParticipant is idempotent
+// (mixer.go:391-409) so this is safe even if teardown is already underway.
+func (m *Mixer) recoverParticipant(p *Participant, loop string) {
+	if r := recover(); r != nil {
+		m.log.Error(loop+" panic",
+			"participant_id", p.ID,
+			"panic", r,
+			"stack", string(debug.Stack()),
+		)
+		m.RemoveParticipant(p.ID)
+	}
+}
+
+// recoverTick logs a panic from a single mixTick invocation and lets the
+// mix loop continue to the next tick. Must be deferred at the per-tick call
+// site (mixLoop's ticker case), never around mixLoop itself — recovering the
+// loop would stop the whole room instead of skipping one tick. Frame
+// contents are deliberately not logged.
+func (m *Mixer) recoverTick() {
+	if r := recover(); r != nil {
+		m.log.Error("mixTick panic, skipping tick",
+			"panic", r,
+			"stack", string(debug.Stack()),
+		)
+	}
 }
 
 // readLoop continuously reads PCM frames from a participant's Reader

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -61,6 +61,18 @@ type Participant struct {
 	// guard wraps Writer to prevent writes after removal.
 	guard *guardedWriter
 
+	// ownerClosesEgress marks a participant whose writer is closed by its own
+	// owner during teardown — a leg, whose Hangup closes the egress pipe. For
+	// such a participant the mixer's panic path must NOT close the writer: the
+	// writer is often the leg's shared egress, and by the time a dead loop's
+	// recover runs the leg may have moved onto a fresh participant over that
+	// same pipe, so closing it here would silence the live successor. The
+	// room's identity-gated panic hook tears the dead leg down via Hangup,
+	// which closes the egress. A source whose owner has no other wakeup — a ws
+	// or agent participant — leaves this false and relies on the panic path's
+	// close. Read on the panic path, set once right after AddParticipant.
+	ownerClosesEgress atomic.Bool
+
 	// Muted prevents this participant's audio from contributing to the mix
 	// and suppresses speaking events. Lock-free via atomic.
 	Muted atomic.Bool
@@ -404,6 +416,14 @@ func (m *Mixer) AddParticipant(id string, reader io.Reader, writer io.Writer) *P
 	return p
 }
 
+// MarkOwnerClosesEgress records that p's writer is closed by its own owner
+// during teardown, so the mixer's panic path leaves the writer alone. The room
+// layer calls this for legs, whose Hangup closes a shared egress the leg may
+// since have moved onto a fresh participant. See ownerClosesEgress.
+func (p *Participant) MarkOwnerClosesEgress() {
+	p.ownerClosesEgress.Store(true)
+}
+
 // AddPlaybackSource adds a read-only source into the mix (e.g. audio file).
 // It is mixed into everyone's output but receives no mixed-minus-self back.
 // Playback is room-wide audio and bypasses the routing matrix.
@@ -494,7 +514,16 @@ func (m *Mixer) removeParticipantIf(p *Participant) bool {
 // Manager.MoveLeg, which adds it to another room. Closing the writer on that
 // path closes a ws/MoQ leg's egress pipe, which is exactly what Hangup does,
 // so the leg would arrive at its new room already dead.
+//
+// The panic path has the same hazard: a leg's writer is closed by its own
+// owner during teardown, and a stale loop's recover can race a MoveLeg, so the
+// leg may already be live on a fresh participant over that same egress. A
+// participant flagged ownerClosesEgress is therefore skipped here and left to
+// the room's identity-gated hook.
 func (m *Mixer) closeWriterForPanic(p *Participant) {
+	if p.ownerClosesEgress.Load() {
+		return
+	}
 	if p.guard == nil {
 		return
 	}

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -538,9 +538,18 @@ func (m *Mixer) mixLoop() {
 		case <-m.stopCh:
 			return
 		case <-ticker.C:
-			m.mixTick()
+			m.safeMixTick()
 		}
 	}
+}
+
+// safeMixTick runs mixTick with a per-tick panic recover. A panic here
+// skips only this tick (recoverTick logs and returns) — mixLoop is not
+// wrapped, so the room's ticker keeps running and the next tick proceeds
+// normally.
+func (m *Mixer) safeMixTick() {
+	defer m.recoverTick()
+	m.mixTick()
 }
 
 // mixTick reads one frame from each participant, computes per-listener

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -116,7 +116,28 @@ type Mixer struct {
 	tapMu  sync.Mutex
 	tapOut io.Writer
 
+	// onParticipantPanic, when set, is notified after a participant's IO
+	// loop panicked and the participant was removed. It lets the owner (the
+	// room layer) finish the teardown the mixer cannot see — the mixer is a
+	// leaf and knows nothing about legs, rooms or events.
+	hookMu             sync.Mutex
+	onParticipantPanic func(participantID, loop string)
+
 	comfortNoise *comfortnoise.Generator
+}
+
+// SetOnParticipantPanic registers a callback invoked once per participant
+// whose readLoop or writeLoop panicked, after the mixer has removed it.
+// loop is "readLoop" or "writeLoop". Passing nil disables the hook.
+//
+// The mixer holds no lock — neither m.mu nor hookMu — while invoking fn, so
+// fn may call back into the mixer. fn runs on the panicking goroutine as its
+// last act before exiting; if fn does anything that blocks, it must hand off
+// to its own goroutine.
+func (m *Mixer) SetOnParticipantPanic(fn func(participantID, loop string)) {
+	m.hookMu.Lock()
+	defer m.hookMu.Unlock()
+	m.onParticipantPanic = fn
 }
 
 func New(log *slog.Logger, sampleRate int) *Mixer {
@@ -457,9 +478,14 @@ func (m *Mixer) Stop() {
 }
 
 // recoverParticipant logs a panic on a per-participant IO loop (readLoop or
-// writeLoop) and removes the participant, mirroring SIPLeg.recoverLoop. The
-// panicking goroutine is not restarted; RemoveParticipant is idempotent
-// (mixer.go:391-409) so this is safe even if teardown is already underway.
+// writeLoop) and removes the participant, mirroring SIPLeg.recoverLoopAndHangup.
+// The panicking goroutine is not restarted.
+//
+// Removing the participant from the mixer is only half of teardown: the owner
+// still has the leg registered and would leave a live call connected but deaf
+// and mute. removeParticipant's returned bool is the exactly-once gate — if
+// both IO loops panic for the same participant, only one of them notifies the
+// owner. The hook is read under hookMu but invoked with no lock held.
 func (m *Mixer) recoverParticipant(p *Participant, loop string) {
 	if r := recover(); r != nil {
 		m.log.Error(loop+" panic",
@@ -467,7 +493,14 @@ func (m *Mixer) recoverParticipant(p *Participant, loop string) {
 			"panic", r,
 			"stack", string(debug.Stack()),
 		)
-		m.RemoveParticipant(p.ID)
+		if m.removeParticipant(p.ID) {
+			m.hookMu.Lock()
+			hook := m.onParticipantPanic
+			m.hookMu.Unlock()
+			if hook != nil {
+				hook(p.ID, loop)
+			}
+		}
 	}
 }
 

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -390,23 +390,43 @@ func (m *Mixer) AddPlaybackSource(id string, reader io.Reader) {
 }
 
 func (m *Mixer) RemoveParticipant(id string) {
+	m.removeParticipant(id)
+}
+
+// removeParticipant detaches a participant and reports whether this call was
+// the one that removed it. The map delete under m.mu is the exactly-once
+// gate: concurrent callers race on the lookup, but only the goroutine that
+// observed ok == true owns teardown, so close(p.done) can never double-close
+// and any caller-side follow-up (see recoverParticipant) fires once even if
+// both IO loops fail for the same participant.
+//
+// Teardown itself runs outside m.mu: guard.Close and the Reader's Close are
+// foreign code — the reader in particular is arbitrary third-party IO — and
+// the mixer lock is never held across a call out of this package.
+func (m *Mixer) removeParticipant(id string) bool {
 	m.mu.Lock()
 	p, ok := m.participants[id]
 	if ok {
 		delete(m.participants, id)
-		if p.guard != nil {
-			p.guard.Close() // prevent any further writes to the network
-		}
-		// Closing p.done alone does not unblock readLoop when it is parked
-		// inside p.Reader.Read (the select runs only between iterations).
-		// If the reader implements io.Closer, close it so the in-flight
-		// Read returns and readLoop observes p.done on the next iteration.
-		if rc, ok := p.Reader.(io.Closer); ok {
-			_ = rc.Close()
-		}
-		close(p.done) // signal readLoop/writeLoop to stop
 	}
 	m.mu.Unlock()
+
+	if !ok {
+		return false
+	}
+
+	if p.guard != nil {
+		p.guard.Close() // prevent any further writes to the network
+	}
+	// Closing p.done alone does not unblock readLoop when it is parked
+	// inside p.Reader.Read (the select runs only between iterations).
+	// If the reader implements io.Closer, close it so the in-flight
+	// Read returns and readLoop observes p.done on the next iteration.
+	if rc, ok := p.Reader.(io.Closer); ok {
+		_ = rc.Close()
+	}
+	close(p.done) // signal readLoop/writeLoop to stop
+	return true
 }
 
 func (m *Mixer) ParticipantCount() int {

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -486,9 +486,26 @@ func (m *Mixer) closeWriterForPanic(p *Participant) {
 	if p.guard == nil {
 		return
 	}
-	if wc, ok := p.guard.w.(io.Closer); ok {
-		_ = wc.Close()
+	_ = closeWriter(p.guard.w)
+}
+
+// closeWriter closes w under either Close shape the mixer is handed, and is a
+// no-op for a writer that has neither.
+//
+// io.Closer alone is not enough: the writers registered through AddParticipant
+// close both ways. *io.PipeWriter (a ws leg) and bridge.Endpoint report an
+// error; the API layer's egress pipe writer, which an agent registers, closes
+// with no return value and so satisfies only the second shape. Testing for
+// io.Closer by itself silently skips exactly the writers whose owners have no
+// other wakeup.
+func closeWriter(w io.Writer) error {
+	switch c := w.(type) {
+	case io.Closer:
+		return c.Close()
+	case interface{ Close() }:
+		c.Close()
 	}
+	return nil
 }
 
 // teardownParticipant releases p's IO and stops its loops. Reachable only via

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -571,9 +571,14 @@ const tickPanicLogInterval = 5 * time.Second
 //
 // Logging is rate-limited because a deterministically panicking frame recurs
 // every tick: at Ptime cadence that is ~50 multi-KB stack traces a second,
-// forever. The first panic carries the full stack — that is the one worth
-// diagnosing — and subsequent ones collapse into at most one stackless line
-// per tickPanicLogInterval carrying the running total.
+// forever. Only the first tick panic of this Mixer's whole lifetime carries a
+// stack; every later one collapses into at most one stackless line per
+// tickPanicLogInterval, carrying the panic value and the running total.
+//
+// The counter is never re-armed, and a Mixer lives as long as its room — hours.
+// So a second, unrelated tick panic long after the first is permanently
+// stackless and still labelled "(repeating)". That is degraded diagnosability,
+// not lost: the panic value still reaches the log every interval.
 func (m *Mixer) recoverTick() {
 	r := recover()
 	if r == nil {

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -121,7 +121,7 @@ type Mixer struct {
 	// room layer) finish the teardown the mixer cannot see — the mixer is a
 	// leaf and knows nothing about legs, rooms or events.
 	hookMu             sync.Mutex
-	onParticipantPanic func(participantID, loop string)
+	onParticipantPanic func(p *Participant, loop string)
 
 	// tickPanics counts recovered mixTick panics; tickPanicLastLog is the
 	// unix-nanos of the last one logged. Both drive recoverTick's rate limit
@@ -136,11 +136,18 @@ type Mixer struct {
 // whose readLoop or writeLoop panicked, after the mixer has removed it.
 // loop is "readLoop" or "writeLoop". Passing nil disables the hook.
 //
+// fn receives the participant instance that panicked, not just its ID. By the
+// time fn — or anything it defers to — acts, the same ID may already carry a
+// replacement instance over a live audio path, and the mixer has removed the
+// panicked one from its own map, so this pointer is the only remaining handle
+// on which instance died. An owner that keyed teardown on the ID would tear
+// down that replacement instead.
+//
 // The mixer holds no lock — neither m.mu nor hookMu — while invoking fn, so
 // fn may call back into the mixer. fn runs on the panicking goroutine as its
 // last act before exiting; if fn does anything that blocks, it must hand off
 // to its own goroutine.
-func (m *Mixer) SetOnParticipantPanic(fn func(participantID, loop string)) {
+func (m *Mixer) SetOnParticipantPanic(fn func(p *Participant, loop string)) {
 	m.hookMu.Lock()
 	defer m.hookMu.Unlock()
 	m.onParticipantPanic = fn
@@ -364,7 +371,11 @@ func (m *Mixer) ClearParticipantOutTap(id string) {
 	}
 }
 
-func (m *Mixer) AddParticipant(id string, reader io.Reader, writer io.Writer) {
+// AddParticipant registers id's audio path and returns the instance created
+// for it. Callers that must later distinguish this instance from a
+// replacement registered under the same ID — see removeParticipantIf — keep
+// the returned pointer; the rest may ignore it.
+func (m *Mixer) AddParticipant(id string, reader io.Reader, writer io.Writer) *Participant {
 	gw := &guardedWriter{w: writer}
 	p := &Participant{
 		ID:       id,
@@ -390,6 +401,7 @@ func (m *Mixer) AddParticipant(id string, reader io.Reader, writer io.Writer) {
 
 	go m.readLoop(p)
 	go m.writeLoop(p)
+	return p
 }
 
 // AddPlaybackSource adds a read-only source into the mix (e.g. audio file).
@@ -589,7 +601,7 @@ func (m *Mixer) recoverParticipant(p *Participant, loop string) {
 			hook := m.onParticipantPanic
 			m.hookMu.Unlock()
 			if hook != nil {
-				hook(p.ID, loop)
+				hook(p, loop)
 			}
 		}
 	}

--- a/internal/mixer/mixer.go
+++ b/internal/mixer/mixer.go
@@ -478,6 +478,17 @@ func (m *Mixer) removeParticipantIf(p *Participant) bool {
 func (m *Mixer) teardownParticipant(p *Participant) {
 	if p.guard != nil {
 		p.guard.Close() // prevent any further writes to the network
+		// Muting the guard stops writes but tells the owner nothing: an owner
+		// parked on the read end of the writer it handed us would wait for
+		// audio that is never coming again. If that writer is an io.Closer,
+		// close it so the owner observes EOF and runs its own teardown. This
+		// is the only notification a participant whose owner is not the room
+		// layer (a WebSocket client, say) ever gets — the mixer is a leaf and
+		// cannot call them. Owner-initiated removals have already closed it;
+		// every writer reaching here is idempotent on Close.
+		if wc, ok := p.guard.w.(io.Closer); ok {
+			_ = wc.Close()
+		}
 	}
 	// Closing p.done alone does not unblock readLoop when it is parked
 	// inside p.Reader.Read (the select runs only between iterations).

--- a/internal/mixer/mixer_closer_test.go
+++ b/internal/mixer/mixer_closer_test.go
@@ -1,0 +1,107 @@
+package mixer
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+// voidClosePanicWriter mirrors the API layer's egress pipe writer, which an
+// agent registers through AddParticipant: its Close reports no error, so it
+// does not satisfy io.Closer. Write panics to drive writeLoop into
+// recoverParticipant. closed stands in for the read end the owner is parked
+// on — closing it is the only wakeup that owner will ever get.
+type voidClosePanicWriter struct {
+	once   sync.Once
+	closed chan struct{}
+}
+
+func (w *voidClosePanicWriter) Write([]byte) (int, error) { panic("simulated write panic") }
+func (w *voidClosePanicWriter) Close()                    { w.once.Do(func() { close(w.closed) }) }
+
+// errClosePanicWriter is the same stand-in with an error-returning Close, used
+// as the destination a rate-crossing leg's resampleWriter wraps.
+type errClosePanicWriter struct {
+	once   sync.Once
+	closed chan struct{}
+}
+
+func (w *errClosePanicWriter) Write([]byte) (int, error) { panic("simulated write panic") }
+func (w *errClosePanicWriter) Close() error {
+	w.once.Do(func() { close(w.closed) })
+	return nil
+}
+
+// parkedReader keeps readLoop blocked instead of spinning, so the write loop is
+// the only one that panics.
+type parkedReader struct{ release chan struct{} }
+
+func (r *parkedReader) Read([]byte) (int, error) {
+	<-r.release
+	return 0, io.EOF
+}
+
+func newClosertestMixer() *Mixer {
+	return New(slog.New(slog.NewTextHandler(io.Discard, nil)), DefaultSampleRate)
+}
+
+// pushOutgoing hands one frame to the participant's write loop, which is what
+// makes it call Write and panic.
+func pushOutgoing(t *testing.T, m *Mixer, id string) {
+	t.Helper()
+	m.mu.Lock()
+	p, ok := m.participants[id]
+	m.mu.Unlock()
+	if !ok {
+		t.Fatalf("participant %q not registered", id)
+	}
+	select {
+	case p.outgoing <- make([]byte, m.frameSizeBytes):
+	case <-time.After(time.Second):
+		t.Fatal("outgoing channel never drained")
+	}
+}
+
+func awaitClose(t *testing.T, closed <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("owner never woken: %s was not closed after its write loop panicked", what)
+	}
+}
+
+// An agent's writer closes with no error return. The panic path must still
+// close it, or the agent's owner parks on the pipe forever.
+func TestCloseWriterForPanicClosesVoidCloseWriter(t *testing.T) {
+	m := newClosertestMixer()
+	rd := &parkedReader{release: make(chan struct{})}
+	t.Cleanup(func() { close(rd.release) })
+	w := &voidClosePanicWriter{closed: make(chan struct{})}
+
+	m.AddParticipant("agent-1", rd, w)
+	pushOutgoing(t, m, "agent-1")
+
+	awaitClose(t, w.closed, "a writer whose Close returns no error")
+}
+
+// Any rate-crossing leg (an 8 kHz PCMU call) is registered as a *resampleWriter.
+// Closing it must reach the leg's egress underneath.
+func TestCloseWriterForPanicClosesResampleWriter(t *testing.T) {
+	m := newClosertestMixer()
+	rd := &parkedReader{release: make(chan struct{})}
+	t.Cleanup(func() { close(rd.release) })
+	dst := &errClosePanicWriter{closed: make(chan struct{})}
+
+	rw := NewResampleWriter(dst, DefaultSampleRate, 8000)
+	if _, ok := rw.(*resampleWriter); !ok {
+		t.Fatalf("NewResampleWriter(16000 -> 8000) = %T, want *resampleWriter", rw)
+	}
+
+	m.AddParticipant("leg-1", rd, rw)
+	pushOutgoing(t, m, "leg-1")
+
+	awaitClose(t, dst.closed, "the writer wrapped by a resampleWriter")
+}

--- a/internal/mixer/mixer_egress_panic_test.go
+++ b/internal/mixer/mixer_egress_panic_test.go
@@ -1,0 +1,90 @@
+package mixer
+
+import (
+	"testing"
+)
+
+// TestMixer_PanicSparesOwnerClosedEgress drives the production panic path and
+// asserts the mixer does NOT close the writer of a participant whose owner
+// closes it itself. This is the leg case: Hangup, dispatched by the room's
+// identity-gated hook, is what closes the egress, so a synchronous close here
+// is redundant when the leg genuinely died and destructive when it moved.
+//
+// The panic hook fires after recoverParticipant has already made its
+// writer-close decision, so waiting on it is a race-free barrier — no timing.
+func TestMixer_PanicSparesOwnerClosedEgress(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+	m.Start()
+	defer m.Stop()
+
+	panicked := make(chan struct{})
+	m.SetOnParticipantPanic(func(p *Participant, loop string) { close(panicked) })
+
+	egress := &closeSpyWriter{}
+	p := m.AddParticipant("leg", &panicAfterReader{limit: 1, frame: make([]byte, m.frameSizeBytes)}, egress)
+	p.MarkOwnerClosesEgress()
+
+	<-panicked
+	if egress.closed.Load() {
+		t.Fatal("the mixer closed a leg's egress on panic; its owner closes it via Hangup, and a moved leg shares that pipe with a live successor")
+	}
+}
+
+// TestMixer_PanicVsMoveKeepsSharedEgressOpen reproduces the panic-vs-move
+// interleaving, laid out in the exact order the race produces it, and asserts
+// the moved leg's shared egress survives.
+//
+// A ws/MoQ leg hands the same egress pipe back from AudioWriter on every join,
+// so the participant carrying the leg before a MoveLeg and the one after it
+// share that writer. When a stale IO loop's recover wins the mixer race, it
+// removes its own instance, the move re-adds the leg on a fresh participant
+// over the same egress, and the recover then reaches the writer close. Ungated,
+// that close silences the successor: it can hear ingress but never send — a
+// one-way zombie the room layer never gets told about, because the room's
+// identity-gated hook correctly does nothing for the already-moved leg.
+//
+// Sequencing the mixer's own steps by hand keeps this deterministic. Each maps
+// to a point in the real race, called on the same methods recoverParticipant
+// runs in the same order.
+func TestMixer_PanicVsMoveKeepsSharedEgressOpen(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+
+	egress := &closeSpyWriter{}
+	frame := make([]byte, m.frameSizeBytes)
+
+	// The leg is in room A on p1.
+	p1 := m.AddParticipant("leg", &silenceReader{frame: frame}, egress)
+	p1.MarkOwnerClosesEgress()
+
+	// 1. p1's dead IO loop recovers and wins the mixer race: it removes p1.
+	if !m.removeParticipantIf(p1) {
+		t.Fatal("removeParticipantIf(p1) did not remove the panicked instance")
+	}
+
+	// 2. The MoveLeg lands: DetachLeg found p1 already gone (RemoveParticipant
+	//    returned false, ignored by removeLegLocked) and AddLeg re-added the leg
+	//    to room B on a fresh participant over the SAME egress.
+	p2 := m.AddParticipant("leg", &silenceReader{frame: frame}, egress)
+	p2.MarkOwnerClosesEgress()
+	defer m.removeParticipantIf(p2)
+
+	// 3. p1's recover finally reaches the writer close.
+	m.closeWriterForPanic(p1)
+
+	if egress.closed.Load() {
+		t.Fatal("a moved leg's shared egress was closed by the panicked instance's recover; its successor can hear but never speak")
+	}
+
+	// The successor is still the registered instance and still live.
+	m.mu.Lock()
+	cur := m.participants["leg"]
+	m.mu.Unlock()
+	if cur != p2 {
+		t.Fatal("the successor is no longer the registered participant")
+	}
+	select {
+	case <-p2.done:
+		t.Fatal("the successor's IO loops were stopped")
+	default:
+	}
+}

--- a/internal/mixer/mixer_panic_test.go
+++ b/internal/mixer/mixer_panic_test.go
@@ -371,6 +371,84 @@ func TestMixer_ParticipantPanicHookFiresExactlyOnce(t *testing.T) {
 	}
 }
 
+// TestMixer_StaleLoopPanicDoesNotEvictSuccessor pins teardown to the
+// participant *instance* rather than to its ID.
+//
+// AddParticipant overwrites m.participants[id] without stopping the previous
+// instance's loops, and the mixer's unblock trick (closing a Reader that is an
+// io.Closer) misses a rate-mismatched leg entirely — NewResampleReader wraps it
+// in a *resampleReader, which has no Close. So an orphaned readLoop can stay
+// parked in Read long after its replacement is live. When that orphan finally
+// panics, keying removal on the ID would delete the healthy successor and fire
+// the hook for it, escalating into a RemoveLeg + Hangup on a good call.
+//
+// Driving recoverParticipant directly keeps this deterministic — no real
+// panicking reader, no timing.
+func TestMixer_StaleLoopPanicDoesNotEvictSuccessor(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+
+	var fired atomic.Int32
+	m.SetOnParticipantPanic(func(id, loop string) {
+		fired.Add(1)
+	})
+
+	// pOld is the orphaned instance: registered under "victim", then replaced.
+	gwOld := &guardedWriter{w: io.Discard}
+	pOld := &Participant{
+		ID:       "victim",
+		Reader:   &silenceReader{frame: make([]byte, m.frameSizeBytes)},
+		Writer:   gwOld,
+		incoming: make(chan []byte, 3),
+		outgoing: make(chan []byte, 3),
+		inject:   make(chan []byte, 3),
+		done:     make(chan struct{}),
+		guard:    gwOld,
+	}
+	m.mu.Lock()
+	m.participants["victim"] = pOld
+	m.mu.Unlock()
+
+	// The re-add: overwrites "victim" with a live instance, orphaning pOld.
+	m.AddParticipant("victim", &silenceReader{frame: make([]byte, m.frameSizeBytes)}, io.Discard)
+
+	m.mu.Lock()
+	pNew := m.participants["victim"]
+	m.mu.Unlock()
+	if pNew == pOld {
+		t.Fatal("AddParticipant did not replace the registered instance")
+	}
+	defer m.removeParticipantIf(pNew)
+
+	// The orphan's parked Read finally panics.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer m.recoverParticipant(pOld, "readLoop")
+		panic("stale loop")
+	}()
+	<-done
+
+	if got := fired.Load(); got != 0 {
+		t.Errorf("hook fired %d times for a stale loop, want 0 — the owner must not be told to tear down a live call", got)
+	}
+	if got := m.ParticipantCount(); got != 1 {
+		t.Fatalf("participant count = %d, want 1 — the successor must survive", got)
+	}
+
+	m.mu.Lock()
+	cur := m.participants["victim"]
+	m.mu.Unlock()
+	if cur != pNew {
+		t.Fatal("the stale loop's panic evicted the live successor")
+	}
+
+	select {
+	case <-pNew.done:
+		t.Fatal("the successor's done was closed by the stale loop's teardown")
+	default:
+	}
+}
+
 // TestMixer_ParticipantPanicHookNilIsNoop verifies a mixer with no hook
 // registered (the mixer is usable standalone) still recovers and removes.
 func TestMixer_ParticipantPanicHookNilIsNoop(t *testing.T) {

--- a/internal/mixer/mixer_panic_test.go
+++ b/internal/mixer/mixer_panic_test.go
@@ -1,6 +1,7 @@
 package mixer
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"runtime"
@@ -337,6 +338,137 @@ func TestMixer_ParticipantPanicHookNilIsNoop(t *testing.T) {
 	waitFor(t, 2*time.Second, "victim removed with no hook registered", func() bool {
 		return m.ParticipantCount() == 0
 	})
+}
+
+// alwaysPanicWriter panics on every Write, simulating a deterministically
+// bad frame that makes every single mix tick panic.
+type alwaysPanicWriter struct{}
+
+func (alwaysPanicWriter) Write(p []byte) (int, error) { panic("simulated tap panic") }
+
+// countingHandler records how many log records carried a "stack" attribute
+// and how many were emitted in total.
+type countingHandler struct {
+	mu          sync.Mutex
+	total       int
+	withStack   int
+	lastMessage string
+}
+
+func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *countingHandler) WithAttrs([]slog.Attr) slog.Handler       { return h }
+func (h *countingHandler) WithGroup(string) slog.Handler            { return h }
+
+func (h *countingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.total++
+	h.lastMessage = r.Message
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == "stack" {
+			h.withStack++
+			return false
+		}
+		return true
+	})
+	return nil
+}
+
+func (h *countingHandler) counts() (total, withStack int) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.total, h.withStack
+}
+
+// TestMixer_TickPanicLogsAreRateLimited verifies that a deterministically
+// panicking frame does not flood the log. A bad frame recurs on every tick,
+// so an unbounded recoverTick would emit a multi-KB stack ~50x a second
+// forever. Exactly one stack-bearing line may be emitted; the rest collapse
+// into at most one stackless summary per interval.
+func TestMixer_TickPanicLogsAreRateLimited(t *testing.T) {
+	h := &countingHandler{}
+	m := New(slog.New(h), DefaultSampleRate)
+
+	gw := &guardedWriter{w: io.Discard}
+	p := &Participant{
+		ID:       "listener",
+		Writer:   gw,
+		incoming: make(chan []byte, 3),
+		outgoing: make(chan []byte, 3),
+		inject:   make(chan []byte, 3),
+		done:     make(chan struct{}),
+		guard:    gw,
+		tap:      alwaysPanicWriter{},
+	}
+	m.mu.Lock()
+	m.participants["listener"] = p
+	m.mu.Unlock()
+
+	// Far more consecutive panicking ticks than a 5s interval could ever
+	// permit a second log line for.
+	const ticks = 500
+	for i := 0; i < ticks; i++ {
+		m.safeMixTick()
+	}
+
+	total, withStack := h.counts()
+	if withStack != 1 {
+		t.Errorf("stack-bearing log lines = %d, want exactly 1 (got %d lines total)", withStack, total)
+	}
+	if total != 1 {
+		t.Errorf("log lines = %d, want 1 — %d ticks inside one interval must collapse", total, ticks)
+	}
+	if got := m.tickPanics.Load(); got != ticks {
+		t.Errorf("tickPanics = %d, want %d — every panic must still be counted", got, ticks)
+	}
+}
+
+// TestMixer_TickPanicSummaryLogsAfterInterval verifies the rate limit lets a
+// stackless summary through once the interval has elapsed, so an ongoing
+// fault stays visible rather than going silent after the first line.
+func TestMixer_TickPanicSummaryLogsAfterInterval(t *testing.T) {
+	h := &countingHandler{}
+	m := New(slog.New(h), DefaultSampleRate)
+
+	gw := &guardedWriter{w: io.Discard}
+	p := &Participant{
+		ID:       "listener",
+		Writer:   gw,
+		incoming: make(chan []byte, 3),
+		outgoing: make(chan []byte, 3),
+		inject:   make(chan []byte, 3),
+		done:     make(chan struct{}),
+		guard:    gw,
+		tap:      alwaysPanicWriter{},
+	}
+	m.mu.Lock()
+	m.participants["listener"] = p
+	m.mu.Unlock()
+
+	m.safeMixTick() // first panic: full stack
+	m.safeMixTick() // suppressed
+
+	if total, withStack := h.counts(); total != 1 || withStack != 1 {
+		t.Fatalf("after 2 ticks: total=%d withStack=%d, want 1 and 1", total, withStack)
+	}
+
+	// Age the last-log stamp past the interval rather than sleeping for it.
+	m.tickPanicLastLog.Store(time.Now().Add(-2 * tickPanicLogInterval).UnixNano())
+	m.safeMixTick()
+
+	total, withStack := h.counts()
+	if total != 2 {
+		t.Errorf("log lines = %d, want 2 — a summary is due after the interval", total)
+	}
+	if withStack != 1 {
+		t.Errorf("stack-bearing lines = %d, want 1 — the summary must not carry a stack", withStack)
+	}
+	h.mu.Lock()
+	msg := h.lastMessage
+	h.mu.Unlock()
+	if msg != "mixTick panic, skipping tick (repeating)" {
+		t.Errorf("summary message = %q", msg)
+	}
 }
 
 // TestMixer_ReadLoopPanicGoroutinesExit verifies that after a read-panic

--- a/internal/mixer/mixer_panic_test.go
+++ b/internal/mixer/mixer_panic_test.go
@@ -1,6 +1,7 @@
 package mixer
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -431,6 +432,32 @@ func TestMixer_ParticipantPanicClosesWriterToWakeOwner(t *testing.T) {
 	waitFor(t, 2*time.Second, "the panicked participant's writer to be closed so its owner wakes", func() bool {
 		return victimWriter.closed.Load()
 	})
+}
+
+// TestMixer_OrdinaryRemovalLeavesWriterOpen is the counterpart to
+// TestMixer_ParticipantPanicClosesWriterToWakeOwner, and the two together are
+// the whole contract: a panic closes the writer, an ordinary removal must not.
+//
+// A removal is not a hangup. The room layer detaches a participant to move it
+// between rooms and expects a live one back, and a leg's writer is frequently
+// the leg's own egress pipe — closing it is precisely what Hangup does. Waking
+// the owner is right when the participant died; doing it when the owner is
+// still using the participant kills a healthy call.
+func TestMixer_OrdinaryRemovalLeavesWriterOpen(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+	m.Start()
+	defer m.Stop()
+
+	w := &closeSpyWriter{}
+	m.AddParticipant("mover", bytes.NewReader(nil), w)
+	m.RemoveParticipant("mover")
+
+	waitFor(t, 2*time.Second, "participant removed", func() bool {
+		return m.ParticipantCount() == 0
+	})
+	if w.closed.Load() {
+		t.Error("an ordinary removal closed the participant's writer; for a ws/MoQ leg that is its egress pipe, so a room-leave or MoveLeg would end the call")
+	}
 }
 
 // TestMixer_StaleLoopPanicDoesNotEvictSuccessor pins teardown to the

--- a/internal/mixer/mixer_panic_test.go
+++ b/internal/mixer/mixer_panic_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log/slog"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -237,6 +238,105 @@ func TestMixer_MixTickPanicSkipsTickNotRoom(t *testing.T) {
 	default:
 		t.Fatal("expected output on the tick after recovery")
 	}
+}
+
+// TestMixer_ParticipantPanicHookFires verifies the owner is notified when a
+// participant's IO loop panics — removing the participant from the mixer's
+// map is only half of teardown, and without this the leg behind it would be
+// left connected but deaf and mute.
+func TestMixer_ParticipantPanicHookFires(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+	m.Start()
+	defer m.Stop()
+
+	type call struct{ id, loop string }
+	calls := make(chan call, 4)
+	m.SetOnParticipantPanic(func(id, loop string) {
+		calls <- call{id, loop}
+	})
+
+	victimReader := &panicAfterReader{limit: 1, frame: make([]byte, m.frameSizeBytes)}
+	m.AddParticipant("victim", victimReader, io.Discard)
+
+	select {
+	case c := <-calls:
+		if c.id != "victim" {
+			t.Errorf("hook participant id = %q, want victim", c.id)
+		}
+		if c.loop != "readLoop" {
+			t.Errorf("hook loop = %q, want readLoop", c.loop)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the participant panic hook to fire")
+	}
+}
+
+// TestMixer_ParticipantPanicHookFiresExactlyOnce is the assertion that buys
+// removeParticipant's returned bool: when both IO loops panic for the same
+// participant, the map delete under m.mu elects a single teardown owner, so
+// the owner is notified once — and close(p.done) is never double-closed.
+func TestMixer_ParticipantPanicHookFiresExactlyOnce(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+
+	var fired atomic.Int32
+	m.SetOnParticipantPanic(func(id, loop string) {
+		fired.Add(1)
+		if id != "victim" {
+			t.Errorf("hook participant id = %q, want victim", id)
+		}
+	})
+
+	gw := &guardedWriter{w: io.Discard}
+	p := &Participant{
+		ID:       "victim",
+		Reader:   &silenceReader{frame: make([]byte, m.frameSizeBytes)},
+		Writer:   gw,
+		incoming: make(chan []byte, 3),
+		outgoing: make(chan []byte, 3),
+		inject:   make(chan []byte, 3),
+		done:     make(chan struct{}),
+		guard:    gw,
+	}
+	m.mu.Lock()
+	m.participants["victim"] = p
+	m.mu.Unlock()
+
+	// Both of this participant's IO loops fail at once. Driving
+	// recoverParticipant directly makes the race deterministic: a real
+	// readLoop panic closes p.done, which would usually retire writeLoop
+	// before it ever got the chance to panic too.
+	var wg sync.WaitGroup
+	for _, loop := range []string{"readLoop", "writeLoop"} {
+		wg.Add(1)
+		go func(loop string) {
+			defer wg.Done()
+			defer m.recoverParticipant(p, loop)
+			panic("simulated " + loop + " panic")
+		}(loop)
+	}
+	wg.Wait()
+
+	if got := fired.Load(); got != 1 {
+		t.Fatalf("hook fired %d times, want exactly 1", got)
+	}
+	if m.ParticipantCount() != 0 {
+		t.Fatalf("participant count = %d, want 0", m.ParticipantCount())
+	}
+}
+
+// TestMixer_ParticipantPanicHookNilIsNoop verifies a mixer with no hook
+// registered (the mixer is usable standalone) still recovers and removes.
+func TestMixer_ParticipantPanicHookNilIsNoop(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+	m.Start()
+	defer m.Stop()
+
+	victimReader := &panicAfterReader{limit: 1, frame: make([]byte, m.frameSizeBytes)}
+	m.AddParticipant("victim", victimReader, io.Discard)
+
+	waitFor(t, 2*time.Second, "victim removed with no hook registered", func() bool {
+		return m.ParticipantCount() == 0
+	})
 }
 
 // TestMixer_ReadLoopPanicGoroutinesExit verifies that after a read-panic

--- a/internal/mixer/mixer_panic_test.go
+++ b/internal/mixer/mixer_panic_test.go
@@ -151,8 +151,8 @@ func TestMixer_WriteLoopPanicRemovesParticipant(t *testing.T) {
 	fsz := m.frameSizeBytes
 
 	gotLoop := make(chan string, 4)
-	m.SetOnParticipantPanic(func(id, loop string) {
-		if id == "victim" {
+	m.SetOnParticipantPanic(func(p *Participant, loop string) {
+		if p.ID == "victim" {
 			gotLoop <- loop
 		}
 	})
@@ -321,8 +321,8 @@ func TestMixer_ParticipantPanicHookFires(t *testing.T) {
 
 	type call struct{ id, loop string }
 	calls := make(chan call, 4)
-	m.SetOnParticipantPanic(func(id, loop string) {
-		calls <- call{id, loop}
+	m.SetOnParticipantPanic(func(p *Participant, loop string) {
+		calls <- call{p.ID, loop}
 	})
 
 	victimReader := &panicAfterReader{limit: 1, frame: make([]byte, m.frameSizeBytes)}
@@ -349,10 +349,10 @@ func TestMixer_ParticipantPanicHookFiresExactlyOnce(t *testing.T) {
 	m := New(testLog(), DefaultSampleRate)
 
 	var fired atomic.Int32
-	m.SetOnParticipantPanic(func(id, loop string) {
+	m.SetOnParticipantPanic(func(p *Participant, loop string) {
 		fired.Add(1)
-		if id != "victim" {
-			t.Errorf("hook participant id = %q, want victim", id)
+		if p.ID != "victim" {
+			t.Errorf("hook participant id = %q, want victim", p.ID)
 		}
 	})
 
@@ -477,7 +477,7 @@ func TestMixer_StaleLoopPanicDoesNotEvictSuccessor(t *testing.T) {
 	m := New(testLog(), DefaultSampleRate)
 
 	var fired atomic.Int32
-	m.SetOnParticipantPanic(func(id, loop string) {
+	m.SetOnParticipantPanic(func(p *Participant, loop string) {
 		fired.Add(1)
 	})
 

--- a/internal/mixer/mixer_panic_test.go
+++ b/internal/mixer/mixer_panic_test.go
@@ -1,0 +1,267 @@
+package mixer
+
+import (
+	"io"
+	"log/slog"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// panicAfterReader panics on the (limit+1)th call to Read; before that it
+// returns a fixed frame. Used to simulate a participant whose Reader.Read
+// panics on a malformed frame after N good reads.
+type panicAfterReader struct {
+	n     int32
+	limit int32
+	frame []byte
+}
+
+func (r *panicAfterReader) Read(p []byte) (int, error) {
+	if atomic.AddInt32(&r.n, 1) > r.limit {
+		panic("simulated read panic")
+	}
+	copy(p, r.frame)
+	return len(p), nil
+}
+
+// silenceReader always returns a fixed (silent) frame, never panics. Used as
+// the "other side" of a participant whose Writer is the one under test.
+type silenceReader struct {
+	frame []byte
+}
+
+func (r *silenceReader) Read(p []byte) (int, error) {
+	copy(p, r.frame)
+	return len(p), nil
+}
+
+// panicAfterWriter panics on the (limit+1)th call to Write; before that it
+// accepts the write silently.
+type panicAfterWriter struct {
+	n     int32
+	limit int32
+}
+
+func (w *panicAfterWriter) Write(p []byte) (int, error) {
+	if atomic.AddInt32(&w.n, 1) > w.limit {
+		panic("simulated write panic")
+	}
+	return len(p), nil
+}
+
+// panicOnceWriter panics on its first Write call and behaves normally
+// afterward. Used to force exactly one bad mixTick.
+type panicOnceWriter struct {
+	fired atomic.Bool
+}
+
+func (w *panicOnceWriter) Write(p []byte) (int, error) {
+	if w.fired.CompareAndSwap(false, true) {
+		panic("simulated tap panic")
+	}
+	return len(p), nil
+}
+
+func testLog() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// waitFor polls cond until it's true or the timeout elapses.
+func waitFor(t *testing.T, timeout time.Duration, msg string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for: %s", msg)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestMixer_ReadLoopPanicRemovesParticipant verifies that a panic inside a
+// participant's Reader.Read is recovered, removes exactly that participant,
+// and does not take down the mixer — other participants keep receiving
+// mixed output afterward.
+func TestMixer_ReadLoopPanicRemovesParticipant(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+	m.Start()
+	defer m.Stop()
+
+	fsz := m.frameSizeBytes
+
+	victimReader := &panicAfterReader{limit: 2, frame: make([]byte, fsz)}
+	m.AddParticipant("victim", victimReader, io.Discard)
+
+	survivorReader, survivorFeeder := io.Pipe()
+	survivorCapture := &captureWriter{}
+	m.AddParticipant("survivor", survivorReader, survivorCapture)
+	stopFeed := make(chan struct{})
+	defer close(stopFeed)
+	go func() {
+		silence := make([]byte, fsz)
+		ticker := time.NewTicker(time.Duration(Ptime) * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopFeed:
+				return
+			case <-ticker.C:
+				if _, err := survivorFeeder.Write(silence); err != nil {
+					return
+				}
+			}
+		}
+	}()
+	defer survivorFeeder.Close()
+
+	waitFor(t, 2*time.Second, "victim removed after read panic", func() bool {
+		return m.ParticipantCount() == 1
+	})
+
+	before := len(survivorCapture.Bytes())
+	time.Sleep(200 * time.Millisecond)
+	after := len(survivorCapture.Bytes())
+	if after <= before {
+		t.Fatalf("survivor stopped receiving audio after victim's read panic: before=%d after=%d", before, after)
+	}
+}
+
+// TestMixer_WriteLoopPanicRemovesParticipant verifies that a panic inside a
+// participant's Writer.Write is recovered, removes exactly that
+// participant, and the mixer keeps ticking for the rest.
+func TestMixer_WriteLoopPanicRemovesParticipant(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+	m.Start()
+	defer m.Stop()
+
+	fsz := m.frameSizeBytes
+
+	victimReader := &silenceReader{frame: make([]byte, fsz)}
+	victimWriter := &panicAfterWriter{limit: 2}
+	m.AddParticipant("victim", victimReader, victimWriter)
+
+	survivorReader, survivorFeeder := io.Pipe()
+	survivorCapture := &captureWriter{}
+	m.AddParticipant("survivor", survivorReader, survivorCapture)
+	stopFeed := make(chan struct{})
+	defer close(stopFeed)
+	go func() {
+		silence := make([]byte, fsz)
+		ticker := time.NewTicker(time.Duration(Ptime) * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopFeed:
+				return
+			case <-ticker.C:
+				if _, err := survivorFeeder.Write(silence); err != nil {
+					return
+				}
+			}
+		}
+	}()
+	defer survivorFeeder.Close()
+
+	waitFor(t, 2*time.Second, "victim removed after write panic", func() bool {
+		return m.ParticipantCount() == 1
+	})
+
+	before := len(survivorCapture.Bytes())
+	time.Sleep(200 * time.Millisecond)
+	after := len(survivorCapture.Bytes())
+	if after <= before {
+		t.Fatalf("survivor stopped receiving audio after victim's write panic: before=%d after=%d", before, after)
+	}
+}
+
+// TestMixer_MixTickPanicSkipsTickNotRoom is the load-bearing assertion that
+// mixTick is recovered per-tick (via safeMixTick), not by a defer wrapped
+// around mixLoop. It drives safeMixTick directly: a panic on the first call
+// must be swallowed with no output produced for that tick, and the very
+// next call must complete normally and produce output — proving the mix
+// loop itself was never unwound.
+func TestMixer_MixTickPanicSkipsTickNotRoom(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+
+	fsz := m.frameSizeBytes
+	spf := m.samplesPerFrame
+
+	gw := &guardedWriter{w: io.Discard}
+	p := &Participant{
+		ID:       "listener",
+		Writer:   gw,
+		incoming: make(chan []byte, 3),
+		outgoing: make(chan []byte, 3),
+		inject:   make(chan []byte, 3),
+		done:     make(chan struct{}),
+		guard:    gw,
+	}
+	// tap.Write is called early in mixTick, before the per-listener mix loop
+	// that produces output — so a panic here proves the whole tick is
+	// skipped, not just this participant's slice of it.
+	panicTap := &panicOnceWriter{}
+	p.tap = panicTap
+
+	m.mu.Lock()
+	m.participants["listener"] = p
+	m.mu.Unlock()
+
+	frame := make([]byte, fsz)
+
+	// Tick 1: tap panics. safeMixTick must recover; no output for this tick.
+	p.incoming <- frame
+	m.safeMixTick()
+
+	select {
+	case <-p.outgoing:
+		t.Fatal("expected no output on the panicking tick")
+	default:
+	}
+
+	// Tick 2: tap no longer panics (fired once); mixTick must complete
+	// normally and produce output — proving mixLoop's ticker case survived
+	// the previous panic.
+	p.incoming <- frame
+	m.safeMixTick()
+
+	select {
+	case out := <-p.outgoing:
+		if len(out) != spf*2 {
+			t.Fatalf("unexpected output length = %d, want %d", len(out), spf*2)
+		}
+	default:
+		t.Fatal("expected output on the tick after recovery")
+	}
+}
+
+// TestMixer_ReadLoopPanicGoroutinesExit verifies that after a read-panic
+// removes a participant, that participant's readLoop/writeLoop goroutines
+// actually exit (via the close(p.done) path in RemoveParticipant) rather
+// than leaking.
+func TestMixer_ReadLoopPanicGoroutinesExit(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+	m.Start()
+	defer m.Stop()
+
+	fsz := m.frameSizeBytes
+
+	// Let the mixer settle before taking the goroutine-count baseline.
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	victimReader := &panicAfterReader{limit: 1, frame: make([]byte, fsz)}
+	m.AddParticipant("victim", victimReader, io.Discard)
+
+	waitFor(t, 2*time.Second, "victim removed after read panic", func() bool {
+		return m.ParticipantCount() == 0
+	})
+
+	waitFor(t, 2*time.Second, "victim's readLoop/writeLoop goroutines to exit", func() bool {
+		return runtime.NumGoroutine() <= before
+	})
+}

--- a/internal/mixer/mixer_panic_test.go
+++ b/internal/mixer/mixer_panic_test.go
@@ -181,12 +181,14 @@ func TestMixer_WriteLoopPanicRemovesParticipant(t *testing.T) {
 	}
 }
 
-// TestMixer_MixTickPanicSkipsTickNotRoom is the load-bearing assertion that
-// mixTick is recovered per-tick (via safeMixTick), not by a defer wrapped
-// around mixLoop. It drives safeMixTick directly: a panic on the first call
-// must be swallowed with no output produced for that tick, and the very
-// next call must complete normally and produce output — proving the mix
-// loop itself was never unwound.
+// TestMixer_MixTickPanicSkipsTickNotRoom asserts the per-tick contract in
+// isolation: a panic on one call is swallowed with no output for that tick,
+// and the very next call completes normally and produces output.
+//
+// It calls safeMixTick directly, so it says nothing about whether mixLoop
+// actually routes its ticker case through safeMixTick — rewiring the ticker
+// to a bare mixTick() would leave this test green while the process regained
+// its crash. TestMixer_MixLoopTickerPanicKeepsRoomRunning covers that.
 func TestMixer_MixTickPanicSkipsTickNotRoom(t *testing.T) {
 	m := New(testLog(), DefaultSampleRate)
 
@@ -238,6 +240,46 @@ func TestMixer_MixTickPanicSkipsTickNotRoom(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected output on the tick after recovery")
+	}
+}
+
+// TestMixer_MixLoopTickerPanicKeepsRoomRunning drives the real mix loop —
+// Start(), the real 20ms ticker, a panic on a real tick — rather than
+// calling safeMixTick by hand. This is what pins mixLoop's ticker case to
+// safeMixTick: if it were rewired to a bare mixTick(), the panic would
+// unwind mixLoop and take the process down with it, so this test cannot
+// pass without the recover actually being on the live path.
+func TestMixer_MixLoopTickerPanicKeepsRoomRunning(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+
+	fsz := m.frameSizeBytes
+	capture := &captureWriter{}
+	m.AddParticipant("listener", &silenceReader{frame: make([]byte, fsz)}, capture)
+
+	// tap.Write runs early in mixTick, before any output is produced, so the
+	// tick that hits it is skipped whole.
+	panicTap := &panicOnceWriter{}
+	m.SetParticipantTap("listener", panicTap)
+
+	m.Start()
+	defer m.Stop()
+
+	waitFor(t, 2*time.Second, "a real ticker tick to reach the panicking tap", func() bool {
+		return panicTap.fired.Load()
+	})
+	waitFor(t, 2*time.Second, "recoverTick to record the tick panic", func() bool {
+		return m.tickPanics.Load() >= 1
+	})
+
+	// Baseline after the panicking tick: any growth from here is produced by
+	// ticks the loop ran *after* it recovered.
+	before := len(capture.Bytes())
+	waitFor(t, 2*time.Second, "a later ticker tick to still produce output", func() bool {
+		return len(capture.Bytes()) > before
+	})
+
+	if got := m.ParticipantCount(); got != 1 {
+		t.Errorf("participant count = %d, want 1 — a tick panic must not evict anyone", got)
 	}
 }
 

--- a/internal/mixer/mixer_panic_test.go
+++ b/internal/mixer/mixer_panic_test.go
@@ -371,6 +371,46 @@ func TestMixer_ParticipantPanicHookFiresExactlyOnce(t *testing.T) {
 	}
 }
 
+// closeSpyWriter accepts every write and records whether it was closed.
+// Stands in for a participant writer whose owner is watching the far end —
+// the WebSocket egress pipe, say, whose reader shuts the client's transport
+// down on EOF.
+type closeSpyWriter struct {
+	closed atomic.Bool
+}
+
+func (w *closeSpyWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func (w *closeSpyWriter) Close() error {
+	w.closed.Store(true)
+	return nil
+}
+
+// TestMixer_ParticipantPanicClosesWriterToWakeOwner pins the only signal a
+// panicking participant's owner ever receives when that owner is not the room
+// layer. The mixer cannot call a WebSocket or agent session — it is a leaf. It
+// can only close the writer it was handed, so the far end sees EOF and tears
+// itself down. Without this, a ws participant's panic leaves the client
+// connected to a room it can no longer be heard in, forever.
+//
+// Muting p.guard is not enough: it stops writes but is invisible from outside
+// the mixer.
+func TestMixer_ParticipantPanicClosesWriterToWakeOwner(t *testing.T) {
+	m := New(testLog(), DefaultSampleRate)
+	m.Start()
+	defer m.Stop()
+
+	victimWriter := &closeSpyWriter{}
+	m.AddParticipant("victim", &panicAfterReader{limit: 1, frame: make([]byte, m.frameSizeBytes)}, victimWriter)
+
+	waitFor(t, 2*time.Second, "victim removed after read panic", func() bool {
+		return m.ParticipantCount() == 0
+	})
+	waitFor(t, 2*time.Second, "the panicked participant's writer to be closed so its owner wakes", func() bool {
+		return victimWriter.closed.Load()
+	})
+}
+
 // TestMixer_StaleLoopPanicDoesNotEvictSuccessor pins teardown to the
 // participant *instance* rather than to its ID.
 //

--- a/internal/mixer/mixer_panic_test.go
+++ b/internal/mixer/mixer_panic_test.go
@@ -136,12 +136,25 @@ func TestMixer_ReadLoopPanicRemovesParticipant(t *testing.T) {
 // TestMixer_WriteLoopPanicRemovesParticipant verifies that a panic inside a
 // participant's Writer.Write is recovered, removes exactly that
 // participant, and the mixer keeps ticking for the rest.
+//
+// It also pins the label writeLoop hands the hook. loop is the only field
+// telling an operator an RTP send failed rather than inbound media, and it is
+// asserted nowhere else against the real loop: the hook's other label test
+// supplies the string itself while direct-driving recoverParticipant, so it
+// cannot catch a mislabelled production call site.
 func TestMixer_WriteLoopPanicRemovesParticipant(t *testing.T) {
 	m := New(testLog(), DefaultSampleRate)
 	m.Start()
 	defer m.Stop()
 
 	fsz := m.frameSizeBytes
+
+	gotLoop := make(chan string, 4)
+	m.SetOnParticipantPanic(func(id, loop string) {
+		if id == "victim" {
+			gotLoop <- loop
+		}
+	})
 
 	victimReader := &silenceReader{frame: make([]byte, fsz)}
 	victimWriter := &panicAfterWriter{limit: 2}
@@ -172,6 +185,15 @@ func TestMixer_WriteLoopPanicRemovesParticipant(t *testing.T) {
 	waitFor(t, 2*time.Second, "victim removed after write panic", func() bool {
 		return m.ParticipantCount() == 1
 	})
+
+	select {
+	case loop := <-gotLoop:
+		if loop != "writeLoop" {
+			t.Errorf("hook loop = %q, want writeLoop — an RTP send failure must not be reported as inbound media", loop)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the write panic to reach the hook")
+	}
 
 	before := len(survivorCapture.Bytes())
 	time.Sleep(200 * time.Millisecond)

--- a/internal/mixer/mixer_panic_test.go
+++ b/internal/mixer/mixer_panic_test.go
@@ -181,15 +181,19 @@ func TestMixer_WriteLoopPanicRemovesParticipant(t *testing.T) {
 	}
 }
 
-// TestMixer_MixTickPanicSkipsTickNotRoom asserts the per-tick contract in
-// isolation: a panic on one call is swallowed with no output for that tick,
-// and the very next call completes normally and produces output.
+// TestMixer_SafeMixTickRecoversAndContinues asserts the per-tick contract of
+// safeMixTick in isolation: a panic on one call is swallowed with no output
+// for that tick, and the very next call completes normally and produces
+// output. Calling safeMixTick directly keeps this deterministic — no ticker,
+// no timing.
 //
-// It calls safeMixTick directly, so it says nothing about whether mixLoop
-// actually routes its ticker case through safeMixTick — rewiring the ticker
-// to a bare mixTick() would leave this test green while the process regained
-// its crash. TestMixer_MixLoopTickerPanicKeepsRoomRunning covers that.
-func TestMixer_MixTickPanicSkipsTickNotRoom(t *testing.T) {
+// Scope, deliberately: this covers the helper, NOT the room-survival
+// guarantee. It says nothing about whether mixLoop routes its ticker case
+// through safeMixTick — rewiring the ticker to a bare mixTick() leaves this
+// test green while the process regains its crash. That wiring is what
+// TestMixer_MixLoopTickerPanicKeepsRoomRunning exists to catch; do not read
+// a green result here as proof the room survives.
+func TestMixer_SafeMixTickRecoversAndContinues(t *testing.T) {
 	m := New(testLog(), DefaultSampleRate)
 
 	fsz := m.frameSizeBytes

--- a/internal/mixer/resample.go
+++ b/internal/mixer/resample.go
@@ -99,6 +99,15 @@ type resampleWriter struct {
 	buf        []byte // accumulate partial samples
 }
 
+// Close closes the wrapped writer, so that closing a rate-crossing leg's
+// writer reaches the leg's egress rather than stopping at the resampler.
+// Without it every 8 kHz leg is unclosable and the mixer's panic path cannot
+// wake its owner. Buffered partial samples are dropped: the frame they would
+// complete is worthless on a writer that is being torn down.
+func (w *resampleWriter) Close() error {
+	return closeWriter(w.dst)
+}
+
 func (w *resampleWriter) Write(p []byte) (int, error) {
 	total := len(p)
 

--- a/internal/room/bridge.go
+++ b/internal/room/bridge.go
@@ -2,6 +2,7 @@ package room
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/VoiceBlender/voiceblender/internal/bridge"
 )
@@ -63,6 +64,17 @@ type Bridge struct {
 	pid      string // synthetic participant id in both mixers
 }
 
+// bridgeParticipantPrefix marks a mixer participant as a synthetic bridge
+// endpoint rather than a leg. The mixer's participant map is not leg-only, so
+// teardown has to be able to tell the classes apart by ID.
+const bridgeParticipantPrefix = "__bridge:"
+
 func bridgeParticipantID(bridgeID string) string {
-	return "__bridge:" + bridgeID
+	return bridgeParticipantPrefix + bridgeID
+}
+
+// bridgeIDFromParticipant reports the bridge behind a synthetic bridge
+// participant ID, and whether participantID is one at all.
+func bridgeIDFromParticipant(participantID string) (string, bool) {
+	return strings.CutPrefix(participantID, bridgeParticipantPrefix)
 }

--- a/internal/room/manager.go
+++ b/internal/room/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"sync"
 
 	"github.com/VoiceBlender/voiceblender/internal/bridge"
@@ -98,6 +99,15 @@ func (m *Manager) Delete(id string) error {
 		wg.Add(1)
 		go func(l leg.Leg) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					m.log.Error("panic hanging up leg during room delete",
+						"leg_id", l.ID(),
+						"panic", r,
+						"stack", string(debug.Stack()),
+					)
+				}
+			}()
 			l.Hangup(context.Background())
 		}(l)
 	}

--- a/internal/room/manager.go
+++ b/internal/room/manager.go
@@ -45,10 +45,64 @@ func (m *Manager) Create(id, appID string, sampleRate int) (*Room, error) {
 	}
 
 	r := NewRoom(id, appID, sampleRate, m.log)
+	m.wireMixerPanicHook(r)
 	m.rooms[id] = r
 	m.log.Info("room created", "room_id", id, "sample_rate", r.SampleRate)
 	m.bus.Publish(events.RoomCreated, &events.RoomCreatedData{RoomScope: events.RoomScope{RoomID: id, AppID: appID}})
 	return r, nil
+}
+
+// wireMixerPanicHook makes the room's mixer report a participant whose IO
+// loop panicked, so the leg behind it is torn down instead of being left in
+// the room as a live-but-silent call. Must be called for every room the
+// manager owns, right after NewRoom.
+//
+// The hook fires on the panicking mixer goroutine holding no locks, but
+// Hangup blocks on a SIP BYE — so dispatch asynchronously and let that
+// goroutine exit, the same way Delete fans hangups out.
+func (m *Manager) wireMixerPanicHook(r *Room) {
+	roomID := r.ID
+	r.Mixer().SetOnParticipantPanic(func(participantID, loop string) {
+		go m.tearDownPanickedLeg(roomID, participantID, loop)
+	})
+}
+
+// tearDownPanickedLeg removes a leg whose mixer IO loop panicked from its
+// room and hangs it up. Further operation of that leg is unsafe: its audio
+// path is gone, so leaving it connected would strand the caller on a deaf,
+// mute call with no operator signal.
+func (m *Manager) tearDownPanickedLeg(roomID, legID, loop string) {
+	// This runs on its own goroutine, so a panic here — Hangup reaching into
+	// a wedged SIP stack, say — would take the process down. That is the exact
+	// failure this teardown exists to contain, so it must contain its own.
+	defer func() {
+		if r := recover(); r != nil {
+			m.log.Error("panic tearing down leg after mixer IO panic",
+				"room_id", roomID,
+				"leg_id", legID,
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
+		}
+	}()
+
+	m.log.Warn("tearing down leg after mixer IO panic",
+		"room_id", roomID,
+		"leg_id", legID,
+		"loop", loop,
+	)
+
+	// Removes the leg from the room and publishes leg.left_room.
+	if err := m.RemoveLeg(roomID, legID); err != nil {
+		m.log.Error("removing panicked leg from room",
+			"room_id", roomID, "leg_id", legID, "error", err)
+	}
+	if l, ok := m.legMgr.Get(legID); ok {
+		if err := l.Hangup(context.Background()); err != nil {
+			m.log.Error("hanging up panicked leg",
+				"room_id", roomID, "leg_id", legID, "error", err)
+		}
+	}
 }
 
 func (m *Manager) Get(id string) (*Room, bool) {
@@ -261,6 +315,7 @@ func (m *Manager) MoveLeg(fromRoomID, toRoomID, legID string) error {
 	toRoom, ok := m.rooms[toRoomID]
 	if !ok {
 		toRoom = NewRoom(toRoomID, "", fromRoom.SampleRate, m.log)
+		m.wireMixerPanicHook(toRoom)
 		m.rooms[toRoomID] = toRoom
 		m.bus.Publish(events.RoomCreated, &events.RoomCreatedData{RoomScope: events.RoomScope{RoomID: toRoomID, AppID: toRoom.AppID}})
 	}

--- a/internal/room/manager.go
+++ b/internal/room/manager.go
@@ -27,7 +27,7 @@ type Manager struct {
 	// following a mixer IO panic. hookMu guards it alone — never take it and
 	// m.mu together, and never call the hook under either.
 	hookMu             sync.Mutex
-	onLegPanicTeardown func(l leg.Leg, reason string)
+	onLegPanicTeardown func(l leg.Leg, roomID, reason string)
 }
 
 // legPanicReason is the disconnect reason reported for a leg torn down after
@@ -48,7 +48,11 @@ const legPanicReason = "mixer_panic"
 //
 // The manager holds no lock while invoking fn. fn runs on the teardown
 // goroutine inside its recover(), so a panicking callback is contained.
-func (m *Manager) SetOnLegPanicTeardown(fn func(l leg.Leg, reason string)) {
+//
+// fn receives the room the leg was removed from. The removal has already
+// cleared the leg's own RoomID, so the hook is the only place that still knows
+// it — without it the owner cannot run the room-scoped half of the teardown.
+func (m *Manager) SetOnLegPanicTeardown(fn func(l leg.Leg, roomID, reason string)) {
 	m.hookMu.Lock()
 	defer m.hookMu.Unlock()
 	m.onLegPanicTeardown = fn
@@ -56,7 +60,7 @@ func (m *Manager) SetOnLegPanicTeardown(fn func(l leg.Leg, reason string)) {
 
 // legPanicTeardownHook snapshots the hook under hookMu and returns it, so the
 // caller can invoke it with no lock held.
-func (m *Manager) legPanicTeardownHook() func(l leg.Leg, reason string) {
+func (m *Manager) legPanicTeardownHook() func(l leg.Leg, roomID, reason string) {
 	m.hookMu.Lock()
 	defer m.hookMu.Unlock()
 	return m.onLegPanicTeardown
@@ -218,10 +222,11 @@ func (m *Manager) tearDownPanickedLeg(roomID string, l leg.Leg, p *mixer.Partici
 
 	// Tell the owner, if one registered. RemoveLeg and Hangup above keep the
 	// room layer self-sufficient with no hook installed; the owner adds the
-	// leg-scoped teardown the room package cannot reach — the CDR, the span,
-	// the per-leg webhook and the leg manager entry.
+	// teardown the room package cannot reach — the CDR, the span, the per-leg
+	// webhook and the leg manager entry, plus the room-scoped cleanup that
+	// hangs off roomID (the room agent and the room recording).
 	if fn := m.legPanicTeardownHook(); fn != nil {
-		fn(l, legPanicReason)
+		fn(l, roomID, legPanicReason)
 	}
 }
 

--- a/internal/room/manager.go
+++ b/internal/room/manager.go
@@ -220,10 +220,10 @@ func (m *Manager) Delete(id string) error {
 		go func(l leg.Leg) {
 			defer wg.Done()
 			defer func() {
-				if r := recover(); r != nil {
+				if rec := recover(); rec != nil {
 					m.log.Error("panic hanging up leg during room delete",
 						"leg_id", l.ID(),
-						"panic", r,
+						"panic", rec,
 						"stack", string(debug.Stack()),
 					)
 				}

--- a/internal/room/manager.go
+++ b/internal/room/manager.go
@@ -21,6 +21,44 @@ type Manager struct {
 	legMgr  *leg.Manager
 	bus     *events.Bus
 	log     *slog.Logger
+
+	// onLegPanicTeardown, when set, is notified after a leg was torn down
+	// following a mixer IO panic. hookMu guards it alone — never take it and
+	// m.mu together, and never call the hook under either.
+	hookMu             sync.Mutex
+	onLegPanicTeardown func(l leg.Leg, reason string)
+}
+
+// legPanicReason is the disconnect reason reported for a leg torn down after
+// its mixer IO loop panicked. It reaches the wire as cdr.reason on
+// leg.disconnected, so it is a public value (documented in API.md).
+const legPanicReason = "mixer_panic"
+
+// SetOnLegPanicTeardown registers a callback invoked after a leg has been
+// removed from its room and hung up because its mixer IO loop panicked.
+// Passing nil disables it.
+//
+// This is NOT a general leg-termination notification: it fires on exactly one
+// path, tearDownPanickedLeg, and never for Delete, an API hangup or shutdown —
+// those have an API-layer caller already positioned to finish the job. The
+// mixer-panic teardown is the only leg-terminal path the room layer triggers
+// asynchronously by itself, which is why it needs the owner told. A future
+// room-side terminal path is NOT covered by this hook.
+//
+// The manager holds no lock while invoking fn. fn runs on the teardown
+// goroutine inside its recover(), so a panicking callback is contained.
+func (m *Manager) SetOnLegPanicTeardown(fn func(l leg.Leg, reason string)) {
+	m.hookMu.Lock()
+	defer m.hookMu.Unlock()
+	m.onLegPanicTeardown = fn
+}
+
+// legPanicTeardownHook snapshots the hook under hookMu and returns it, so the
+// caller can invoke it with no lock held.
+func (m *Manager) legPanicTeardownHook() func(l leg.Leg, reason string) {
+	m.hookMu.Lock()
+	defer m.hookMu.Unlock()
+	return m.onLegPanicTeardown
 }
 
 func NewManager(legMgr *leg.Manager, bus *events.Bus, log *slog.Logger) *Manager {
@@ -38,16 +76,27 @@ func (m *Manager) Create(id, appID string, sampleRate int) (*Room, error) {
 		id = uuid.New().String()
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if _, exists := m.rooms[id]; exists {
-		return nil, fmt.Errorf("room %s already exists", id)
-	}
-
+	// Built before the lock: NewRoom only allocates and the mixer starts no
+	// goroutines until a participant joins, so a candidate that loses the
+	// exists-check costs an allocation and nothing else. Wiring the panic hook
+	// out here also keeps Mixer.hookMu out of m.mu's lock order, and means the
+	// room is never reachable without its hook.
 	r := NewRoom(id, appID, sampleRate, m.log)
 	m.wireMixerPanicHook(r)
+
+	m.mu.Lock()
+	if _, exists := m.rooms[id]; exists {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("room %s already exists", id)
+	}
 	m.rooms[id] = r
+	m.mu.Unlock()
+
+	// Publish with m.mu released. Bus.Publish runs every handler synchronously
+	// on this goroutine and sync.RWMutex is not reentrant, so a subscriber that
+	// calls back into the manager — Get, List — would block forever. The insert
+	// above already happened, so the room is discoverable before the event
+	// announces it. Same shape as CreateBridge/DeleteBridge.
 	m.log.Info("room created", "room_id", id, "sample_rate", r.SampleRate)
 	m.bus.Publish(events.RoomCreated, &events.RoomCreatedData{RoomScope: events.RoomScope{RoomID: id, AppID: appID}})
 	return r, nil
@@ -137,6 +186,14 @@ func (m *Manager) tearDownPanickedLeg(roomID string, l leg.Leg, loop string) {
 	if err := l.Hangup(context.Background()); err != nil {
 		m.log.Error("hanging up panicked leg",
 			"room_id", roomID, "leg_id", legID, "error", err)
+	}
+
+	// Tell the owner, if one registered. RemoveLeg and Hangup above keep the
+	// room layer self-sufficient with no hook installed; the owner adds the
+	// leg-scoped teardown the room package cannot reach — the CDR, the span,
+	// the per-leg webhook and the leg manager entry.
+	if fn := m.legPanicTeardownHook(); fn != nil {
+		fn(l, legPanicReason)
 	}
 }
 
@@ -376,16 +433,32 @@ func (m *Manager) MoveLeg(fromRoomID, toRoomID, legID string) error {
 		return fmt.Errorf("room %s not found", fromRoomID)
 	}
 
-	// Get or create target room.
-	m.mu.Lock()
-	toRoom, ok := m.rooms[toRoomID]
+	// Get or create target room. Moving into a room that already exists is the
+	// common path, so take the read fast path first and only allocate on a
+	// miss; a candidate that loses the race below is safe to drop because
+	// nothing has been started on it.
+	toRoom, ok := m.Get(toRoomID)
+	created := false
 	if !ok {
-		toRoom = NewRoom(toRoomID, "", fromRoom.SampleRate, m.log)
-		m.wireMixerPanicHook(toRoom)
-		m.rooms[toRoomID] = toRoom
+		candidate := NewRoom(toRoomID, "", fromRoom.SampleRate, m.log)
+		m.wireMixerPanicHook(candidate)
+
+		m.mu.Lock()
+		// Re-check under the lock: without it, two concurrent moves into the
+		// same absent room would both insert and both publish room.created.
+		if toRoom, ok = m.rooms[toRoomID]; !ok {
+			toRoom = candidate
+			m.rooms[toRoomID] = candidate
+			created = true
+		}
+		m.mu.Unlock()
+	}
+	// Publish with m.mu released, for the reason Create documents. Only the
+	// goroutine that actually inserted publishes, which keeps room.created
+	// exactly-once.
+	if created {
 		m.bus.Publish(events.RoomCreated, &events.RoomCreatedData{RoomScope: events.RoomScope{RoomID: toRoomID, AppID: toRoom.AppID}})
 	}
-	m.mu.Unlock()
 
 	l, ok := fromRoom.DetachLeg(legID)
 	if !ok {

--- a/internal/room/manager.go
+++ b/internal/room/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/VoiceBlender/voiceblender/internal/bridge"
 	"github.com/VoiceBlender/voiceblender/internal/events"
 	"github.com/VoiceBlender/voiceblender/internal/leg"
+	"github.com/VoiceBlender/voiceblender/internal/mixer"
 	"github.com/google/uuid"
 )
 
@@ -115,8 +116,8 @@ func (m *Manager) Create(id, appID string, sampleRate int) (*Room, error) {
 // asynchronously, the same way Delete fans its hangups out.
 func (m *Manager) wireMixerPanicHook(r *Room) {
 	roomID := r.ID
-	r.Mixer().SetOnParticipantPanic(func(participantID, loop string) {
-		go m.tearDownPanickedParticipant(roomID, participantID, loop)
+	r.Mixer().SetOnParticipantPanic(func(p *mixer.Participant, loop string) {
+		go m.tearDownPanickedParticipant(roomID, p, loop)
 	})
 }
 
@@ -129,7 +130,9 @@ func (m *Manager) wireMixerPanicHook(r *Room) {
 // by something different. Treating every participant as a leg would fabricate
 // leg.left_room, a documented webhook, for IDs that were never legs, while
 // cleaning up nothing that actually leaked.
-func (m *Manager) tearDownPanickedParticipant(roomID, participantID, loop string) {
+func (m *Manager) tearDownPanickedParticipant(roomID string, p *mixer.Participant, loop string) {
+	participantID := p.ID
+
 	// This runs on its own goroutine, so a panic here — Hangup reaching into
 	// a wedged SIP stack, say — would take the process down. That is the exact
 	// failure this teardown exists to contain, so it must contain its own.
@@ -149,7 +152,7 @@ func (m *Manager) tearDownPanickedParticipant(roomID, participantID, loop string
 		return
 	}
 	if l, ok := m.legMgr.Get(participantID); ok {
-		m.tearDownPanickedLeg(roomID, l, loop)
+		m.tearDownPanickedLeg(roomID, l, p, loop)
 		return
 	}
 
@@ -170,19 +173,44 @@ func (m *Manager) tearDownPanickedParticipant(roomID, participantID, loop string
 // room and hangs it up. Further operation of that leg is unsafe: its audio
 // path is gone, so leaving it connected would strand the caller on a deaf,
 // mute call with no operator signal.
-func (m *Manager) tearDownPanickedLeg(roomID string, l leg.Leg, loop string) {
+//
+// p is the participant instance that panicked, and teardown is elected on it,
+// not on the leg's presence in roomID. This runs on its own goroutine, so the
+// leg may since have moved rooms, or left and returned to roomID, and be live
+// on a fresh participant; the leg would then still be a member here and a
+// membership-keyed election would hang up that healthy call and report it as
+// a mixer panic. RemoveLegIfParticipant resolves the identity and removes
+// under the room's lock in one step, so nothing lands in between.
+//
+// Removing nothing means the panicked path is already detached — by a move,
+// a room delete, or an API removal — and each of those owns its own teardown.
+// This path then does nothing at all: no hangup, no event, no hook.
+func (m *Manager) tearDownPanickedLeg(roomID string, l leg.Leg, p *mixer.Participant, loop string) {
 	legID := l.ID()
+
+	r, ok := m.Get(roomID)
+	if !ok {
+		m.log.Debug("room of panicked leg already deleted",
+			"room_id", roomID, "leg_id", legID)
+		return
+	}
+	if !r.RemoveLegIfParticipant(legID, p) {
+		m.log.Debug("panicked leg's audio path already replaced or detached",
+			"room_id", roomID, "leg_id", legID, "loop", loop)
+		return
+	}
+
 	m.log.Warn("tearing down leg after mixer IO panic",
 		"room_id", roomID,
 		"leg_id", legID,
 		"loop", loop,
 	)
 
-	// Removes the leg from the room and publishes leg.left_room.
-	if err := m.RemoveLeg(roomID, legID); err != nil {
-		m.log.Error("removing panicked leg from room",
-			"room_id", roomID, "leg_id", legID, "error", err)
-	}
+	// RemoveLegIfParticipant did the removal RemoveLeg would have; this is the
+	// event that goes with it.
+	m.bus.Publish(events.LegLeftRoom, &events.LegLeftRoomData{
+		LegRoomScope: events.LegRoomScope{LegID: legID, RoomID: roomID, AppID: l.AppID()},
+	})
 	if err := l.Hangup(context.Background()); err != nil {
 		m.log.Error("hanging up panicked leg",
 			"room_id", roomID, "leg_id", legID, "error", err)

--- a/internal/room/manager.go
+++ b/internal/room/manager.go
@@ -2,6 +2,7 @@ package room
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -53,39 +54,75 @@ func (m *Manager) Create(id, appID string, sampleRate int) (*Room, error) {
 }
 
 // wireMixerPanicHook makes the room's mixer report a participant whose IO
-// loop panicked, so the leg behind it is torn down instead of being left in
-// the room as a live-but-silent call. Must be called for every room the
-// manager owns, right after NewRoom.
+// loop panicked, so whoever owns that participant can tear it down instead of
+// leaving a dead audio path wired into a live room. Must be called for every
+// room the manager owns, right after NewRoom.
 //
-// The hook fires on the panicking mixer goroutine holding no locks, but
-// Hangup blocks on a SIP BYE — so dispatch asynchronously and let that
-// goroutine exit, the same way Delete fans hangups out.
+// The hook fires on the panicking mixer goroutine as its last act before that
+// goroutine exits, so teardown must not run inline: RemoveLeg and DeleteBridge
+// publish on the bus, and WhatsAppLeg.Hangup hands ctx straight to Bye and can
+// block on a non-responsive peer. (SIPLeg.Hangup returns immediately — its BYE
+// is fire-and-forget — but it is not the only implementation.) Dispatch
+// asynchronously, the same way Delete fans its hangups out.
 func (m *Manager) wireMixerPanicHook(r *Room) {
 	roomID := r.ID
 	r.Mixer().SetOnParticipantPanic(func(participantID, loop string) {
-		go m.tearDownPanickedLeg(roomID, participantID, loop)
+		go m.tearDownPanickedParticipant(roomID, participantID, loop)
 	})
+}
+
+// tearDownPanickedParticipant routes a panicking mixer participant to the
+// component that owns it.
+//
+// The mixer's participant map is not leg-only: synthetic bridge endpoints
+// (attachBridge) and the API layer's WebSocket, agent, playback and TTS
+// sources all register there too, and each class is owned — and cleaned up —
+// by something different. Treating every participant as a leg would fabricate
+// leg.left_room, a documented webhook, for IDs that were never legs, while
+// cleaning up nothing that actually leaked.
+func (m *Manager) tearDownPanickedParticipant(roomID, participantID, loop string) {
+	// This runs on its own goroutine, so a panic here — Hangup reaching into
+	// a wedged SIP stack, say — would take the process down. That is the exact
+	// failure this teardown exists to contain, so it must contain its own.
+	defer func() {
+		if rec := recover(); rec != nil {
+			m.log.Error("panic tearing down panicked mixer participant",
+				"room_id", roomID,
+				"participant_id", participantID,
+				"panic", rec,
+				"stack", string(debug.Stack()),
+			)
+		}
+	}()
+
+	if bridgeID, ok := bridgeIDFromParticipant(participantID); ok {
+		m.tearDownPanickedBridge(roomID, bridgeID, loop)
+		return
+	}
+	if l, ok := m.legMgr.Get(participantID); ok {
+		m.tearDownPanickedLeg(roomID, l, loop)
+		return
+	}
+
+	// A ws/agent/playback/TTS source: owned by the API layer, which the room
+	// package cannot call into. The mixer has already closed the participant's
+	// reader and writer, which is what unblocks those owners — a closed egress
+	// pipe drops a ws client's send loop, a closed playback pipe fails the
+	// player's next write — so each runs its own cleanup and publishes its own
+	// event. There is nothing for the room layer to remove or hang up.
+	m.log.Warn("mixer participant panicked; no leg or bridge owns it",
+		"room_id", roomID,
+		"participant_id", participantID,
+		"loop", loop,
+	)
 }
 
 // tearDownPanickedLeg removes a leg whose mixer IO loop panicked from its
 // room and hangs it up. Further operation of that leg is unsafe: its audio
 // path is gone, so leaving it connected would strand the caller on a deaf,
 // mute call with no operator signal.
-func (m *Manager) tearDownPanickedLeg(roomID, legID, loop string) {
-	// This runs on its own goroutine, so a panic here — Hangup reaching into
-	// a wedged SIP stack, say — would take the process down. That is the exact
-	// failure this teardown exists to contain, so it must contain its own.
-	defer func() {
-		if r := recover(); r != nil {
-			m.log.Error("panic tearing down leg after mixer IO panic",
-				"room_id", roomID,
-				"leg_id", legID,
-				"panic", r,
-				"stack", string(debug.Stack()),
-			)
-		}
-	}()
-
+func (m *Manager) tearDownPanickedLeg(roomID string, l leg.Leg, loop string) {
+	legID := l.ID()
 	m.log.Warn("tearing down leg after mixer IO panic",
 		"room_id", roomID,
 		"leg_id", legID,
@@ -97,11 +134,40 @@ func (m *Manager) tearDownPanickedLeg(roomID, legID, loop string) {
 		m.log.Error("removing panicked leg from room",
 			"room_id", roomID, "leg_id", legID, "error", err)
 	}
-	if l, ok := m.legMgr.Get(legID); ok {
-		if err := l.Hangup(context.Background()); err != nil {
-			m.log.Error("hanging up panicked leg",
-				"room_id", roomID, "leg_id", legID, "error", err)
-		}
+	if err := l.Hangup(context.Background()); err != nil {
+		m.log.Error("hanging up panicked leg",
+			"room_id", roomID, "leg_id", legID, "error", err)
+	}
+}
+
+// tearDownPanickedBridge tears down the whole bridge behind a panicking
+// synthetic bridge participant.
+//
+// Letting the mixer drop the participant is not enough: only detachBridge
+// decrements the room's bridgeRefs, so a dead endpoint would keep
+// mixerShouldRun() true and this room's mixer ticking forever behind an
+// endpoint nobody reads, and the peer room would keep pushing audio into a
+// conduit with no far side. DeleteBridge does the whole job — deregister,
+// detach from both rooms, close both endpoints, publish room.unbridged — and
+// its registry delete is the exactly-once gate for the case where both
+// endpoints panic at once.
+func (m *Manager) tearDownPanickedBridge(roomID, bridgeID, loop string) {
+	m.log.Warn("tearing down bridge after mixer IO panic",
+		"room_id", roomID,
+		"bridge_id", bridgeID,
+		"loop", loop,
+	)
+
+	err := m.DeleteBridge(bridgeID)
+	switch {
+	case err == nil:
+	case errors.Is(err, ErrBridgeNotFound):
+		// The peer endpoint's panic, or a concurrent delete, got there first.
+		m.log.Debug("panicked bridge already torn down",
+			"room_id", roomID, "bridge_id", bridgeID)
+	default:
+		m.log.Error("deleting panicked bridge",
+			"room_id", roomID, "bridge_id", bridgeID, "error", err)
 	}
 }
 

--- a/internal/room/manager_stale_teardown_test.go
+++ b/internal/room/manager_stale_teardown_test.go
@@ -1,0 +1,245 @@
+package room
+
+import (
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+	"github.com/VoiceBlender/voiceblender/internal/leg"
+	"github.com/VoiceBlender/voiceblender/internal/mixer"
+)
+
+// addHealthyLeg joins a leg whose audio path never fails: its reader blocks
+// until the pipe is written to, so the mixer's readLoop simply parks there.
+func addHealthyLeg(t *testing.T, mgr *Manager, legMgr *leg.Manager, roomID, legID string) *mockLeg {
+	t.Helper()
+	pr, pw := io.Pipe()
+	t.Cleanup(func() { pw.Close() })
+
+	l := newMockLeg(legID)
+	l.reader = pr
+	l.writer = io.Discard
+	legMgr.Add(l)
+	if err := mgr.AddLeg(roomID, legID); err != nil {
+		t.Fatalf("AddLeg: %v", err)
+	}
+	return l
+}
+
+// anchorRoom parks a permanent leg in roomID. The room's mixer is stopped
+// whenever the room empties and restarted when it refills, and a restart
+// reassigns Mixer.stopCh under a lock readLoop does not take — an unrelated
+// pre-existing race the detector trips over. Keeping one leg resident the
+// whole test keeps the mixer running so these tests exercise their own
+// subject rather than that.
+func anchorRoom(t *testing.T, mgr *Manager, legMgr *leg.Manager, roomID string) {
+	t.Helper()
+	addHealthyLeg(t, mgr, legMgr, roomID, "anchor-"+roomID)
+}
+
+// hasLeg reports whether legID is currently a member of r.
+func hasLeg(r *Room, legID string) bool {
+	for _, l := range r.Participants() {
+		if l.ID() == legID {
+			return true
+		}
+	}
+	return false
+}
+
+// legParticipant returns the mixer instance currently carrying legID's audio.
+func legParticipant(t *testing.T, r *Room, legID string) *mixer.Participant {
+	t.Helper()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.legParts[legID]
+	if !ok {
+		t.Fatalf("no mixer participant recorded for leg %s in room %s", legID, r.ID)
+	}
+	return p
+}
+
+// leftRoomCounter counts leg.left_room events per room.
+type leftRoomCounter struct {
+	mu sync.Mutex
+	n  map[string]int
+}
+
+func newLeftRoomCounter(bus *events.Bus) *leftRoomCounter {
+	c := &leftRoomCounter{n: map[string]int{}}
+	bus.Subscribe(func(e events.Event) {
+		if e.Type != events.LegLeftRoom {
+			return
+		}
+		d, ok := e.Data.(*events.LegLeftRoomData)
+		if !ok {
+			return
+		}
+		c.mu.Lock()
+		c.n[d.RoomID]++
+		c.mu.Unlock()
+	})
+	return c
+}
+
+func (c *leftRoomCounter) count(roomID string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.n[roomID]
+}
+
+// TestManager_StalePanicTeardownSparesLegThatLeftAndReturned pins the election
+// tearDownPanickedLeg makes.
+//
+// The teardown runs on a goroutine dispatched by the panicking mixer loop, so
+// it can be scheduled arbitrarily late. In that window a leg can leave r1 and
+// come back to it, landing on a fresh mixer participant over a live ingress.
+// The leg is then a member of r1 again — so an election keyed on room
+// membership ("the leg is still here, tear it down") hangs up a healthy call
+// and reports cdr.reason=mixer_panic for it. Only the participant instance
+// separates the dead path from the replacement.
+//
+// Invoking tearDownPanickedParticipant directly is what makes the late
+// scheduling deterministic. It is the same function wireMixerPanicHook
+// dispatches, with the same arguments.
+func TestManager_StalePanicTeardownSparesLegThatLeftAndReturned(t *testing.T) {
+	bus := newTestBus()
+	left := newLeftRoomCounter(bus)
+
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, bus, newTestLog())
+	var notified int
+	mgr.SetOnLegPanicTeardown(func(l leg.Leg, reason string) { notified++ })
+
+	for _, id := range []string{"r1", "r2"} {
+		if _, err := mgr.Create(id, "", 0); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+	r1, _ := mgr.Get("r1")
+	anchorRoom(t, mgr, legMgr, "r1")
+	anchorRoom(t, mgr, legMgr, "r2")
+
+	l := addHealthyLeg(t, mgr, legMgr, "r1", "leg-1")
+
+	// The instance that panics. Everything below happens before the teardown
+	// it scheduled gets to run.
+	pOld := legParticipant(t, r1, "leg-1")
+
+	if err := mgr.MoveLeg("r1", "r2", "leg-1"); err != nil {
+		t.Fatalf("MoveLeg r1->r2: %v", err)
+	}
+	if err := mgr.MoveLeg("r2", "r1", "leg-1"); err != nil {
+		t.Fatalf("MoveLeg r2->r1: %v", err)
+	}
+
+	pNew := legParticipant(t, r1, "leg-1")
+	if pNew == pOld {
+		t.Fatal("returning to r1 did not mint a fresh mixer participant; the test proves nothing")
+	}
+	if got := left.count("r1"); got != 1 {
+		t.Fatalf("leg.left_room for r1 before teardown = %d, want 1 (the move out)", got)
+	}
+
+	// The stale teardown finally lands.
+	mgr.tearDownPanickedParticipant("r1", pOld, "readLoop")
+
+	if l.hungUp.Load() {
+		t.Error("stale teardown hung up a leg that is live in r1 on a fresh participant")
+	}
+	if got := left.count("r1"); got != 1 {
+		t.Errorf("leg.left_room for r1 = %d, want 1; the stale teardown published a duplicate for a leg that never left", got)
+	}
+	if notified != 0 {
+		t.Errorf("owner notified %d times, want 0; a live leg was reported as %s", notified, legPanicReason)
+	}
+	if !hasLeg(r1, "leg-1") {
+		t.Error("the stale teardown evicted the live leg from r1")
+	}
+	if l.RoomID() != "r1" {
+		t.Errorf("leg room = %q, want r1", l.RoomID())
+	}
+	if legParticipant(t, r1, "leg-1") != pNew {
+		t.Error("the live leg's mixer participant was replaced or dropped by the stale teardown")
+	}
+}
+
+// TestManager_StalePanicTeardownSparesMovedLeg is the same hazard without the
+// return trip: the leg is live in r2 when r1's teardown lands. r1 must not
+// reach across and hang it up, nor publish a leg.left_room for a room the leg
+// has already left.
+func TestManager_StalePanicTeardownSparesMovedLeg(t *testing.T) {
+	bus := newTestBus()
+	left := newLeftRoomCounter(bus)
+
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, bus, newTestLog())
+
+	for _, id := range []string{"r1", "r2"} {
+		if _, err := mgr.Create(id, "", 0); err != nil {
+			t.Fatalf("Create %s: %v", id, err)
+		}
+	}
+	r1, _ := mgr.Get("r1")
+	r2, _ := mgr.Get("r2")
+	anchorRoom(t, mgr, legMgr, "r1")
+	anchorRoom(t, mgr, legMgr, "r2")
+
+	l := addHealthyLeg(t, mgr, legMgr, "r1", "leg-1")
+	pOld := legParticipant(t, r1, "leg-1")
+
+	if err := mgr.MoveLeg("r1", "r2", "leg-1"); err != nil {
+		t.Fatalf("MoveLeg r1->r2: %v", err)
+	}
+
+	mgr.tearDownPanickedParticipant("r1", pOld, "readLoop")
+
+	if l.hungUp.Load() {
+		t.Error("stale teardown in r1 hung up a leg that is live in r2")
+	}
+	if got := left.count("r1"); got != 1 {
+		t.Errorf("leg.left_room for r1 = %d, want 1 (the move out only)", got)
+	}
+	if !hasLeg(r2, "leg-1") {
+		t.Error("r1's stale teardown evicted the leg from r2")
+	}
+}
+
+// TestManager_PanicTeardownStillTearsDownTheLiveInstance is the other side of
+// the election: when the participant that panicked is still the leg's audio
+// path, teardown must happen in full. An identity check that spared everything
+// would pass the tests above while leaving a deaf, mute call connected.
+func TestManager_PanicTeardownStillTearsDownTheLiveInstance(t *testing.T) {
+	bus := newTestBus()
+	left := newLeftRoomCounter(bus)
+
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, bus, newTestLog())
+	var notified []string
+	mgr.SetOnLegPanicTeardown(func(l leg.Leg, reason string) { notified = append(notified, reason) })
+
+	if _, err := mgr.Create("r1", "", 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	r1, _ := mgr.Get("r1")
+	anchorRoom(t, mgr, legMgr, "r1")
+
+	l := addHealthyLeg(t, mgr, legMgr, "r1", "leg-1")
+	p := legParticipant(t, r1, "leg-1")
+
+	mgr.tearDownPanickedParticipant("r1", p, "readLoop")
+
+	if !l.hungUp.Load() {
+		t.Error("the panicked leg's live instance was not hung up")
+	}
+	if got := left.count("r1"); got != 1 {
+		t.Errorf("leg.left_room for r1 = %d, want 1", got)
+	}
+	if hasLeg(r1, "leg-1") {
+		t.Error("the panicked leg is still a member of r1")
+	}
+	if len(notified) != 1 || notified[0] != legPanicReason {
+		t.Errorf("owner notifications = %v, want exactly one %q", notified, legPanicReason)
+	}
+}

--- a/internal/room/manager_stale_teardown_test.go
+++ b/internal/room/manager_stale_teardown_test.go
@@ -110,7 +110,7 @@ func TestManager_StalePanicTeardownSparesLegThatLeftAndReturned(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, bus, newTestLog())
 	var notified int
-	mgr.SetOnLegPanicTeardown(func(l leg.Leg, reason string) { notified++ })
+	mgr.SetOnLegPanicTeardown(func(l leg.Leg, roomID, reason string) { notified++ })
 
 	for _, id := range []string{"r1", "r2"} {
 		if _, err := mgr.Create(id, "", 0); err != nil {
@@ -217,7 +217,7 @@ func TestManager_PanicTeardownStillTearsDownTheLiveInstance(t *testing.T) {
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, bus, newTestLog())
 	var notified []string
-	mgr.SetOnLegPanicTeardown(func(l leg.Leg, reason string) { notified = append(notified, reason) })
+	mgr.SetOnLegPanicTeardown(func(l leg.Leg, roomID, reason string) { notified = append(notified, reason) })
 
 	if _, err := mgr.Create("r1", "", 0); err != nil {
 		t.Fatalf("Create: %v", err)

--- a/internal/room/manager_test.go
+++ b/internal/room/manager_test.go
@@ -3,6 +3,7 @@ package room
 import (
 	"errors"
 	"io"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -85,6 +86,39 @@ func TestManager_MixerParticipantPanicTearsDownLeg(t *testing.T) {
 			}
 		}
 		return false
+	})
+}
+
+// TestManager_PanickedLegTeardownGoroutineExits asserts the hook's teardown
+// goroutine actually returns. It is the only goroutine the panic path spawns,
+// and nothing else in this package observes its exit: mockLeg.Hangup records
+// hungUp on entry, so waiting on that proves the goroutine started, not that
+// it finished.
+func TestManager_PanickedLegTeardownGoroutineExits(t *testing.T) {
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, newTestBus(), newTestLog())
+	if _, err := mgr.Create("r1", "", 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Let the room settle before sampling, so the baseline does not include
+	// goroutines that are still winding up.
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	l := addPanickingLeg(t, mgr, legMgr, "r1", "leg-1")
+
+	r, _ := mgr.Get("r1")
+	waitFor(t, 2*time.Second, "panicked leg removed from the room", func() bool {
+		return r.ParticipantCount() == 0
+	})
+	waitFor(t, 2*time.Second, "panicked leg hung up", func() bool {
+		return l.hungUp.Load()
+	})
+	// Generous, because the room's mixLoop is also winding down via
+	// syncMixerLocked; a bare assertion here would be flaky.
+	waitFor(t, 2*time.Second, "teardown goroutine to exit", func() bool {
+		return runtime.NumGoroutine() <= before
 	})
 }
 

--- a/internal/room/manager_test.go
+++ b/internal/room/manager_test.go
@@ -1,11 +1,160 @@
 package room
 
 import (
+	"io"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/VoiceBlender/voiceblender/internal/events"
 	"github.com/VoiceBlender/voiceblender/internal/leg"
 )
+
+// panicReader panics on its first Read, simulating a leg whose inbound audio
+// path blows up inside the mixer's readLoop.
+type panicReader struct{}
+
+func (panicReader) Read(p []byte) (int, error) { panic("simulated read panic") }
+
+// waitFor polls cond until it is true or the timeout elapses.
+func waitFor(t *testing.T, timeout time.Duration, msg string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for: %s", msg)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// addPanickingLeg registers a leg whose mixer readLoop panics on the first
+// frame and joins it to roomID.
+func addPanickingLeg(t *testing.T, mgr *Manager, legMgr *leg.Manager, roomID, legID string) *mockLeg {
+	t.Helper()
+	l := newMockLeg(legID)
+	l.reader = panicReader{}
+	l.writer = io.Discard
+	legMgr.Add(l)
+	if err := mgr.AddLeg(roomID, legID); err != nil {
+		t.Fatalf("AddLeg: %v", err)
+	}
+	return l
+}
+
+// TestManager_MixerParticipantPanicTearsDownLeg verifies the mixer's
+// participant-panic hook is wired to real room teardown. Removing the
+// participant from the mixer alone would leave a live SIP call connected but
+// permanently deaf and mute, with no operator signal — so the leg must also
+// leave the room, publish leg.left_room, and be hung up.
+func TestManager_MixerParticipantPanicTearsDownLeg(t *testing.T) {
+	bus := newTestBus()
+	var mu sync.Mutex
+	var eventTypes []events.EventType
+	bus.Subscribe(func(e events.Event) {
+		mu.Lock()
+		eventTypes = append(eventTypes, e.Type)
+		mu.Unlock()
+	})
+
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, bus, newTestLog())
+	if _, err := mgr.Create("r1", "", 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	l := addPanickingLeg(t, mgr, legMgr, "r1", "leg-1")
+
+	r, _ := mgr.Get("r1")
+	waitFor(t, 2*time.Second, "panicked leg removed from the room", func() bool {
+		return r.ParticipantCount() == 0
+	})
+	waitFor(t, 2*time.Second, "panicked leg hung up", func() bool {
+		return l.hungUp.Load()
+	})
+	waitFor(t, 2*time.Second, "leg.left_room published for the panicked leg", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, et := range eventTypes {
+			if et == events.LegLeftRoom {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// TestManager_MixerParticipantPanicHangupPanicDoesNotCrash verifies the
+// teardown goroutine contains its own panics. It is spawned by the hook, so
+// a panic inside Hangup would take the process down — the exact failure this
+// teardown exists to prevent.
+func TestManager_MixerParticipantPanicHangupPanicDoesNotCrash(t *testing.T) {
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, newTestBus(), newTestLog())
+	if _, err := mgr.Create("r1", "", 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	l := newMockLeg("leg-1")
+	l.reader = panicReader{}
+	l.writer = io.Discard
+	l.panicOnHangup = true
+	legMgr.Add(l)
+	if err := mgr.AddLeg("r1", "leg-1"); err != nil {
+		t.Fatalf("AddLeg: %v", err)
+	}
+
+	r, _ := mgr.Get("r1")
+	waitFor(t, 2*time.Second, "panicked leg removed from the room", func() bool {
+		return r.ParticipantCount() == 0
+	})
+	waitFor(t, 2*time.Second, "hangup attempted on the panicked leg", func() bool {
+		return l.hungUp.Load()
+	})
+
+	// Reaching here at all means the recover held: the panic from Hangup ran
+	// on the teardown goroutine, where an escape would have killed the test
+	// binary rather than failed this test.
+	time.Sleep(100 * time.Millisecond)
+}
+
+// TestManager_MoveLegWiresMixerPanicHook guards the second NewRoom site: a
+// room created implicitly by MoveLeg must get the same panic teardown as one
+// created through Create.
+func TestManager_MoveLegWiresMixerPanicHook(t *testing.T) {
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, newTestBus(), newTestLog())
+	if _, err := mgr.Create("r1", "", 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// A non-panicking leg to move, so "r2" is created by the move path.
+	mover := newMockLeg("mover")
+	legMgr.Add(mover)
+	if err := mgr.AddLeg("r1", "mover"); err != nil {
+		t.Fatalf("AddLeg: %v", err)
+	}
+	if err := mgr.MoveLeg("r1", "r2", "mover"); err != nil {
+		t.Fatalf("MoveLeg: %v", err)
+	}
+
+	r2, ok := mgr.Get("r2")
+	if !ok {
+		t.Fatal("expected r2 to exist after MoveLeg")
+	}
+
+	l := addPanickingLeg(t, mgr, legMgr, "r2", "leg-1")
+
+	waitFor(t, 2*time.Second, "panicked leg torn down in the move-created room", func() bool {
+		return l.hungUp.Load()
+	})
+	if r2.ParticipantCount() != 1 {
+		t.Errorf("r2 count = %d, want 1 (only the mover left)", r2.ParticipantCount())
+	}
+}
 
 // TestManager_DeletePanickingLegDoesNotCrash verifies that a panic inside
 // one leg's Hangup during the room-delete fan-out is recovered rather than

--- a/internal/room/manager_test.go
+++ b/internal/room/manager_test.go
@@ -1,6 +1,7 @@
 package room
 
 import (
+	"errors"
 	"io"
 	"sync"
 	"testing"
@@ -85,6 +86,118 @@ func TestManager_MixerParticipantPanicTearsDownLeg(t *testing.T) {
 		}
 		return false
 	})
+}
+
+// TestManager_NonLegParticipantPanicPublishesNothing pins the gate on the
+// panic hook's leg assumption. Exactly one of the mixer's production
+// registration sites registers a leg; the rest are bridge endpoints and the
+// API layer's ws/agent/playback/TTS sources. Treating a panicking playback
+// source as a leg would publish leg.left_room — a documented webhook — naming
+// an ID that was never a leg and never in the room, while removing and hanging
+// up nothing at all.
+func TestManager_NonLegParticipantPanicPublishesNothing(t *testing.T) {
+	bus := newTestBus()
+	var mu sync.Mutex
+	var eventTypes []events.EventType
+	bus.Subscribe(func(e events.Event) {
+		mu.Lock()
+		eventTypes = append(eventTypes, e.Type)
+		mu.Unlock()
+	})
+
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, bus, newTestLog())
+	if _, err := mgr.Create("r1", "", 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	r, _ := mgr.Get("r1")
+
+	// A room playback source, not a leg: "pb-1" is unknown to the leg manager.
+	r.Mixer().AddPlaybackSource("pb-1", panicReader{})
+	r.Mixer().Start()
+	defer r.Mixer().Stop()
+
+	waitFor(t, 2*time.Second, "panicked playback source removed from the mixer", func() bool {
+		return r.Mixer().ParticipantCount() == 0
+	})
+
+	// Let the teardown goroutine run to completion; the publish, if it were
+	// coming, happens on that goroutine after the mixer removal above.
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, et := range eventTypes {
+		if et == events.LegLeftRoom {
+			t.Fatal("leg.left_room published for a playback source that was never a leg")
+		}
+	}
+}
+
+// TestManager_BridgeParticipantPanicTearsDownBridge pins the bridge arm of the
+// panic dispatch. Dropping the participant from this room's mixer is only a
+// fraction of the job: bridgeRefs is decremented solely by detachBridge, so a
+// dead endpoint otherwise keeps mixerShouldRun() true and this room's mixer
+// ticking forever, leaves the bridge in the registry, and strands the peer room
+// writing into a conduit with no far side.
+//
+// The panicking reader stands in for the conduit endpoint's Read blowing up:
+// registering it under the bridge's participant ID is what makes the mixer's
+// real hook fire with a bridge-classed ID.
+func TestManager_BridgeParticipantPanicTearsDownBridge(t *testing.T) {
+	mgr, bus := newBridgeTestManager(t)
+	got, mu := collectEvents(bus)
+	mgr.Create("a", "", 16000)
+	mgr.Create("b", "", 16000)
+	br, err := mgr.CreateBridge("br1", "a", "b", DirectionBidirectional)
+	if err != nil {
+		t.Fatalf("CreateBridge: %v", err)
+	}
+
+	ra, _ := mgr.Get("a")
+	rb, _ := mgr.Get("b")
+	ra.Mixer().AddPlaybackSource(bridgeParticipantID("br1"), panicReader{})
+
+	waitFor(t, 2*time.Second, "panicked bridge deregistered", func() bool {
+		_, ok := mgr.GetBridge("br1")
+		return !ok
+	})
+	waitFor(t, 2*time.Second, "both rooms' mixers to stop after the bridge died", func() bool {
+		ra.mu.RLock()
+		rb.mu.RLock()
+		defer ra.mu.RUnlock()
+		defer rb.mu.RUnlock()
+		return !ra.mixerRunning && !rb.mixerRunning
+	})
+
+	ra.mu.RLock()
+	refsA := ra.bridgeRefs
+	ra.mu.RUnlock()
+	rb.mu.RLock()
+	refsB := rb.bridgeRefs
+	rb.mu.RUnlock()
+	if refsA != 0 || refsB != 0 {
+		t.Errorf("bridgeRefs after panic teardown = (a:%d, b:%d), want (0, 0) — the mixers tick forever otherwise", refsA, refsB)
+	}
+
+	if _, err := br.epA.Write([]byte{0, 0}); !errors.Is(err, io.ErrClosedPipe) {
+		t.Errorf("conduit endpoint should be closed after panic teardown, Write err = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var sawUnbridged bool
+	for _, e := range *got {
+		if e.Type == events.RoomUnbridged {
+			sawUnbridged = true
+		}
+		if e.Type == events.LegLeftRoom {
+			t.Error("leg.left_room published for a bridge endpoint that was never a leg")
+		}
+	}
+	if !sawUnbridged {
+		t.Error("expected room.unbridged when a bridge endpoint's IO panicked")
+	}
 }
 
 // TestManager_MixerParticipantPanicHangupPanicDoesNotCrash verifies the

--- a/internal/room/manager_test.go
+++ b/internal/room/manager_test.go
@@ -1,0 +1,52 @@
+package room
+
+import (
+	"testing"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+	"github.com/VoiceBlender/voiceblender/internal/leg"
+)
+
+// TestManager_DeletePanickingLegDoesNotCrash verifies that a panic inside
+// one leg's Hangup during the room-delete fan-out is recovered rather than
+// crashing the process: Delete still returns (wg completes), the room is
+// removed from the map, and RoomDeleted still publishes.
+func TestManager_DeletePanickingLegDoesNotCrash(t *testing.T) {
+	bus := newTestBus()
+	var eventTypes []events.EventType
+	bus.Subscribe(func(e events.Event) {
+		eventTypes = append(eventTypes, e.Type)
+	})
+
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, bus, newTestLog())
+
+	r, err := mgr.Create("r1", "", 0)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	good := newMockLeg("good")
+	bad := newMockLeg("bad")
+	bad.panicOnHangup = true
+	r.AddLeg(good)
+	r.AddLeg(bad)
+
+	if err := mgr.Delete("r1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, ok := mgr.Get("r1"); ok {
+		t.Error("room should be deleted")
+	}
+
+	found := false
+	for _, et := range eventTypes {
+		if et == events.RoomDeleted {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected room.deleted event after a panicking leg hangup")
+	}
+}

--- a/internal/room/manager_test.go
+++ b/internal/room/manager_test.go
@@ -449,55 +449,85 @@ func TestManager_MoveLegDoesNotHoldLockWhilePublishing(t *testing.T) {
 // concurrent moves into the same absent room must announce it exactly once —
 // the guarantee the old lock-around-everything gave, which the fix has to keep
 // by other means.
+//
+// The get-or-create window this races on is only a few hundred nanoseconds
+// wide (NewRoom plus the Lock), so one round catches a regression maybe one
+// time in five on a loaded machine. Rounds are repeated to make the guard
+// dependable rather than decorative: an unguarded insert is caught on every
+// observed run.
 func TestManager_MoveLegConcurrentCreatePublishesOnce(t *testing.T) {
+	const (
+		rounds = 150
+		movers = 4
+	)
+
 	bus := newTestBus()
 	legMgr := leg.NewManager()
 	mgr := NewManager(legMgr, bus, newTestLog())
 
-	const movers = 8
-	for i := 0; i < movers; i++ {
-		src := fmt.Sprintf("from-%d", i)
-		if _, err := mgr.Create(src, "", 0); err != nil {
-			t.Fatalf("Create %s: %v", src, err)
-		}
-		l := newMockLeg(fmt.Sprintf("leg-%d", i))
-		legMgr.Add(l)
-		if err := mgr.AddLeg(src, l.ID()); err != nil {
-			t.Fatalf("AddLeg: %v", err)
+	srcRoom := func(r, i int) string { return fmt.Sprintf("from-%d-%d", r, i) }
+	legID := func(r, i int) string { return fmt.Sprintf("leg-%d-%d", r, i) }
+	target := func(r int) string { return fmt.Sprintf("to-%d", r) }
+
+	for r := 0; r < rounds; r++ {
+		for i := 0; i < movers; i++ {
+			if _, err := mgr.Create(srcRoom(r, i), "", 0); err != nil {
+				t.Fatalf("Create %s: %v", srcRoom(r, i), err)
+			}
+			l := newMockLeg(legID(r, i))
+			legMgr.Add(l)
+			if err := mgr.AddLeg(srcRoom(r, i), l.ID()); err != nil {
+				t.Fatalf("AddLeg: %v", err)
+			}
 		}
 	}
 
+	// Subscribed after the fixture, so only the targets' room.created is seen.
 	var mu sync.Mutex
-	targetCreated := 0
+	created := map[string]int{}
 	bus.Subscribe(func(e events.Event) {
 		d, ok := e.Data.(*events.RoomCreatedData)
-		if !ok || e.Type != events.RoomCreated || d.RoomID != "to" {
+		if !ok || e.Type != events.RoomCreated {
 			return
 		}
 		mu.Lock()
-		targetCreated++
+		created[d.RoomID]++
 		mu.Unlock()
 	})
 
-	start := make(chan struct{})
-	var wg sync.WaitGroup
-	for i := 0; i < movers; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			<-start
-			if err := mgr.MoveLeg(fmt.Sprintf("from-%d", i), "to", fmt.Sprintf("leg-%d", i)); err != nil {
-				t.Errorf("MoveLeg: %v", err)
-			}
-		}(i)
+	for r := 0; r < rounds; r++ {
+		// Spin barrier, not a channel close: waking N goroutines off a closed
+		// channel lets the runtime release them one at a time, and the first
+		// can finish its whole move before the last wakes, so the window never
+		// overlaps. Spinning keeps every mover hot on its own P.
+		var ready sync.WaitGroup
+		var gate atomic.Bool
+		var wg sync.WaitGroup
+		ready.Add(movers)
+		for i := 0; i < movers; i++ {
+			wg.Add(1)
+			go func(r, i int) {
+				defer wg.Done()
+				ready.Done()
+				for !gate.Load() {
+					runtime.Gosched()
+				}
+				if err := mgr.MoveLeg(srcRoom(r, i), target(r), legID(r, i)); err != nil {
+					t.Errorf("MoveLeg: %v", err)
+				}
+			}(r, i)
+		}
+		ready.Wait()
+		gate.Store(true)
+		wg.Wait()
 	}
-	close(start)
-	wg.Wait()
 
 	mu.Lock()
 	defer mu.Unlock()
-	if targetCreated != 1 {
-		t.Fatalf("room.created for target published %d times, want exactly 1", targetCreated)
+	for r := 0; r < rounds; r++ {
+		if n := created[target(r)]; n != 1 {
+			t.Fatalf("room.created for %s published %d times, want exactly 1", target(r), n)
+		}
 	}
 }
 

--- a/internal/room/manager_test.go
+++ b/internal/room/manager_test.go
@@ -543,13 +543,14 @@ func TestManager_PanickedLegNotifiesOwner(t *testing.T) {
 
 	type notice struct {
 		leg    leg.Leg
+		roomID string
 		reason string
 	}
 	var mu sync.Mutex
 	var notices []notice
-	mgr.SetOnLegPanicTeardown(func(l leg.Leg, reason string) {
+	mgr.SetOnLegPanicTeardown(func(l leg.Leg, roomID, reason string) {
 		mu.Lock()
-		notices = append(notices, notice{leg: l, reason: reason})
+		notices = append(notices, notice{leg: l, roomID: roomID, reason: reason})
 		mu.Unlock()
 	})
 

--- a/internal/room/manager_test.go
+++ b/internal/room/manager_test.go
@@ -2,9 +2,11 @@ package room
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -344,5 +346,209 @@ func TestManager_DeletePanickingLegDoesNotCrash(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected room.deleted event after a panicking leg hangup")
+	}
+}
+
+// TestManager_CreateDoesNotHoldLockWhilePublishing pins the fix for a live
+// self-deadlock, not a style point. Bus.Publish runs handlers synchronously on
+// the caller's goroutine and sync.RWMutex is not reentrant, so publishing
+// room.created under m.mu wedges any subscriber that calls back into the
+// manager. It also asserts the room is discoverable by the time the event
+// announces it, which is the ordering the old locked publish gave for free.
+func TestManager_CreateDoesNotHoldLockWhilePublishing(t *testing.T) {
+	bus := newTestBus()
+	mgr := NewManager(leg.NewManager(), bus, newTestLog())
+
+	var probeReturned, found atomic.Bool
+	bus.Subscribe(func(e events.Event) {
+		if e.Type != events.RoomCreated {
+			return
+		}
+		// Probe from another goroutine and block this one until it answers.
+		// Calling Get inline would deadlock Create's own goroutine forever
+		// instead of failing; and returning without waiting would release
+		// m.mu before the probe ran, so the probe must finish inside the
+		// publish window to prove anything.
+		probeDone := make(chan struct{})
+		go func() {
+			defer close(probeDone)
+			_, ok := mgr.Get("r1")
+			found.Store(ok)
+		}()
+		select {
+		case <-probeDone:
+			probeReturned.Store(true)
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	if _, err := mgr.Create("r1", "", 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if !probeReturned.Load() {
+		t.Fatal("room.created published while m.mu was held: subscriber's Get() blocked")
+	}
+	if !found.Load() {
+		t.Fatal("room.created published before the room was discoverable")
+	}
+}
+
+// TestManager_MoveLegDoesNotHoldLockWhilePublishing is the Create test's twin
+// for MoveLeg's fallback room creation. That branch is only reachable when the
+// target room is absent — the sole API caller creates it first, so in
+// production it takes a delete race — but the violation is identical and the
+// unit API reaches it directly.
+func TestManager_MoveLegDoesNotHoldLockWhilePublishing(t *testing.T) {
+	bus := newTestBus()
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, bus, newTestLog())
+	if _, err := mgr.Create("from", "", 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	mover := newMockLeg("mover")
+	legMgr.Add(mover)
+	if err := mgr.AddLeg("from", "mover"); err != nil {
+		t.Fatalf("AddLeg: %v", err)
+	}
+
+	// Subscribed after the source room exists, so the only room.created seen
+	// here is the one MoveLeg publishes for the target.
+	var probeReturned, found atomic.Bool
+	bus.Subscribe(func(e events.Event) {
+		if e.Type != events.RoomCreated {
+			return
+		}
+		probeDone := make(chan struct{})
+		go func() {
+			defer close(probeDone)
+			_, ok := mgr.Get("to")
+			found.Store(ok)
+		}()
+		select {
+		case <-probeDone:
+			probeReturned.Store(true)
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	if err := mgr.MoveLeg("from", "to", "mover"); err != nil {
+		t.Fatalf("MoveLeg: %v", err)
+	}
+
+	if !probeReturned.Load() {
+		t.Fatal("MoveLeg published room.created while m.mu was held: subscriber's Get() blocked")
+	}
+	if !found.Load() {
+		t.Fatal("MoveLeg published room.created before the target room was discoverable")
+	}
+}
+
+// TestManager_MoveLegConcurrentCreatePublishesOnce pins the double-check that
+// replaced the single locked !ok branch. room.created is a public webhook, so
+// concurrent moves into the same absent room must announce it exactly once —
+// the guarantee the old lock-around-everything gave, which the fix has to keep
+// by other means.
+func TestManager_MoveLegConcurrentCreatePublishesOnce(t *testing.T) {
+	bus := newTestBus()
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, bus, newTestLog())
+
+	const movers = 8
+	for i := 0; i < movers; i++ {
+		src := fmt.Sprintf("from-%d", i)
+		if _, err := mgr.Create(src, "", 0); err != nil {
+			t.Fatalf("Create %s: %v", src, err)
+		}
+		l := newMockLeg(fmt.Sprintf("leg-%d", i))
+		legMgr.Add(l)
+		if err := mgr.AddLeg(src, l.ID()); err != nil {
+			t.Fatalf("AddLeg: %v", err)
+		}
+	}
+
+	var mu sync.Mutex
+	targetCreated := 0
+	bus.Subscribe(func(e events.Event) {
+		d, ok := e.Data.(*events.RoomCreatedData)
+		if !ok || e.Type != events.RoomCreated || d.RoomID != "to" {
+			return
+		}
+		mu.Lock()
+		targetCreated++
+		mu.Unlock()
+	})
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < movers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			if err := mgr.MoveLeg(fmt.Sprintf("from-%d", i), "to", fmt.Sprintf("leg-%d", i)); err != nil {
+				t.Errorf("MoveLeg: %v", err)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if targetCreated != 1 {
+		t.Fatalf("room.created for target published %d times, want exactly 1", targetCreated)
+	}
+}
+
+// TestManager_PanickedLegNotifiesOwner drives the real path — a leg whose
+// AudioReader panics, through the real mixer readLoop, the real
+// SetOnParticipantPanic hook, into tearDownPanickedLeg — and asserts the owner
+// is told. Without the notification the room layer hangs the leg up and the
+// API layer never learns, so no CDR is published and the leg leaks in the leg
+// manager.
+func TestManager_PanickedLegNotifiesOwner(t *testing.T) {
+	legMgr := leg.NewManager()
+	mgr := NewManager(legMgr, newTestBus(), newTestLog())
+
+	type notice struct {
+		leg    leg.Leg
+		reason string
+	}
+	var mu sync.Mutex
+	var notices []notice
+	mgr.SetOnLegPanicTeardown(func(l leg.Leg, reason string) {
+		mu.Lock()
+		notices = append(notices, notice{leg: l, reason: reason})
+		mu.Unlock()
+	})
+
+	if _, err := mgr.Create("r1", "", 0); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	l := addPanickingLeg(t, mgr, legMgr, "r1", "leg-1")
+
+	waitFor(t, 2*time.Second, "owner notified of the panicked leg", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(notices) > 0
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(notices) != 1 {
+		t.Fatalf("owner notified %d times, want exactly 1", len(notices))
+	}
+	if notices[0].leg.ID() != "leg-1" {
+		t.Fatalf("owner notified for leg %q, want %q", notices[0].leg.ID(), "leg-1")
+	}
+	if notices[0].reason != "mixer_panic" {
+		t.Fatalf("reason = %q, want %q", notices[0].reason, "mixer_panic")
+	}
+	// The owner's callback runs cleanupLeg, which hangs the leg up; the room
+	// must have done that already rather than leaving it to a hook that may
+	// not be installed.
+	if !l.hungUp.Load() {
+		t.Fatal("owner notified before the panicked leg was hung up")
 	}
 }

--- a/internal/room/room.go
+++ b/internal/room/room.go
@@ -88,10 +88,16 @@ func (r *Room) addLegLocked(l leg.Leg) {
 		// When rates match (e.g. G.722 at 16kHz = mixer rate), this is a passthrough.
 		legRate := l.SampleRate()
 		mixRate := r.SampleRate
-		r.legParts[l.ID()] = r.mix.AddParticipant(l.ID(),
+		p := r.mix.AddParticipant(l.ID(),
 			mixer.NewResampleReader(reader, legRate, mixRate),
 			mixer.NewResampleWriter(writer, mixRate, legRate),
 		)
+		// A leg's writer is its egress pipe, closed by Hangup during teardown
+		// and reused across a MoveLeg. Keep the mixer's panic path from closing
+		// it, or a stale loop's recover racing a move would silence the leg on
+		// its fresh participant. The room's panic hook closes it via Hangup.
+		p.MarkOwnerClosesEgress()
+		r.legParts[l.ID()] = p
 		// Sync mute/deaf state so legs muted/deafened before room join stay that way in mixer.
 		if l.IsMuted() {
 			r.mix.SetParticipantMuted(l.ID(), true)

--- a/internal/room/room.go
+++ b/internal/room/room.go
@@ -18,6 +18,13 @@ type Room struct {
 	mix          *mixer.Mixer
 	log          *slog.Logger
 
+	// legParts[legID] is the mixer participant instance currently carrying
+	// that leg's audio. The mixer drops a participant from its own map before
+	// reporting that its IO loop panicked, so once that report arrives this is
+	// the only record of which instance the leg was on — see
+	// RemoveLegIfParticipant. Guarded by r.mu, in step with participants.
+	legParts map[string]*mixer.Participant
+
 	bridgeRefs   int  // synthetic bridge participants keeping the mixer alive
 	mixerRunning bool // tracks whether r.mix is currently started
 
@@ -36,6 +43,7 @@ func NewRoom(id, appID string, sampleRate int, log *slog.Logger) *Room {
 		AppID:        appID,
 		SampleRate:   sampleRate,
 		participants: make(map[string]leg.Leg),
+		legParts:     make(map[string]*mixer.Participant),
 		mix:          mixer.New(log, sampleRate),
 		log:          log,
 	}
@@ -73,12 +81,14 @@ func (r *Room) addLegLocked(l leg.Leg) {
 
 	reader := l.AudioReader()
 	writer := l.AudioWriter()
-	if reader != nil && writer != nil {
+	if reader == nil || writer == nil {
+		delete(r.legParts, l.ID())
+	} else {
 		// Wrap with rate-aware resamplers to bridge leg↔mixer rate difference.
 		// When rates match (e.g. G.722 at 16kHz = mixer rate), this is a passthrough.
 		legRate := l.SampleRate()
 		mixRate := r.SampleRate
-		r.mix.AddParticipant(l.ID(),
+		r.legParts[l.ID()] = r.mix.AddParticipant(l.ID(),
 			mixer.NewResampleReader(reader, legRate, mixRate),
 			mixer.NewResampleWriter(writer, mixRate, legRate),
 		)
@@ -101,9 +111,7 @@ func (r *Room) DetachLeg(legID string) (leg.Leg, bool) {
 	if !ok {
 		return nil, false
 	}
-	l.SetRoomID("")
-	delete(r.participants, legID)
-	r.mix.RemoveParticipant(legID)
+	r.removeLegLocked(l)
 
 	r.applyRoutingLocked()
 	r.syncMixerLocked()
@@ -115,13 +123,47 @@ func (r *Room) RemoveLeg(legID string) {
 	defer r.mu.Unlock()
 
 	if l, ok := r.participants[legID]; ok {
-		l.SetRoomID("")
-		delete(r.participants, legID)
-		r.mix.RemoveParticipant(legID)
+		r.removeLegLocked(l)
 	}
 
 	r.applyRoutingLocked()
 	r.syncMixerLocked()
+}
+
+func (r *Room) removeLegLocked(l leg.Leg) {
+	l.SetRoomID("")
+	delete(r.participants, l.ID())
+	delete(r.legParts, l.ID())
+	r.mix.RemoveParticipant(l.ID())
+}
+
+// RemoveLegIfParticipant removes legID from the room only if p is still the
+// mixer participant carrying that leg's audio, and reports whether this call
+// removed it.
+//
+// This is the room-membership half of the mixer's removeParticipantIf, for the
+// panic teardown that runs asynchronously: by the time it acts, the leg may
+// have left and rejoined — including leaving and returning to this same room —
+// behind a fresh participant over a live ingress. Only p identifies the
+// instance that died; legID does not, and neither does the leg's presence
+// here. The lookup and the removal share r.mu, which is the lock every
+// membership change takes, so no join or move can land between them.
+func (r *Room) RemoveLegIfParticipant(legID string, p *mixer.Participant) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if cur, ok := r.legParts[legID]; !ok || cur != p {
+		return false
+	}
+	l, ok := r.participants[legID]
+	if !ok {
+		return false
+	}
+	r.removeLegLocked(l)
+
+	r.applyRoutingLocked()
+	r.syncMixerLocked()
+	return true
 }
 
 func (r *Room) Participants() []leg.Leg {

--- a/internal/room/room_test.go
+++ b/internal/room/room_test.go
@@ -27,6 +27,9 @@ type mockLeg struct {
 	createdAt      time.Time
 	disconnectDone atomic.Bool
 	panicOnHangup  bool
+	// hungUp records that Hangup was entered. Atomic because teardown can
+	// run on a goroutine the test only observes.
+	hungUp atomic.Bool
 }
 
 func newMockLeg(id string) *mockLeg {
@@ -47,6 +50,7 @@ func (m *mockLeg) AudioWriter() io.Writer                       { return m.write
 func (m *mockLeg) OnDTMF(func(digit rune))                      {}
 func (m *mockLeg) SendDTMF(ctx context.Context, d string) error { return nil }
 func (m *mockLeg) Hangup(ctx context.Context) error {
+	m.hungUp.Store(true)
 	if m.panicOnHangup {
 		panic("simulated hangup panic")
 	}

--- a/internal/room/room_test.go
+++ b/internal/room/room_test.go
@@ -452,3 +452,56 @@ func TestManager_Events(t *testing.T) {
 		t.Error("expected room.created event")
 	}
 }
+
+// TestRoom_RemoveLegLeavesWSEgressOpen pins the leg-level consequence of the
+// mixer's teardown, at the sample rate the default configuration actually runs.
+//
+// A WebSocket leg's AudioWriter is its egress pipe, and addLegLocked hands that
+// pipe to the mixer through NewResampleWriter, which is a passthrough when the
+// leg and the room agree on a rate. So any writer.Close() inside mixer teardown
+// arrives at the leg as the same call Hangup makes: the transport's send loop
+// reads EOF and drops the client's socket.
+//
+// Leaving a room is not leaving the call. DetachLeg exists so Manager.MoveLeg
+// can hand a live leg to another room, and RemoveLeg is the DELETE endpoint,
+// after which the leg is still the caller's to use.
+//
+// The rate is the whole point: at a mismatched rate the writer is wrapped in a
+// *resampleWriter, which has no Close and hides the bug. This test runs the
+// matched rate on purpose.
+func TestRoom_RemoveLegLeavesWSEgressOpen(t *testing.T) {
+	const rate = 16000
+
+	for _, tc := range []struct {
+		name   string
+		remove func(r *Room, id string)
+	}{
+		{"RemoveLeg", func(r *Room, id string) { r.RemoveLeg(id) }},
+		{"DetachLeg", func(r *Room, id string) { r.DetachLeg(id) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRoom("r1", "app", rate, slog.Default())
+			r.Mixer().Start()
+			defer r.Mixer().Stop()
+
+			l := leg.NewWebSocketOutboundPendingLeg(rate, false, slog.Default())
+			r.AddLeg(l)
+
+			tc.remove(r, l.ID())
+
+			// A closed pipe fails the write immediately; a live one blocks for
+			// want of a reader, which is what a healthy detached leg does.
+			werr := make(chan error, 1)
+			go func() {
+				_, err := l.AudioWriter().Write(make([]byte, 320))
+				werr <- err
+			}()
+			select {
+			case err := <-werr:
+				t.Fatalf("%s closed the leg's egress pipe (%v); the ws client's send loop takes that as EOF and drops the call", tc.name, err)
+			case <-time.After(200 * time.Millisecond):
+				// Still open: the leg survived the room, as it must.
+			}
+		})
+	}
+}

--- a/internal/room/room_test.go
+++ b/internal/room/room_test.go
@@ -26,6 +26,7 @@ type mockLeg struct {
 	writer         io.Writer
 	createdAt      time.Time
 	disconnectDone atomic.Bool
+	panicOnHangup  bool
 }
 
 func newMockLeg(id string) *mockLeg {
@@ -45,35 +46,41 @@ func (m *mockLeg) AudioReader() io.Reader                       { return m.reade
 func (m *mockLeg) AudioWriter() io.Writer                       { return m.writer }
 func (m *mockLeg) OnDTMF(func(digit rune))                      {}
 func (m *mockLeg) SendDTMF(ctx context.Context, d string) error { return nil }
-func (m *mockLeg) Hangup(ctx context.Context) error             { m.state = leg.StateHungUp; return nil }
-func (m *mockLeg) Answer(ctx context.Context) error             { return nil }
-func (m *mockLeg) Context() context.Context                     { return context.Background() }
-func (m *mockLeg) RoomID() string                               { return m.roomID }
-func (m *mockLeg) SetRoomID(id string)                          { m.roomID = id }
-func (m *mockLeg) AppID() string                                { return "" }
-func (m *mockLeg) SetAppID(string)                              {}
-func (m *mockLeg) Role() string                                 { return m.role }
-func (m *mockLeg) SetRole(r string)                             { m.role = r }
-func (m *mockLeg) IsMuted() bool                                { return m.muted }
-func (m *mockLeg) SetMuted(v bool)                              { m.muted = v }
-func (m *mockLeg) IsDeaf() bool                                 { return m.deaf }
-func (m *mockLeg) SetDeaf(v bool)                               { m.deaf = v }
-func (m *mockLeg) AcceptDTMF() bool                             { return m.acceptDTMF }
-func (m *mockLeg) SetAcceptDTMF(v bool)                         { m.acceptDTMF = v }
-func (m *mockLeg) OnTextReceived(func(string, bool))            {}
-func (m *mockLeg) SendText(context.Context, string) error       { return leg.ErrRTTNotNegotiated }
-func (m *mockLeg) AcceptText() bool                             { return false }
-func (m *mockLeg) SetAcceptText(bool)                           {}
-func (m *mockLeg) RTTNegotiated() bool                          { return false }
-func (m *mockLeg) SetSpeakingTap(w io.Writer)                   {}
-func (m *mockLeg) ClearSpeakingTap()                            {}
-func (m *mockLeg) IsHeld() bool                                 { return false }
-func (m *mockLeg) CreatedAt() time.Time                         { return m.createdAt }
-func (m *mockLeg) AnsweredAt() time.Time                        { return time.Time{} }
-func (m *mockLeg) SIPHeaders() map[string]string                { return nil }
-func (m *mockLeg) Headers() map[string]string                   { return nil }
-func (m *mockLeg) RTPStats() leg.RTPStats                       { return leg.RTPStats{} }
-func (m *mockLeg) ClaimDisconnect() bool                        { return m.disconnectDone.CompareAndSwap(false, true) }
+func (m *mockLeg) Hangup(ctx context.Context) error {
+	if m.panicOnHangup {
+		panic("simulated hangup panic")
+	}
+	m.state = leg.StateHungUp
+	return nil
+}
+func (m *mockLeg) Answer(ctx context.Context) error       { return nil }
+func (m *mockLeg) Context() context.Context               { return context.Background() }
+func (m *mockLeg) RoomID() string                         { return m.roomID }
+func (m *mockLeg) SetRoomID(id string)                    { m.roomID = id }
+func (m *mockLeg) AppID() string                          { return "" }
+func (m *mockLeg) SetAppID(string)                        {}
+func (m *mockLeg) Role() string                           { return m.role }
+func (m *mockLeg) SetRole(r string)                       { m.role = r }
+func (m *mockLeg) IsMuted() bool                          { return m.muted }
+func (m *mockLeg) SetMuted(v bool)                        { m.muted = v }
+func (m *mockLeg) IsDeaf() bool                           { return m.deaf }
+func (m *mockLeg) SetDeaf(v bool)                         { m.deaf = v }
+func (m *mockLeg) AcceptDTMF() bool                       { return m.acceptDTMF }
+func (m *mockLeg) SetAcceptDTMF(v bool)                   { m.acceptDTMF = v }
+func (m *mockLeg) OnTextReceived(func(string, bool))      {}
+func (m *mockLeg) SendText(context.Context, string) error { return leg.ErrRTTNotNegotiated }
+func (m *mockLeg) AcceptText() bool                       { return false }
+func (m *mockLeg) SetAcceptText(bool)                     {}
+func (m *mockLeg) RTTNegotiated() bool                    { return false }
+func (m *mockLeg) SetSpeakingTap(w io.Writer)             {}
+func (m *mockLeg) ClearSpeakingTap()                      {}
+func (m *mockLeg) IsHeld() bool                           { return false }
+func (m *mockLeg) CreatedAt() time.Time                   { return m.createdAt }
+func (m *mockLeg) AnsweredAt() time.Time                  { return time.Time{} }
+func (m *mockLeg) SIPHeaders() map[string]string          { return nil }
+func (m *mockLeg) Headers() map[string]string             { return nil }
+func (m *mockLeg) RTPStats() leg.RTPStats                 { return leg.RTPStats{} }
+func (m *mockLeg) ClaimDisconnect() bool                  { return m.disconnectDone.CompareAndSwap(false, true) }
 
 func newTestBus() *events.Bus  { return events.NewBus("test") }
 func newTestLog() *slog.Logger { return slog.Default() }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4124,6 +4124,7 @@ x-webhooks:
                                                     - invite_failed
                                                     - connect_failed
                                                     - ice_failure
+                                                    - mixer_panic
                                             duration_total:
                                                 type: number
                                                 description: Seconds from leg creation to disconnect

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4102,29 +4102,7 @@ x-webhooks:
                                         properties:
                                             reason:
                                                 type: string
-                                                description: Disconnect reason. Common SIP failures are mapped to named reasons; unmapped 4xx/5xx/6xx codes appear as sip_{code}.
-                                                enum:
-                                                    - api_hangup
-                                                    - remote_bye
-                                                    - caller_cancel
-                                                    - ring_timeout
-                                                    - max_duration
-                                                    - busy
-                                                    - unavailable
-                                                    - not_found
-                                                    - forbidden
-                                                    - unauthorized
-                                                    - timeout
-                                                    - cancelled
-                                                    - not_acceptable
-                                                    - service_unavailable
-                                                    - declined
-                                                    - rtp_timeout
-                                                    - session_expired
-                                                    - invite_failed
-                                                    - connect_failed
-                                                    - ice_failure
-                                                    - mixer_panic
+                                                description: 'Disconnect reason. Common SIP failures are mapped to named reasons; unmapped 4xx/5xx/6xx codes appear as sip_{code}. This is an open set — treat an unrecognized value as a new reason rather than an error. Known values: api_hangup, room_deleted, remote_bye, caller_cancel, max_duration, session_expired, rtp_timeout, busy, declined, rejected, unavailable, not_found, forbidden, server_error, ring_timeout, unauthorized, timeout, cancelled, not_acceptable, service_unavailable, invite_failed, connect_failed, challenged, transfer_completed, transfer_originate_failed, transfer_connect_failed, bad_answer, mixer_panic, hangup, peer_slow, connection_reset, ws_error, ws_dial_failed, moq_error, ice_failure, ice_failed, ice_disconnected, livekit_client_initiated, livekit_duplicate_identity, livekit_server_shutdown, livekit_kicked, livekit_room_deleted, livekit_state_mismatch, livekit_join_failure, livekit_migration, livekit_signal_close, livekit_room_closed, livekit_user_unavailable, livekit_user_rejected, livekit_token_expired, livekit_media_failure, livekit_disconnected, livekit_client_closed, livekit_signal_closed, livekit_signal_error, livekit_pc_setup_failed, livekit_add_track_failed, livekit_publisher_failed, livekit_subscriber_failed, livekit_signal_loop_exit, livekit_set_remote_desc_failed, livekit_create_answer_failed, livekit_set_local_desc_failed, livekit_signal_send_failed, livekit_set_publisher_remote_failed, livekit_participant_left.'
                                             duration_total:
                                                 type: number
                                                 description: Seconds from leg creation to disconnect


### PR DESCRIPTION
There is currently no `recover` anywhere in `internal/mixer`. `readLoop`, `writeLoop` and
`mixTick` all run on bare goroutines, so a panic in any of them takes down the process — every
room, every call, every leg. `middleware.Recoverer` is chi HTTP middleware and never sees them.

This adds recovery at the participant boundary. A panicking participant is torn down and its
owner notified; the room and every other participant carry on. Recovery for the mix loop is
per-tick rather than per-room, so a bad frame skips one tick instead of stopping the room.
Repeated panic logs are rate-limited.

Teardown dispatches on what the participant actually is:

- **bridge** — the whole bridge comes down, both endpoints in both rooms, `room.unbridged` published
- **leg** (any type, not just SIP) — removed from the room, hung up, `leg.disconnected` with `cdr.reason = mixer_panic`
- **anything else** (room ws audio streams, agent, playback and TTS sources; a ws leg takes the leg path above) — logged, and woken by the mixer closing whichever of its reader and writer it can close

Leg removal is identity-gated on the participant instance, so a leg that has already been replaced or detached is not torn down a second time. Bridge teardown is gated instead by DeleteBridge's registry delete, which elects a single caller when both endpoints panic at once.

Rooms deliberately keep their existing lifetime semantics: they are explicit-lifetime objects
with one deletion path, and an empty room already lingers after a normal hangup, so a panic
converging on "empty room" is the pre-existing state rather than a new leak. Happy to revisit
if you'd rather a panic could end a room.

`mixer_panic` is a new public `cdr.reason` value and is documented in API.md.

**Note if you also take `fix/room-recording-cleanup`:** see the note on that PR — it adds a `roomScopedLegRemoval` helper covering the same three room-scoped cleanup calls this hook writes out by hand, and the resolution is to route this hook through that helper.

