### PR TITLE
Publish recordings atomically and drive stereo capture from the master clock

### DIFF
--- a/API.md
+++ b/API.md
@@ -1199,6 +1199,8 @@ When `s3_bucket` is provided, a per-request S3 backend is created using the supp
 
 Recording runs asynchronously. Events `recording.started` and `recording.finished` are emitted. When `storage=s3`, the `file` field in the stop response and the `recording.finished` event will contain an `s3://bucket/key` URI.
 
+The `file` path above does **not** exist while the recording is in progress: the recording is written to a staging file and only appears at this path once it stops, so it is never observed half-written. Read it after `recording.finished`, not during the call.
+
 **Errors:**
 - `400` — Invalid storage type, S3 not configured, or invalid S3 credentials
 - `404` — Leg not found
@@ -2868,7 +2870,7 @@ All event data uses typed structs with consistent field names. Events scoped to 
 | `tts.started` | TTS synthesis began playing | `leg_id` or `room_id`, `tts_id` |
 | `tts.finished` | TTS synthesis finished playing | `leg_id` or `room_id`, `tts_id` |
 | `tts.error` | TTS synthesis or playback failed | `leg_id` or `room_id`, `tts_id`, `error` |
-| `recording.started` | Recording began | `leg_id` or `room_id`, `file` |
+| `recording.started` | Recording began | `leg_id` or `room_id`, `file` (does not exist yet — the path only appears when the recording stops) |
 | `recording.finished` | Recording ended | `leg_id` or `room_id`, `file`, `multi_channel_file`, `channels` (multi-channel only) |
 | `recording.paused` | Recording paused (audio replaced with silence) | `leg_id` or `room_id` |
 | `recording.resumed` | Recording resumed from a paused state | `leg_id` or `room_id` |

--- a/API.md
+++ b/API.md
@@ -1222,6 +1222,18 @@ Stop recording a leg.
 }
 ```
 
+| Field | Type | Description |
+|-------|------|-------------|
+| `file` | string | Path/URI of the recording. Omitted entirely when the capture was discarded and no file was written — see below. |
+
+A capture that fails mid-write, or that never captures a frame, is discarded:
+nothing is written and no file exists. The stop still succeeds with
+`status: stopped` — the recording did stop — but the response carries no `file`
+key at all, and the `recording.finished` event carries `"file": ""`. Treat
+either as "there is no recording to fetch", not as a path: it is the one case
+where a `200` produces no artefact. A present, non-empty `file` always names
+something that exists.
+
 **Errors:** `404` — No recording in progress
 
 ---
@@ -2112,7 +2124,7 @@ Multi-channel recording — includes a single multi-channel WAV with channel met
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `file` | string | Path/URI of the full mix recording (mono) |
+| `file` | string | Path/URI of the full mix recording (mono). Omitted entirely when the full-mix capture was discarded and no file was written. |
 | `multi_channel_file` | string | Path/URI of the multi-channel WAV file. Only present when `multi_channel: true` was used. |
 | `channels` | object | Map of leg ID to channel metadata. Only present when `multi_channel: true` was used. |
 | `channels[].channel` | integer | Zero-based channel index in the multi-channel WAV |
@@ -2127,7 +2139,18 @@ that were lost are named in `omitted_legs`. Those leg IDs have no entry in
 is only meaningful via `channels`, never by position. If **every** participant's
 capture fails there is nothing to merge, and the response carries neither
 `multi_channel_file` nor `channels` (the failure is logged server-side; the stop
-itself still succeeds and returns the full-mix `file`).
+itself still succeeds).
+
+The full mix is captured independently of the per-participant ones, so it can be
+discarded on its own: a capture that fails mid-write, or that never captures a
+frame, writes no file. When that happens the response omits the `file` key
+entirely (the `recording.finished` event instead carries `"file": ""`), while
+`multi_channel_file` and `channels` may still be present and usable. The stop
+still reports `status: stopped`. An absent `file` means there is no full mix to
+fetch, not a path; a present, non-empty `file` always names something real. In
+the worst case both the full mix and every per-participant capture are
+discarded, and the stop succeeds carrying none of `file`,
+`multi_channel_file`, or `channels`.
 
 Whether a partial recording is acceptable is the caller's decision, so check
 `omitted_legs` before treating `multi_channel_file` as a complete record of the

--- a/API.md
+++ b/API.md
@@ -2118,6 +2118,21 @@ Multi-channel recording — includes a single multi-channel WAV with channel met
 | `channels[].channel` | integer | Zero-based channel index in the multi-channel WAV |
 | `channels[].start_ms` | integer | Milliseconds from recording start when this participant joined |
 | `channels[].end_ms` | integer | Milliseconds from recording start when this participant's audio ends |
+| `omitted_legs` | array | Leg IDs that took part but are absent from `multi_channel_file`, because capturing them failed. Omitted entirely when the recording is complete. |
+
+A participant whose capture fails is left out of the merge rather than failing
+the whole room: the other participants' audio is still produced, and the legs
+that were lost are named in `omitted_legs`. Those leg IDs have no entry in
+`channels`, and the remaining channel indices are contiguous — a channel index
+is only meaningful via `channels`, never by position. If **every** participant's
+capture fails there is nothing to merge, and the response carries neither
+`multi_channel_file` nor `channels` (the failure is logged server-side; the stop
+itself still succeeds and returns the full-mix `file`).
+
+Whether a partial recording is acceptable is the caller's decision, so check
+`omitted_legs` before treating `multi_channel_file` as a complete record of the
+room. Treat a missing `multi_channel_file` on a `multi_channel: true` recording
+the same way — as a failure to produce one, not as an empty room.
 
 **Errors:** `404` — No recording in progress
 
@@ -2871,7 +2886,7 @@ All event data uses typed structs with consistent field names. Events scoped to 
 | `tts.finished` | TTS synthesis finished playing | `leg_id` or `room_id`, `tts_id` |
 | `tts.error` | TTS synthesis or playback failed | `leg_id` or `room_id`, `tts_id`, `error` |
 | `recording.started` | Recording began | `leg_id` or `room_id`, `file` (does not exist yet — the path only appears when the recording stops) |
-| `recording.finished` | Recording ended | `leg_id` or `room_id`, `file`, `multi_channel_file`, `channels` (multi-channel only) |
+| `recording.finished` | Recording ended | `leg_id` or `room_id`, `file`, `multi_channel_file`, `channels`, `omitted_legs` (multi-channel only; `omitted_legs` only when a participant's capture failed) |
 | `recording.paused` | Recording paused (audio replaced with silence) | `leg_id` or `room_id` |
 | `recording.resumed` | Recording resumed from a paused state | `leg_id` or `room_id` |
 | `stt.text` | Speech-to-text transcript | `leg_id`, `room_id` (if room STT), `text`, `is_final` |

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -5174,6 +5174,10 @@ components:
                     type: object
                     additionalProperties:
                         $ref: '#/components/schemas/ChannelInfo'
+                omitted_legs:
+                    type: array
+                    items:
+                        type: string
             required:
                 - status
                 - file

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -5160,7 +5160,6 @@ components:
                     type: string
             required:
                 - status
-                - file
         RecordingStopRoomResult:
             type: object
             properties:
@@ -5180,7 +5179,6 @@ components:
                         type: string
             required:
                 - status
-                - file
         RegistrationView:
             type: object
             properties:

--- a/internal/api/openapi_meta.go
+++ b/internal/api/openapi_meta.go
@@ -106,16 +106,17 @@ func WebhookFieldDescriptions() map[string]string {
 		"tts.error.error":      "Error message",
 
 		// recording
-		"recording.started.leg_id":   "Leg identifier",
-		"recording.started.room_id":  "Room identifier",
-		"recording.started.file":     "Recording file path or S3 URI",
-		"recording.finished.leg_id":  "Leg identifier",
-		"recording.finished.room_id": "Room identifier",
-		"recording.finished.file":    "Recording file path or S3 URI",
-		"recording.paused.leg_id":    "Leg identifier",
-		"recording.paused.room_id":   "Room identifier",
-		"recording.resumed.leg_id":   "Leg identifier",
-		"recording.resumed.room_id":  "Room identifier",
+		"recording.started.leg_id":        "Leg identifier",
+		"recording.started.room_id":       "Room identifier",
+		"recording.started.file":          "Recording file path or S3 URI — does not exist yet; the path only appears when the recording stops",
+		"recording.finished.leg_id":       "Leg identifier",
+		"recording.finished.room_id":      "Room identifier",
+		"recording.finished.file":         "Recording file path or S3 URI",
+		"recording.finished.omitted_legs": "Participants whose audio is missing from multi_channel_file because their capture failed. Absent when the recording is complete",
+		"recording.paused.leg_id":         "Leg identifier",
+		"recording.paused.room_id":        "Room identifier",
+		"recording.resumed.leg_id":        "Leg identifier",
+		"recording.resumed.room_id":       "Room identifier",
 
 		// room
 		"room.created.room_id": "Room identifier",

--- a/internal/api/recording.go
+++ b/internal/api/recording.go
@@ -891,6 +891,37 @@ func (r *pipeReader) Read(p []byte) (int, error) {
 	}
 }
 
+// TryRead is a non-blocking counterpart to Read. It serves any buffered
+// remainder first, then one frame if the writer already queued it, and
+// otherwise returns (0, nil) rather than waiting for one. io.EOF is reported
+// only once the writer is closed and nothing is left buffered or queued.
+//
+// Callers that must keep to their own clock use this to drain the pipe for
+// whatever it has right now, so a silent writer never stalls the reader.
+func (r *pipeReader) TryRead(p []byte) (int, error) {
+	if len(r.buf) > 0 {
+		n := copy(p, r.buf)
+		r.buf = r.buf[n:]
+		return n, nil
+	}
+	select {
+	case data := <-r.ch:
+		n := copy(p, data)
+		if n < len(data) {
+			r.buf = data[n:]
+		}
+		return n, nil
+	default:
+	}
+	// Nothing buffered and nothing queued: EOF only once the writer is gone.
+	select {
+	case <-r.done:
+		return 0, io.EOF
+	default:
+		return 0, nil
+	}
+}
+
 type pipeWriter struct {
 	ch     chan []byte
 	done   chan struct{}

--- a/internal/api/recording.go
+++ b/internal/api/recording.go
@@ -855,6 +855,7 @@ func (s *Server) stopRoomRecordingIfEmpty(roomID string) {
 	if mcResult != nil {
 		evtData.MultiChannelFile = mcResult.FilePath
 		evtData.Channels = mcResult.Channels
+		evtData.OmittedLegs = mcResult.OmittedLegs
 	}
 	s.Bus.Publish(events.RecordingFinished, evtData)
 	s.Log.Info("auto-stopped room recording (empty room)", "room_id", roomID, "file", location)

--- a/internal/api/recording.go
+++ b/internal/api/recording.go
@@ -133,8 +133,10 @@ func (mc *multiChannelState) stopLeg(legID string, m mixerIface) {
 	// Recording it anyway would hand the merge a path it cannot open, and the
 	// merge fails on the first unreadable input — so one leg's failure would
 	// destroy every other participant's audio too. Leave it out instead; stopAll
-	// reports which legs went missing.
-	if !rec.Published() {
+	// reports which legs went missing. Finalized, not Published, is the gate: a
+	// recording whose only failure was the closing directory sync is present and
+	// readable at fpath and belongs in the merge.
+	if !rec.Finalized() {
 		mc.log.Error("multi-channel: leg capture was discarded, dropping it from the merge", "leg_id", legID, "file", fpath)
 		return
 	}
@@ -450,9 +452,11 @@ func (s *Server) stopLegRecording(legID string) (string, bool) {
 	// Stop reports the path the capture was headed for whether or not it got
 	// there: a discarded capture leaves nothing at fpath, so there is no file to
 	// upload and none to name. Report the stop without a location rather than
-	// hand the caller a path that cannot be opened.
+	// hand the caller a path that cannot be opened. Finalized, not Published, is
+	// the gate: a capture whose only failure was the closing directory sync is
+	// present and readable at fpath, so it is still reported and uploaded.
 	var location string
-	if !rec.Published() {
+	if !rec.Finalized() {
 		s.Log.Error("leg capture was discarded, stopping without a file", "leg_id", legID, "file", fpath)
 	} else {
 		// Upload to storage backend if not plain file.
@@ -707,7 +711,9 @@ func (s *Server) cleanupRoomRecording(id string) (location string, mcResult *rec
 	// A discarded capture leaves nothing at fpath — see stopLegRecording. The
 	// stop still succeeded, and any multi-channel result stands on its own, so
 	// report it without a location rather than as "no recording in progress".
-	if !rec.Published() {
+	// Finalized, not Published, is the gate: a capture whose only failure was the
+	// closing directory sync is present and readable at fpath.
+	if !rec.Finalized() {
 		s.Log.Error("room mix capture was discarded, stopping without a file", "room_id", id, "file", fpath)
 		return "", mcResult, true
 	}

--- a/internal/api/recording.go
+++ b/internal/api/recording.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -49,6 +50,20 @@ type multiChannelState struct {
 	log          *slog.Logger
 }
 
+// noteParticipant gives legID a channel position, at most one across every
+// path that reaches it. A leg is recorded here even when its start failed, so
+// stopAll's walk can find it and report it omitted; the recorders guard in
+// startLeg cannot stand in for this check, because a failed start never enters
+// recorders and so a retry — failing or succeeding — reaches this again. A
+// second position would duplicate the leg's channel in the merge and leave
+// Channels, which is keyed by leg ID, naming only the later index.
+// Callers must hold mc.mu.
+func (mc *multiChannelState) noteParticipant(legID string) {
+	if !slices.Contains(mc.participantOrder, legID) {
+		mc.participantOrder = append(mc.participantOrder, legID)
+	}
+}
+
 // startLeg begins recording a single participant's audio via the mixer's recordTap.
 func (mc *multiChannelState) startLeg(legID string, m mixerIface, dir string) {
 	mc.mu.Lock()
@@ -69,6 +84,11 @@ func (mc *multiChannelState) startLeg(legID string, m mixerIface, dir string) {
 		mc.log.Error("multi-channel: failed to start per-leg recording", "leg_id", legID, "error", err)
 		m.ClearParticipantRecordTap(legID)
 		pw.Close()
+		// A leg that never started has no recorder and no file, so
+		// participantOrder is the only place stopAll's walk can find it —
+		// without this it vanishes from both the merge and omitted_legs, and
+		// the room looks complete.
+		mc.noteParticipant(legID)
 		return
 	}
 
@@ -81,7 +101,7 @@ func (mc *multiChannelState) startLeg(legID string, m mixerIface, dir string) {
 
 	mc.recorders[legID] = rec
 	mc.pipes[legID] = pw
-	mc.participantOrder = append(mc.participantOrder, legID)
+	mc.noteParticipant(legID)
 	mc.joinOffsets[legID] = time.Since(mc.startTime)
 	mc.log.Info("multi-channel: started per-leg recording", "leg_id", legID, "file", fpath)
 }
@@ -427,19 +447,28 @@ func (s *Server) stopLegRecording(legID string) (string, bool) {
 	fpath := rec.Stop()
 	rec.Wait()
 
-	// Upload to storage backend if not plain file.
-	var backend storage.Backend
-	if info != nil {
-		backend = info.storage
-	}
-	location := fpath
-	if backend != nil {
-		loc, err := backend.Upload(context.Background(), fpath)
-		if err != nil {
-			s.Log.Error("storage upload failed", "leg_id", legID, "error", err)
-			// Keep local file and use local path.
-		} else {
-			location = loc
+	// Stop reports the path the capture was headed for whether or not it got
+	// there: a discarded capture leaves nothing at fpath, so there is no file to
+	// upload and none to name. Report the stop without a location rather than
+	// hand the caller a path that cannot be opened.
+	var location string
+	if !rec.Published() {
+		s.Log.Error("leg capture was discarded, stopping without a file", "leg_id", legID, "file", fpath)
+	} else {
+		// Upload to storage backend if not plain file.
+		var backend storage.Backend
+		if info != nil {
+			backend = info.storage
+		}
+		location = fpath
+		if backend != nil {
+			loc, err := backend.Upload(context.Background(), fpath)
+			if err != nil {
+				s.Log.Error("storage upload failed", "leg_id", legID, "error", err)
+				// Keep local file and use local path.
+			} else {
+				location = loc
+			}
 		}
 	}
 
@@ -457,7 +486,9 @@ func (s *Server) stopLegRecording(legID string) (string, bool) {
 // RecordingStopLegResult is the success payload for stopping a leg recording.
 type RecordingStopLegResult struct {
 	Status string `json:"status"`
-	File   string `json:"file"`
+	// File is the path/URI of the capture. Absent when the capture was discarded
+	// and nothing was written — the stop still succeeded, but there is no file.
+	File string `json:"file,omitempty"`
 }
 
 // RecordingPauseResumeResult is the success payload for pause/resume on a leg
@@ -673,6 +704,14 @@ func (s *Server) cleanupRoomRecording(id string) (location string, mcResult *rec
 	fpath := rec.Stop()
 	rec.Wait()
 
+	// A discarded capture leaves nothing at fpath — see stopLegRecording. The
+	// stop still succeeded, and any multi-channel result stands on its own, so
+	// report it without a location rather than as "no recording in progress".
+	if !rec.Published() {
+		s.Log.Error("room mix capture was discarded, stopping without a file", "room_id", id, "file", fpath)
+		return "", mcResult, true
+	}
+
 	location = fpath
 	if backend != nil {
 		loc, err := backend.Upload(context.Background(), fpath)
@@ -690,8 +729,10 @@ func (s *Server) cleanupRoomRecording(id string) (location string, mcResult *rec
 // recording. multi_channel_file/channels are present only when the recording
 // was started with multi_channel=true.
 type RecordingStopRoomResult struct {
-	Status           string                           `json:"status"`
-	File             string                           `json:"file"`
+	Status string `json:"status"`
+	// File is the path/URI of the full mix. Absent when that capture was
+	// discarded and nothing was written; multi_channel_file may still be present.
+	File             string                           `json:"file,omitempty"`
 	MultiChannelFile string                           `json:"multi_channel_file,omitempty"`
 	Channels         map[string]recording.ChannelInfo `json:"channels,omitempty"`
 	// OmittedLegs names participants whose audio is missing from the merged

--- a/internal/api/recording.go
+++ b/internal/api/recording.go
@@ -108,6 +108,17 @@ func (mc *multiChannelState) stopLeg(legID string, m mixerIface) {
 	fpath := rec.Stop()
 	rec.Wait()
 
+	// Stop reports the path the recording was headed for whether or not it got
+	// there: a capture that failed is discarded, so nothing exists at fpath.
+	// Recording it anyway would hand the merge a path it cannot open, and the
+	// merge fails on the first unreadable input — so one leg's failure would
+	// destroy every other participant's audio too. Leave it out instead; stopAll
+	// reports which legs went missing.
+	if !rec.Published() {
+		mc.log.Error("multi-channel: leg capture was discarded, dropping it from the merge", "leg_id", legID, "file", fpath)
+		return
+	}
+
 	mc.mu.Lock()
 	mc.files[legID] = fpath
 	mc.mu.Unlock()
@@ -133,21 +144,38 @@ func (mc *multiChannelState) stopAll(m mixerIface) (*recording.MultiChannelResul
 	}
 
 	mc.mu.Lock()
-	// Build merge inputs in channel order.
-	inputs := make([]recording.MultiChannelInput, len(mc.participantOrder))
-	for i, legID := range mc.participantOrder {
-		inputs[i] = recording.MultiChannelInput{
-			LegID:      legID,
-			FilePath:   mc.files[legID],
-			JoinOffset: mc.joinOffsets[legID],
+	// Build merge inputs in channel order, over the legs that actually published.
+	// A leg whose capture was discarded has no file to merge; including it would
+	// fail the merge on its first unreadable input and take the whole room's
+	// audio down with it. The survivors are merged and the losses reported, so
+	// the caller can tell a complete recording from a partial one.
+	inputs := make([]recording.MultiChannelInput, 0, len(mc.participantOrder))
+	var omitted []string
+	for _, legID := range mc.participantOrder {
+		fpath, ok := mc.files[legID]
+		if !ok {
+			omitted = append(omitted, legID)
+			continue
 		}
+		inputs = append(inputs, recording.MultiChannelInput{
+			LegID:      legID,
+			FilePath:   fpath,
+			JoinOffset: mc.joinOffsets[legID],
+		})
 	}
 	mc.mu.Unlock()
 
+	// If nothing published, there is no recording to salvage: MergeMultiChannel
+	// refuses an empty input set, which fails the stop loudly rather than
+	// reporting an empty room as a success.
 	result, err := recording.MergeMultiChannel(mc.dir, inputs, totalDuration, mc.sampleRate)
 	if err != nil {
-		mc.log.Error("multi-channel: merge failed", "error", err)
+		mc.log.Error("multi-channel: merge failed", "error", err, "omitted_legs", omitted)
 		return nil, err
+	}
+	result.OmittedLegs = omitted
+	if len(omitted) > 0 {
+		mc.log.Warn("multi-channel: merged without the legs whose captures were discarded", "omitted_legs", omitted)
 	}
 
 	// Upload the merged file if storage backend is set.
@@ -666,6 +694,9 @@ type RecordingStopRoomResult struct {
 	File             string                           `json:"file"`
 	MultiChannelFile string                           `json:"multi_channel_file,omitempty"`
 	Channels         map[string]recording.ChannelInfo `json:"channels,omitempty"`
+	// OmittedLegs names participants whose audio is missing from the merged
+	// file because their capture failed. Absent when the recording is complete.
+	OmittedLegs []string `json:"omitted_legs,omitempty"`
 }
 
 func (s *Server) doStopRecordRoom(roomID string) (*RecordingStopRoomResult, error) {
@@ -685,8 +716,10 @@ func (s *Server) doStopRecordRoom(roomID string) (*RecordingStopRoomResult, erro
 	if mcResult != nil {
 		res.MultiChannelFile = mcResult.FilePath
 		res.Channels = mcResult.Channels
+		res.OmittedLegs = mcResult.OmittedLegs
 		evtData.MultiChannelFile = mcResult.FilePath
 		evtData.Channels = mcResult.Channels
+		evtData.OmittedLegs = mcResult.OmittedLegs
 	}
 	s.Bus.Publish(events.RecordingFinished, evtData)
 	return res, nil

--- a/internal/api/recording_multichannel_test.go
+++ b/internal/api/recording_multichannel_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/VoiceBlender/voiceblender/internal/events"
 	"github.com/VoiceBlender/voiceblender/internal/recording"
 )
 
@@ -119,5 +120,102 @@ func TestMultiChannelStopAll_AllLegsDiscardedFails(t *testing.T) {
 
 	if _, err := mc.stopAll(fakeMixer{}); err == nil {
 		t.Fatal("stopAll reported success though no leg published any audio")
+	}
+}
+
+// TestStopRoomRecordingIfEmpty_PublishesOmittedLegs covers the auto-stop exit.
+// A room recording has two ways to finish — the API stop and this one, taken
+// when the last leg leaves — and only the API stop is reachable from a request,
+// so the merge result reaching the event on this path has no other coverage.
+// Naming the lost leg is the whole point of salvaging the survivors: a listener
+// that is told a partial recording is complete has been misinformed.
+func TestStopRoomRecordingIfEmpty_PublishesOmittedLegs(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	s := newTestServer(t)
+
+	const roomID = "auto-stop-room"
+	if _, err := s.RoomMgr.Create(roomID, "test-app", 8000); err != nil {
+		t.Fatalf("create room: %v", err)
+	}
+	// The room is empty, which is the precondition this exit tests for; a leg
+	// still present would make it return before publishing anything.
+
+	// The room mix recorder: cleanupRoomRecording reports no recording at all
+	// without one, and the auto-stop returns silently.
+	mix := recording.NewRecorder(slog.Default())
+	if _, err := mix.StartAt(ctx, bytes.NewReader(make([]byte, 16000)), dir, 8000); err != nil {
+		t.Fatalf("start room mix recorder: %v", err)
+	}
+	roomRecorders.Lock()
+	roomRecorders.m[roomID] = mix
+	roomRecorders.Unlock()
+	t.Cleanup(func() {
+		roomRecorders.Lock()
+		delete(roomRecorders.m, roomID)
+		roomRecorders.Unlock()
+	})
+
+	good := recording.NewRecorder(slog.Default())
+	if _, err := good.StartAt(ctx, bytes.NewReader(make([]byte, 16000)), dir, 8000); err != nil {
+		t.Fatalf("start good leg: %v", err)
+	}
+	good.Wait()
+	if !good.Published() {
+		t.Fatal("precondition: the good leg did not publish, so this test proves nothing")
+	}
+
+	bad := recording.NewRecorder(slog.Default())
+	if _, err := bad.StartStereo(ctx, bytes.NewReader(nil), bytes.NewReader(nil), dir, 8000); err != nil {
+		t.Fatalf("start bad leg: %v", err)
+	}
+	bad.Wait()
+	if bad.Published() {
+		t.Fatal("precondition: the bad leg published, so this test proves nothing")
+	}
+
+	mc := &multiChannelState{
+		active:           true,
+		startTime:        time.Now().Add(-time.Second),
+		sampleRate:       8000,
+		dir:              dir,
+		recorders:        map[string]*recording.Recorder{"good": good, "bad": bad},
+		pipes:            map[string]*pipeWriter{},
+		files:            map[string]string{},
+		joinOffsets:      map[string]time.Duration{},
+		leaveOffsets:     map[string]time.Duration{},
+		participantOrder: []string{"good", "bad"},
+		log:              slog.Default(),
+	}
+	roomMultiChannel.Lock()
+	roomMultiChannel.m[roomID] = mc
+	roomMultiChannel.Unlock()
+	t.Cleanup(func() {
+		roomMultiChannel.Lock()
+		delete(roomMultiChannel.m, roomID)
+		roomMultiChannel.Unlock()
+	})
+
+	var got *events.RecordingFinishedData
+	unsub := s.Bus.Subscribe(func(e events.Event) {
+		if e.Type != events.RecordingFinished {
+			return
+		}
+		if d, ok := e.Data.(*events.RecordingFinishedData); ok {
+			got = d
+		}
+	})
+	defer unsub()
+
+	s.stopRoomRecordingIfEmpty(roomID)
+
+	if got == nil {
+		t.Fatal("the auto-stop published no recording.finished, so this test proves nothing")
+	}
+	if _, ok := got.Channels["good"]; !ok {
+		t.Errorf("the healthy leg is missing from the event; channels = %v", got.Channels)
+	}
+	if names := got.OmittedLegs; len(names) != 1 || names[0] != "bad" {
+		t.Errorf("OmittedLegs = %v, want [bad] — the auto-stop reported a partial recording as complete", names)
 	}
 }

--- a/internal/api/recording_multichannel_test.go
+++ b/internal/api/recording_multichannel_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/recording"
+)
+
+// fakeMixer stands in for the room mixer, which stopAll only ever uses to
+// detach record taps.
+type fakeMixer struct{}
+
+func (fakeMixer) SetParticipantRecordTap(string, io.Writer) {}
+func (fakeMixer) ClearParticipantRecordTap(string)          {}
+
+// TestMultiChannelStopAll_SurvivesDiscardedLeg pins the blast radius of a single
+// leg's capture failure. A discarded capture leaves nothing at the path Stop
+// reports, and the merge refuses to open a file that is not there — so storing
+// that path anyway meant one participant's failure destroyed every other
+// participant's audio along with it. The healthy legs must still merge, and the
+// dropped one must be named rather than silently vanishing.
+func TestMultiChannelStopAll_SurvivesDiscardedLeg(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	mc := &multiChannelState{
+		active: true,
+		// Backdated so the merge spans a real duration and actually writes frames.
+		startTime:    time.Now().Add(-time.Second),
+		sampleRate:   8000,
+		dir:          dir,
+		recorders:    map[string]*recording.Recorder{},
+		pipes:        map[string]*pipeWriter{},
+		files:        map[string]string{},
+		joinOffsets:  map[string]time.Duration{},
+		leaveOffsets: map[string]time.Duration{},
+		log:          slog.Default(),
+	}
+
+	// A healthy leg: a finite reader, so the capture ends at EOF and publishes.
+	// Waiting for it here is what makes the test deterministic — stopAll would
+	// otherwise cancel it mid-flight, and a capture cancelled before its first
+	// frame publishes a headerless file the merge rejects for an unrelated
+	// reason.
+	good := recording.NewRecorder(slog.Default())
+	if _, err := good.StartAt(ctx, bytes.NewReader(make([]byte, 16000)), dir, 8000); err != nil {
+		t.Fatalf("start good leg: %v", err)
+	}
+	good.Wait()
+	if !good.Published() {
+		t.Fatal("precondition: the good leg did not publish, so this test proves nothing")
+	}
+
+	// A failing leg: a stereo companion that cannot be drained without blocking
+	// is a real, reachable capture error, so this staging file is discarded.
+	bad := recording.NewRecorder(slog.Default())
+	if _, err := bad.StartStereo(ctx, bytes.NewReader(nil), bytes.NewReader(nil), dir, 8000); err != nil {
+		t.Fatalf("start bad leg: %v", err)
+	}
+	bad.Wait()
+	if bad.Published() {
+		t.Fatal("precondition: the bad leg published, so this test proves nothing")
+	}
+
+	mc.recorders["good"] = good
+	mc.recorders["bad"] = bad
+	mc.participantOrder = []string{"good", "bad"}
+
+	res, err := mc.stopAll(fakeMixer{})
+	if err != nil {
+		t.Fatalf("stopAll lost the whole room over one discarded leg: %v", err)
+	}
+	if _, ok := res.Channels["good"]; !ok {
+		t.Errorf("the healthy leg is missing from the merge; channels = %v", res.Channels)
+	}
+	if _, ok := res.Channels["bad"]; ok {
+		t.Errorf("the discarded leg was given a channel, but it has no audio; channels = %v", res.Channels)
+	}
+	if got := res.OmittedLegs; len(got) != 1 || got[0] != "bad" {
+		t.Errorf("OmittedLegs = %v, want [bad] — a partial recording must name what it lost", got)
+	}
+}
+
+// TestMultiChannelStopAll_AllLegsDiscardedFails is the other half of the
+// contract: salvaging survivors must not degrade into reporting an empty room as
+// a success. With nothing to merge, the stop has to fail loudly.
+func TestMultiChannelStopAll_AllLegsDiscardedFails(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	mc := &multiChannelState{
+		active:       true,
+		startTime:    time.Now().Add(-time.Second),
+		sampleRate:   8000,
+		dir:          dir,
+		recorders:    map[string]*recording.Recorder{},
+		pipes:        map[string]*pipeWriter{},
+		files:        map[string]string{},
+		joinOffsets:  map[string]time.Duration{},
+		leaveOffsets: map[string]time.Duration{},
+		log:          slog.Default(),
+	}
+
+	bad := recording.NewRecorder(slog.Default())
+	if _, err := bad.StartStereo(ctx, bytes.NewReader(nil), bytes.NewReader(nil), dir, 8000); err != nil {
+		t.Fatalf("start bad leg: %v", err)
+	}
+	bad.Wait()
+	if bad.Published() {
+		t.Fatal("precondition: the bad leg published, so this test proves nothing")
+	}
+
+	mc.recorders["bad"] = bad
+	mc.participantOrder = []string{"bad"}
+
+	if _, err := mc.stopAll(fakeMixer{}); err == nil {
+		t.Fatal("stopAll reported success though no leg published any audio")
+	}
+}

--- a/internal/api/recording_multichannel_test.go
+++ b/internal/api/recording_multichannel_test.go
@@ -44,9 +44,8 @@ func TestMultiChannelStopAll_SurvivesDiscardedLeg(t *testing.T) {
 
 	// A healthy leg: a finite reader, so the capture ends at EOF and publishes.
 	// Waiting for it here is what makes the test deterministic — stopAll would
-	// otherwise cancel it mid-flight, and a capture cancelled before its first
-	// frame publishes a headerless file the merge rejects for an unrelated
-	// reason.
+	// otherwise cancel it before its first frame, which discards the capture and
+	// omits the leg from the merge, leaving nothing for this test to prove.
 	good := recording.NewRecorder(slog.Default())
 	if _, err := good.StartAt(ctx, bytes.NewReader(make([]byte, 16000)), dir, 8000); err != nil {
 		t.Fatalf("start good leg: %v", err)

--- a/internal/api/recording_published_test.go
+++ b/internal/api/recording_published_test.go
@@ -1,0 +1,285 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+	"github.com/VoiceBlender/voiceblender/internal/recording"
+)
+
+// discardedRecorder returns a recorder whose capture failed and was therefore
+// discarded, along with the path Stop will nonetheless report. A stereo
+// companion that cannot be drained without blocking is a real, reachable
+// capture error, so the staging file never reaches that path.
+func discardedRecorder(t *testing.T, dir string) (*recording.Recorder, string) {
+	t.Helper()
+	rec := recording.NewRecorder(slog.Default())
+	fpath, err := rec.StartStereo(context.Background(), bytes.NewReader(nil), bytes.NewReader(nil), dir, 8000)
+	if err != nil {
+		t.Fatalf("start discarded recorder: %v", err)
+	}
+	rec.Wait()
+	if rec.Published() {
+		t.Fatal("precondition: the capture published, so this test proves nothing")
+	}
+	if _, err := os.Stat(fpath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: something exists at %s, so this test proves nothing", fpath)
+	}
+	return rec, fpath
+}
+
+// newMultiChannelState builds an active state with every map initialised, the
+// shape startLeg and stopAll both assume.
+func newMultiChannelState(t *testing.T, dir string, startTime time.Time) *multiChannelState {
+	t.Helper()
+	return &multiChannelState{
+		active:       true,
+		startTime:    startTime,
+		sampleRate:   8000,
+		dir:          dir,
+		recorders:    map[string]*recording.Recorder{},
+		pipes:        map[string]*pipeWriter{},
+		files:        map[string]string{},
+		joinOffsets:  map[string]time.Duration{},
+		leaveOffsets: map[string]time.Duration{},
+		log:          slog.Default(),
+	}
+}
+
+// unstartableDir returns a recording directory the recorder cannot create: its
+// parent is a regular file, so MkdirAll fails with ENOTDIR. A merely absent
+// directory is no good here — the recorder creates it, and as root it creates
+// it almost anywhere.
+func unstartableDir(t *testing.T) string {
+	t.Helper()
+	blocker := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatalf("write blocker file: %v", err)
+	}
+	return filepath.Join(blocker, "recordings")
+}
+
+// TestStopLegRecording_DiscardedCaptureReportsNoFile pins the leg stop path.
+// Stop reports the path the capture was headed for whether or not it got there,
+// so returning it unconditionally handed the caller a 200 naming a file that is
+// not on disk — and, with a storage backend configured, sent that nonexistent
+// path to Upload.
+func TestStopLegRecording_DiscardedCaptureReportsNoFile(t *testing.T) {
+	s := newTestServer(t)
+	const legID = "discarded-leg"
+
+	rec, fpath := discardedRecorder(t, t.TempDir())
+	legRecorders.Lock()
+	legRecorders.m[legID] = rec
+	legRecorders.Unlock()
+	t.Cleanup(func() {
+		legRecorders.Lock()
+		delete(legRecorders.m, legID)
+		legRecorders.Unlock()
+	})
+
+	var got *events.RecordingFinishedData
+	unsub := s.Bus.Subscribe(func(e events.Event) {
+		if e.Type != events.RecordingFinished {
+			return
+		}
+		if d, ok := e.Data.(*events.RecordingFinishedData); ok {
+			got = d
+		}
+	})
+	defer unsub()
+
+	loc, ok := s.stopLegRecording(legID)
+	if !ok {
+		t.Fatal("stopLegRecording reported no recording, though one was in progress")
+	}
+	if loc != "" {
+		t.Errorf("stopLegRecording returned %q, want no location — nothing was written to %s", loc, fpath)
+	}
+	if got == nil {
+		t.Fatal("no recording.finished was published, so this test proves nothing")
+	}
+	if got.File == fpath {
+		t.Errorf("recording.finished carries File = %q, but no file exists there", got.File)
+	}
+	// The event type has no omitempty on File, so unlike the REST result it
+	// carries an empty string rather than dropping the key. API.md documents
+	// exactly this; pin it so the two cannot drift apart silently.
+	body, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal event: %v", err)
+	}
+	if decoded["file"] != "" {
+		t.Errorf("recording.finished file = %v, want an empty string; API.md documents that shape", decoded["file"])
+	}
+}
+
+// TestStopLegResult_OmitsFileWhenNothingPublished is the wire-level half: a
+// discarded capture must not put a `file` key in the response at all, which is
+// what the regenerated spec now says by leaving it out of `required`.
+func TestStopLegResult_OmitsFileWhenNothingPublished(t *testing.T) {
+	s := newTestServer(t)
+	const legID = "discarded-leg-wire"
+
+	rec, _ := discardedRecorder(t, t.TempDir())
+	legRecorders.Lock()
+	legRecorders.m[legID] = rec
+	legRecorders.Unlock()
+	t.Cleanup(func() {
+		legRecorders.Lock()
+		delete(legRecorders.m, legID)
+		legRecorders.Unlock()
+	})
+
+	res, err := s.doStopRecordLeg(legID)
+	if err != nil {
+		t.Fatalf("doStopRecordLeg: %v", err)
+	}
+	if res.Status != "stopped" {
+		t.Errorf("Status = %q, want stopped — the stop itself succeeded", res.Status)
+	}
+	body, err := json.Marshal(res)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if _, present := decoded["file"]; present {
+		t.Errorf("response carries a file key though nothing was published: %s", body)
+	}
+}
+
+// TestCleanupRoomRecording_DiscardedMixReportsNoFile pins the room stop path,
+// which had the same unconditional return as the leg path. The stop must still
+// report that a recording was in progress: answering "no recording" would turn
+// the API stop into a 404 and throw away any multi-channel result with it.
+func TestCleanupRoomRecording_DiscardedMixReportsNoFile(t *testing.T) {
+	s := newTestServer(t)
+	const roomID = "discarded-mix-room"
+	if _, err := s.RoomMgr.Create(roomID, "test-app", 8000); err != nil {
+		t.Fatalf("create room: %v", err)
+	}
+
+	rec, fpath := discardedRecorder(t, t.TempDir())
+	roomRecorders.Lock()
+	roomRecorders.m[roomID] = rec
+	roomRecorders.Unlock()
+	t.Cleanup(func() {
+		roomRecorders.Lock()
+		delete(roomRecorders.m, roomID)
+		roomRecorders.Unlock()
+	})
+
+	location, _, ok := s.cleanupRoomRecording(roomID)
+	if !ok {
+		t.Fatal("cleanupRoomRecording reported no recording, though one was in progress")
+	}
+	if location != "" {
+		t.Errorf("cleanupRoomRecording returned %q, want no location — nothing was written to %s", location, fpath)
+	}
+}
+
+// TestMultiChannelStartLeg_FailedStartIsReportedOmitted covers the leg that
+// never started. It enters neither recorders nor files, so participantOrder is
+// the only place stopAll's walk can find it — without it the leg was absent
+// from the merge and from omitted_legs alike, and the operator was told the
+// recording was complete.
+func TestMultiChannelStartLeg_FailedStartIsReportedOmitted(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	// Backdated so the merge spans a real duration and actually writes frames.
+	mc := newMultiChannelState(t, dir, time.Now().Add(-time.Second))
+
+	// A healthy leg, so the merge has something to produce and the omission is
+	// reported on a successful stop rather than swallowed by a failing one.
+	good := recording.NewRecorder(slog.Default())
+	if _, err := good.StartAt(ctx, bytes.NewReader(make([]byte, 16000)), dir, 8000); err != nil {
+		t.Fatalf("start good leg: %v", err)
+	}
+	good.Wait()
+	if !good.Published() {
+		t.Fatal("precondition: the good leg did not publish, so this test proves nothing")
+	}
+	mc.recorders["good"] = good
+	mc.participantOrder = []string{"good"}
+
+	// An uncreatable recording directory is a real, reachable per-leg start failure.
+	mc.startLeg("bad", fakeMixer{}, unstartableDir(t))
+	if _, started := mc.recorders["bad"]; started {
+		t.Fatal("precondition: the leg started, so this test proves nothing")
+	}
+
+	res, err := mc.stopAll(fakeMixer{})
+	if err != nil {
+		t.Fatalf("stopAll: %v", err)
+	}
+	if _, ok := res.Channels["bad"]; ok {
+		t.Errorf("the leg that never started was given a channel; channels = %v", res.Channels)
+	}
+	if names := res.OmittedLegs; len(names) != 1 || names[0] != "bad" {
+		t.Errorf("OmittedLegs = %v, want [bad] — a leg that never started must not vanish", names)
+	}
+}
+
+// TestMultiChannelStartLeg_ParticipantRecordedAtMostOnce walks every ordering
+// that reaches the participantOrder append. A failed start is recorded there so
+// stopAll can report it omitted, but a failed start never enters recorders — so
+// the recorders guard cannot catch a retry, and each retried ordering could
+// give one leg two channel positions. That duplicates the leg's channel in the
+// merge (numChannels is len(inputs)) and leaves Channels, keyed by leg ID,
+// naming only the later index.
+func TestMultiChannelStartLeg_ParticipantRecordedAtMostOnce(t *testing.T) {
+	tests := []struct {
+		name  string
+		dirs  []func(t *testing.T) string // one per startLeg call, in order
+		joins bool                        // whether a successful start is expected
+	}{
+		{
+			name:  "start succeeds",
+			dirs:  []func(*testing.T) string{func(t *testing.T) string { return t.TempDir() }},
+			joins: true,
+		},
+		{
+			name: "start fails then fails again",
+			dirs: []func(*testing.T) string{unstartableDir, unstartableDir},
+		},
+		{
+			name: "start fails then succeeds on retry",
+			dirs: []func(*testing.T) string{
+				unstartableDir,
+				func(t *testing.T) string { return t.TempDir() },
+			},
+			joins: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := newMultiChannelState(t, t.TempDir(), time.Now())
+			for _, dir := range tc.dirs {
+				mc.startLeg("flaky", fakeMixer{}, dir(t))
+			}
+
+			if got := mc.participantOrder; len(got) != 1 || got[0] != "flaky" {
+				t.Fatalf("participantOrder = %v, want [flaky] exactly once — a duplicate "+
+					"position duplicates the leg's channel in the merge", got)
+			}
+			if _, started := mc.recorders["flaky"]; started != tc.joins {
+				t.Errorf("recorders has flaky = %v, want %v", started, tc.joins)
+			}
+		})
+	}
+}

--- a/internal/api/recording_test.go
+++ b/internal/api/recording_test.go
@@ -7,9 +7,9 @@ import (
 	"log/slog"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/VoiceBlender/voiceblender/internal/recording"
+	"github.com/go-audio/wav"
 )
 
 // TestPipeReader_TryRead covers the non-blocking read contract: nothing ready
@@ -101,20 +101,57 @@ func TestPipeReader_TryRead(t *testing.T) {
 	})
 }
 
+// masterGate wraps the master pipe and reports once the recorder has read every
+// frame the test queued into it. That is a direct observation of the recorder
+// having consumed the pipe, which is what makes closing the writers safe:
+// pipeReader.Read selects between a queued frame and the closed-writer signal,
+// and Go picks uniformly at random when both are ready, so a close that
+// overtakes queued frames discards them and ends the capture early.
+//
+// It delegates to the real pipeReader, and the companion pipe — the linkage
+// under test — is handed to the recorder unwrapped.
+//
+// It is read only by the recording goroutine; the test only receives on drained.
+type masterGate struct {
+	r       *pipeReader
+	want    int
+	read    int
+	sent    bool
+	drained chan struct{}
+}
+
+func (g *masterGate) Read(p []byte) (int, error) {
+	n, err := g.r.Read(p)
+	g.read += n
+	if !g.sent && g.read >= g.want {
+		g.sent = true
+		close(g.drained)
+	}
+	return n, err
+}
+
 // TestStartStereo_CompanionAudioReachesLeftChannel wires the real recording
 // pipes into the real stereo recorder, which is the linkage the recording
 // package's own tests cannot cover: they stand in their own pipe double, so
 // they would stay green if this pipe stopped satisfying the recorder's
 // non-blocking-read requirement and every recording's left channel silently
 // went mute.
+//
+// Every companion frame carries its own marker, so the left channel is checked
+// slot by slot for order and completeness rather than for the mere presence of
+// companion audio. Frames that all looked alike would let a pop that advances by
+// the wrong stride — repeating or skipping frames — still produce a left channel
+// indistinguishable from a correct one.
 func TestStartStereo_CompanionAudioReachesLeftChannel(t *testing.T) {
 	const (
 		rate         = 8000
 		slotBytes    = rate / 50 * 2 // one 20 ms frame, as the taps emit
+		slotSamples  = slotBytes / 2
 		nFrames      = 8
 		masterSample = int16(0x2222)
-		compSample   = int16(0x1111)
 	)
+
+	compSample := func(k int) int16 { return int16(0x1000 + k) }
 
 	frameOf := func(v int16) []byte {
 		b := make([]byte, slotBytes)
@@ -128,45 +165,66 @@ func TestStartStereo_CompanionAudioReachesLeftChannel(t *testing.T) {
 	// Exactly the wiring doStartRecordLeg uses for a standalone SIP leg.
 	leftPR, leftPW := createPipe()
 	rightPR, rightPW := createPipe()
+	gate := &masterGate{r: rightPR, want: nFrames * slotBytes, drained: make(chan struct{})}
 
 	rec := recording.NewRecorder(slog.Default())
-	fpath, err := rec.StartStereo(context.Background(), leftPR, rightPR, dir, rate)
+	fpath, err := rec.StartStereo(context.Background(), leftPR, gate, dir, rate)
 	if err != nil {
 		t.Fatalf("StartStereo: %v", err)
 	}
 
+	// Queue every companion frame before the first master frame. The recorder
+	// reads the master before it drains the companion, so with no master frame
+	// written it cannot have touched the companion pipe yet: all nFrames are
+	// queued by the time the first slot drains it, and each slot pops one. That
+	// makes the slot-to-frame mapping below exact rather than timing-dependent.
 	for k := 0; k < nFrames; k++ {
-		leftPW.Write(frameOf(compSample))
+		leftPW.Write(frameOf(compSample(k)))
+	}
+	for k := 0; k < nFrames; k++ {
 		rightPW.Write(frameOf(masterSample))
 	}
-	// Let the recorder drain before the close races the queued frames.
-	time.Sleep(200 * time.Millisecond)
+
+	// Every master frame is provably out of the pipe, so the close races nothing.
+	<-gate.drained
 	leftPW.Close()
 	rightPW.Close()
 	rec.Wait()
 
-	data, err := os.ReadFile(fpath)
+	f, err := os.Open(fpath)
 	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
+		t.Fatalf("open recording: %v — the recorder wrote nothing, so it rejected these pipes", err)
 	}
-	if len(data) < 44 {
-		t.Fatalf("WAV is %d bytes: the recorder wrote nothing, so it rejected these pipes", len(data))
-	}
-	pcm := data[44:]
+	defer f.Close()
 
-	var sawMaster, sawCompanion bool
-	for i := 0; i+3 < len(pcm); i += 4 {
-		if int16(binary.LittleEndian.Uint16(pcm[i:])) == compSample {
-			sawCompanion = true
-		}
-		if int16(binary.LittleEndian.Uint16(pcm[i+2:])) == masterSample {
-			sawMaster = true
-		}
+	dec := wav.NewDecoder(f)
+	buf, err := dec.FullPCMBuffer()
+	if err != nil {
+		t.Fatalf("decode recording: %v", err)
 	}
-	if !sawMaster {
-		t.Error("right channel carries no master audio: the paced pipe is not clocking the recorder")
+	if got := int(dec.NumChans); got != 2 {
+		t.Fatalf("recording has %d channels, want 2", got)
 	}
-	if !sawCompanion {
-		t.Error("left channel is silent: audio written to the companion pipe never reached the recording")
+
+	// The master clocks one slot per frame and nothing else ends the capture, so
+	// the slot count is exact.
+	if got, want := len(buf.Data), nFrames*slotSamples*2; got != want {
+		t.Fatalf("recording holds %d interleaved samples, want %d (%d slots of %d)",
+			got, want, nFrames, slotSamples)
+	}
+
+	for k := 0; k < nFrames; k++ {
+		for i := 0; i < slotSamples; i++ {
+			j := (k*slotSamples + i) * 2
+			if got := int16(buf.Data[j]); got != compSample(k) {
+				t.Fatalf("left channel slot %d sample %d = %#04x, want companion frame %d (%#04x): "+
+					"the companion frames did not reach the recording one per slot in order",
+					k, i, got, k, compSample(k))
+			}
+			if got := int16(buf.Data[j+1]); got != masterSample {
+				t.Fatalf("right channel slot %d sample %d = %#04x, want master (%#04x): "+
+					"the paced pipe is not clocking the recorder", k, i, got, masterSample)
+			}
+		}
 	}
 }

--- a/internal/api/recording_test.go
+++ b/internal/api/recording_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"io"
+	"testing"
+)
+
+// TestPipeReader_TryRead covers the non-blocking read contract: nothing ready
+// yields (0, nil) without waiting, a buffered remainder is served before the
+// channel, and io.EOF appears only after Close plus a full drain.
+func TestPipeReader_TryRead(t *testing.T) {
+	t.Run("empty returns zero without blocking", func(t *testing.T) {
+		pr, _ := createPipe()
+		p := make([]byte, 4)
+		n, err := pr.TryRead(p)
+		if n != 0 || err != nil {
+			t.Fatalf("TryRead on empty pipe = (%d, %v), want (0, nil)", n, err)
+		}
+	})
+
+	t.Run("serves a queued frame", func(t *testing.T) {
+		pr, pw := createPipe()
+		pw.Write([]byte{1, 2, 3, 4})
+		p := make([]byte, 4)
+		n, err := pr.TryRead(p)
+		if n != 4 || err != nil {
+			t.Fatalf("TryRead = (%d, %v), want (4, nil)", n, err)
+		}
+		if string(p) != string([]byte{1, 2, 3, 4}) {
+			t.Fatalf("TryRead payload = %v, want [1 2 3 4]", p)
+		}
+	})
+
+	t.Run("serves buffered remainder before the channel", func(t *testing.T) {
+		pr, pw := createPipe()
+		pw.Write([]byte{1, 2, 3, 4})
+		pw.Write([]byte{9, 9})
+
+		// A short read leaves a remainder buffered on the reader.
+		small := make([]byte, 2)
+		n, err := pr.TryRead(small)
+		if n != 2 || err != nil {
+			t.Fatalf("first TryRead = (%d, %v), want (2, nil)", n, err)
+		}
+		if small[0] != 1 || small[1] != 2 {
+			t.Fatalf("first TryRead payload = %v, want [1 2]", small)
+		}
+
+		// The remainder of frame one must win over the queued frame two.
+		n, err = pr.TryRead(small)
+		if n != 2 || err != nil {
+			t.Fatalf("second TryRead = (%d, %v), want (2, nil)", n, err)
+		}
+		if small[0] != 3 || small[1] != 4 {
+			t.Fatalf("remainder served out of order: got %v, want [3 4]", small)
+		}
+
+		n, err = pr.TryRead(small)
+		if n != 2 || err != nil {
+			t.Fatalf("third TryRead = (%d, %v), want (2, nil)", n, err)
+		}
+		if small[0] != 9 || small[1] != 9 {
+			t.Fatalf("third TryRead payload = %v, want [9 9]", small)
+		}
+	})
+
+	t.Run("EOF only after close and drain", func(t *testing.T) {
+		pr, pw := createPipe()
+		pw.Write([]byte{7, 7})
+		pw.Close()
+
+		// Still queued data: must be served, not swallowed by the close.
+		p := make([]byte, 4)
+		n, err := pr.TryRead(p)
+		if n != 2 || err != nil {
+			t.Fatalf("TryRead after Close with data queued = (%d, %v), want (2, nil)", n, err)
+		}
+
+		n, err = pr.TryRead(p)
+		if n != 0 || err != io.EOF {
+			t.Fatalf("TryRead after Close and drain = (%d, %v), want (0, io.EOF)", n, err)
+		}
+	})
+
+	t.Run("open and empty is not EOF", func(t *testing.T) {
+		pr, _ := createPipe()
+		p := make([]byte, 4)
+		for i := 0; i < 3; i++ {
+			n, err := pr.TryRead(p)
+			if n != 0 || err != nil {
+				t.Fatalf("TryRead on open empty pipe = (%d, %v), want (0, nil)", n, err)
+			}
+		}
+	})
+}

--- a/internal/api/recording_test.go
+++ b/internal/api/recording_test.go
@@ -1,8 +1,15 @@
 package api
 
 import (
+	"context"
+	"encoding/binary"
 	"io"
+	"log/slog"
+	"os"
 	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/recording"
 )
 
 // TestPipeReader_TryRead covers the non-blocking read contract: nothing ready
@@ -92,4 +99,74 @@ func TestPipeReader_TryRead(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestStartStereo_CompanionAudioReachesLeftChannel wires the real recording
+// pipes into the real stereo recorder, which is the linkage the recording
+// package's own tests cannot cover: they stand in their own pipe double, so
+// they would stay green if this pipe stopped satisfying the recorder's
+// non-blocking-read requirement and every recording's left channel silently
+// went mute.
+func TestStartStereo_CompanionAudioReachesLeftChannel(t *testing.T) {
+	const (
+		rate         = 8000
+		slotBytes    = rate / 50 * 2 // one 20 ms frame, as the taps emit
+		nFrames      = 8
+		masterSample = int16(0x2222)
+		compSample   = int16(0x1111)
+	)
+
+	frameOf := func(v int16) []byte {
+		b := make([]byte, slotBytes)
+		for i := 0; i+1 < len(b); i += 2 {
+			binary.LittleEndian.PutUint16(b[i:], uint16(v))
+		}
+		return b
+	}
+
+	dir := t.TempDir()
+	// Exactly the wiring doStartRecordLeg uses for a standalone SIP leg.
+	leftPR, leftPW := createPipe()
+	rightPR, rightPW := createPipe()
+
+	rec := recording.NewRecorder(slog.Default())
+	fpath, err := rec.StartStereo(context.Background(), leftPR, rightPR, dir, rate)
+	if err != nil {
+		t.Fatalf("StartStereo: %v", err)
+	}
+
+	for k := 0; k < nFrames; k++ {
+		leftPW.Write(frameOf(compSample))
+		rightPW.Write(frameOf(masterSample))
+	}
+	// Let the recorder drain before the close races the queued frames.
+	time.Sleep(200 * time.Millisecond)
+	leftPW.Close()
+	rightPW.Close()
+	rec.Wait()
+
+	data, err := os.ReadFile(fpath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(data) < 44 {
+		t.Fatalf("WAV is %d bytes: the recorder wrote nothing, so it rejected these pipes", len(data))
+	}
+	pcm := data[44:]
+
+	var sawMaster, sawCompanion bool
+	for i := 0; i+3 < len(pcm); i += 4 {
+		if int16(binary.LittleEndian.Uint16(pcm[i:])) == compSample {
+			sawCompanion = true
+		}
+		if int16(binary.LittleEndian.Uint16(pcm[i+2:])) == masterSample {
+			sawMaster = true
+		}
+	}
+	if !sawMaster {
+		t.Error("right channel carries no master audio: the paced pipe is not clocking the recorder")
+	}
+	if !sawCompanion {
+		t.Error("left channel is silent: audio written to the companion pipe never reached the recording")
+	}
 }

--- a/internal/events/data.go
+++ b/internal/events/data.go
@@ -338,6 +338,9 @@ type RecordingFinishedData struct {
 	File             string                           `json:"file"`
 	MultiChannelFile string                           `json:"multi_channel_file,omitempty"`
 	Channels         map[string]recording.ChannelInfo `json:"channels,omitempty"`
+	// OmittedLegs names participants whose audio is missing from the merged
+	// file because their capture failed. Absent when the recording is complete.
+	OmittedLegs []string `json:"omitted_legs,omitempty"`
 }
 
 type RecordingPausedData struct {

--- a/internal/recording/companion_test.go
+++ b/internal/recording/companion_test.go
@@ -1,0 +1,170 @@
+package recording
+
+import (
+	"bytes"
+	"testing"
+)
+
+// slotOf builds a slotBytes-long slot whose every byte is v, so a popped slot
+// can be identified by value.
+func slotOf(v byte, slotBytes int) []byte {
+	return bytes.Repeat([]byte{v}, slotBytes)
+}
+
+func TestCompanionBuffer_AppendAndBound(t *testing.T) {
+	const slotBytes = 4
+
+	tests := []struct {
+		name     string
+		maxSlots int
+		appends  []byte // one slot appended per value
+		wantSize int
+		wantTail []byte // expected remaining slot values, oldest first
+	}{
+		{
+			name:     "below bound retains all",
+			maxSlots: 4,
+			appends:  []byte{1, 2, 3},
+			wantSize: 3 * slotBytes,
+			wantTail: []byte{1, 2, 3},
+		},
+		{
+			name:     "exactly at bound retains all",
+			maxSlots: 3,
+			appends:  []byte{1, 2, 3},
+			wantSize: 3 * slotBytes,
+			wantTail: []byte{1, 2, 3},
+		},
+		{
+			name:     "over bound drops the oldest slot",
+			maxSlots: 3,
+			appends:  []byte{1, 2, 3, 4},
+			wantSize: 3 * slotBytes,
+			wantTail: []byte{2, 3, 4},
+		},
+		{
+			name:     "far over bound keeps only the newest slots",
+			maxSlots: 2,
+			appends:  []byte{1, 2, 3, 4, 5, 6, 7},
+			wantSize: 2 * slotBytes,
+			wantTail: []byte{6, 7},
+		},
+		{
+			name:     "single slot bound keeps the newest only",
+			maxSlots: 1,
+			appends:  []byte{1, 2, 3},
+			wantSize: slotBytes,
+			wantTail: []byte{3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newCompanionBuffer(slotBytes, tc.maxSlots)
+			for _, v := range tc.appends {
+				c.append(slotOf(v, slotBytes))
+			}
+
+			if got := c.size(); got != tc.wantSize {
+				t.Errorf("size = %d, want %d", got, tc.wantSize)
+			}
+			if got := c.size(); got > tc.maxSlots*slotBytes {
+				t.Errorf("size %d exceeds bound %d", got, tc.maxSlots*slotBytes)
+			}
+
+			// The retained tail must be the newest slots, oldest first.
+			for i, want := range tc.wantTail {
+				slot, ok := c.pop()
+				if !ok {
+					t.Fatalf("pop %d: got !ok, want slot %d", i, want)
+				}
+				if !bytes.Equal(slot, slotOf(want, slotBytes)) {
+					t.Fatalf("pop %d = %v, want slot of %d", i, slot, want)
+				}
+			}
+			if _, ok := c.pop(); ok {
+				t.Error("pop after draining the tail: got ok, want !ok")
+			}
+		})
+	}
+}
+
+func TestCompanionBuffer_PopOnEmpty(t *testing.T) {
+	c := newCompanionBuffer(4, 4)
+	slot, ok := c.pop()
+	if ok {
+		t.Errorf("pop on empty = (%v, true), want (nil, false)", slot)
+	}
+}
+
+func TestCompanionBuffer_PopUnderflowKeepsPartialSlot(t *testing.T) {
+	const slotBytes = 4
+	c := newCompanionBuffer(slotBytes, 4)
+
+	// A partial slot is not poppable...
+	c.append([]byte{1, 1})
+	if _, ok := c.pop(); ok {
+		t.Fatal("pop with a partial slot buffered: got ok, want !ok")
+	}
+	if got := c.size(); got != 2 {
+		t.Fatalf("size after failed pop = %d, want 2 (partial slot retained)", got)
+	}
+
+	// ...until the rest of it arrives, and it must not be lost.
+	c.append([]byte{2, 2})
+	slot, ok := c.pop()
+	if !ok {
+		t.Fatal("pop after the slot completed: got !ok, want ok")
+	}
+	if !bytes.Equal(slot, []byte{1, 1, 2, 2}) {
+		t.Errorf("pop = %v, want [1 1 2 2] (partial slot must reassemble)", slot)
+	}
+}
+
+func TestCompanionBuffer_PopAdvancesOneSlotAtATime(t *testing.T) {
+	const slotBytes = 4
+	c := newCompanionBuffer(slotBytes, 8)
+	c.append(slotOf(1, slotBytes))
+	c.append(slotOf(2, slotBytes))
+
+	slot, ok := c.pop()
+	if !ok || !bytes.Equal(slot, slotOf(1, slotBytes)) {
+		t.Fatalf("first pop = (%v, %v), want (slot of 1, true)", slot, ok)
+	}
+	if got := c.size(); got != slotBytes {
+		t.Errorf("size after one pop = %d, want %d (exactly one slot consumed)", got, slotBytes)
+	}
+
+	slot, ok = c.pop()
+	if !ok || !bytes.Equal(slot, slotOf(2, slotBytes)) {
+		t.Fatalf("second pop = (%v, %v), want (slot of 2, true)", slot, ok)
+	}
+	if got := c.size(); got != 0 {
+		t.Errorf("size after draining = %d, want 0", got)
+	}
+}
+
+// TestCompanionBuffer_AppendAcrossSlotBoundaries feeds byte runs that do not
+// line up with slot boundaries, mirroring a writer whose frames are not exactly
+// one slot each.
+func TestCompanionBuffer_AppendAcrossSlotBoundaries(t *testing.T) {
+	const slotBytes = 4
+	c := newCompanionBuffer(slotBytes, 2)
+
+	// 12 bytes = 3 slots, fed in 5-, 5- and 2-byte runs; bound is 2 slots.
+	c.append([]byte{1, 1, 1, 1, 2})
+	c.append([]byte{2, 2, 2, 3, 3})
+	c.append([]byte{3, 3})
+
+	if got, want := c.size(), 2*slotBytes; got != want {
+		t.Fatalf("size = %d, want %d", got, want)
+	}
+	slot, ok := c.pop()
+	if !ok || !bytes.Equal(slot, slotOf(2, slotBytes)) {
+		t.Fatalf("first pop = (%v, %v), want (slot of 2, true) — oldest slot should have been dropped", slot, ok)
+	}
+	slot, ok = c.pop()
+	if !ok || !bytes.Equal(slot, slotOf(3, slotBytes)) {
+		t.Fatalf("second pop = (%v, %v), want (slot of 3, true)", slot, ok)
+	}
+}

--- a/internal/recording/merge.go
+++ b/internal/recording/merge.go
@@ -83,14 +83,25 @@ func MergeMultiChannel(dir string, inputs []MultiChannelInput, totalDuration tim
 	filename := fmt.Sprintf("%s_multichannel_%s.wav",
 		time.Now().Format("20060102_150405"), uuid.New().String()[:8])
 	outPath := filepath.Join(dir, filename)
-	outFile, err := os.Create(outPath)
+	// The merged output is staged next to its final name and only renamed there
+	// once its bytes are durable, so a caller listing the directory never sees a
+	// half-written merge at outPath.
+	staged, err := createStagedFile(outPath)
 	if err != nil {
 		return nil, fmt.Errorf("create output: %w", err)
 	}
-	defer outFile.Close()
+	outFile := staged.f
 
 	enc := wav.NewEncoder(outFile, sampleRate, 16, numChannels, 1)
-	defer enc.Close()
+	// Until the merge reaches its finalize step below, any return is a failure
+	// and must leave nothing behind at either name.
+	finalized := false
+	defer func() {
+		if !finalized {
+			enc.Close()
+			discardTemp(outFile, staged.tmpPath)
+		}
+	}()
 
 	// Read buffers — one per channel.
 	const frameSamples = 320 // 20ms at 16kHz
@@ -159,6 +170,17 @@ func MergeMultiChannel(dir string, inputs []MultiChannelInput, totalDuration tim
 		if werr := enc.Write(outBuf); werr != nil {
 			return nil, fmt.Errorf("write merged frame: %w", werr)
 		}
+	}
+
+	// enc.Close rewrites the RIFF/data size header, so it has to complete before
+	// the file is synced and renamed into place.
+	finalized = true
+	if err := enc.Close(); err != nil {
+		discardTemp(outFile, staged.tmpPath)
+		return nil, fmt.Errorf("close merged output: %w", err)
+	}
+	if err := publishFile(outFile, staged.tmpPath, staged.finalPath); err != nil {
+		return nil, fmt.Errorf("publish merged output: %w", err)
 	}
 
 	// Build channel metadata.

--- a/internal/recording/merge.go
+++ b/internal/recording/merge.go
@@ -31,6 +31,15 @@ type MultiChannelInput struct {
 type MultiChannelResult struct {
 	FilePath string
 	Channels map[string]ChannelInfo
+	// OmittedLegs names participants who took part but are absent from the
+	// merged file, because their capture produced nothing to merge. It is empty
+	// when every participant made it in.
+	//
+	// MergeMultiChannel never sets this: it merges exactly the inputs it is
+	// given and has no way to know a participant was dropped before it was
+	// called. Whoever selects the inputs fills it in, and only that caller can
+	// distinguish a complete recording from a partial one — so it must say.
+	OmittedLegs []string
 }
 
 // MergeMultiChannel reads per-participant mono WAV files and produces a single

--- a/internal/recording/merge_test.go
+++ b/internal/recording/merge_test.go
@@ -1,0 +1,92 @@
+package recording
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-audio/audio"
+	"github.com/go-audio/wav"
+)
+
+// writeMonoWAV lays down a mono WAV for the merge inputs.
+func writeMonoWAV(t *testing.T, path string, sampleRate, samples int) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer f.Close()
+
+	enc := wav.NewEncoder(f, sampleRate, 16, 1, 1)
+	buf := &audio.IntBuffer{
+		Format:         &audio.Format{SampleRate: sampleRate, NumChannels: 1},
+		Data:           make([]int, samples),
+		SourceBitDepth: 16,
+	}
+	for i := range buf.Data {
+		buf.Data[i] = 100 + i%50
+	}
+	if err := enc.Write(buf); err != nil {
+		t.Fatalf("encode %s: %v", path, err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("close encoder for %s: %v", path, err)
+	}
+}
+
+// TestMergeMultiChannel_PublishesDurably covers the merge output through the
+// same durable publish as a captured recording.
+func TestMergeMultiChannel_PublishesDurably(t *testing.T) {
+	const sampleRate = 16000
+
+	// Inputs live outside the output directory so the residue check there is
+	// unambiguous.
+	srcDir := t.TempDir()
+	outDir := t.TempDir()
+
+	a := filepath.Join(srcDir, "a.wav")
+	b := filepath.Join(srcDir, "b.wav")
+	writeMonoWAV(t, a, sampleRate, sampleRate)
+	writeMonoWAV(t, b, sampleRate, sampleRate)
+
+	res, err := MergeMultiChannel(outDir, []MultiChannelInput{
+		{LegID: "a", FilePath: a},
+		{LegID: "b", FilePath: b, JoinOffset: 500 * time.Millisecond},
+	}, time.Second, sampleRate)
+	if err != nil {
+		t.Fatalf("MergeMultiChannel: %v", err)
+	}
+
+	assertPlayable(t, res.FilePath, 2)
+	assertPublishedMode(t, res.FilePath)
+	assertNoStagingResidue(t, outDir)
+}
+
+// TestMergeMultiChannel_InvalidInputLeavesNothingBehind proves a merge that
+// fails part-way publishes nothing and leaves no staging file.
+func TestMergeMultiChannel_InvalidInputLeavesNothingBehind(t *testing.T) {
+	srcDir := t.TempDir()
+	outDir := t.TempDir()
+
+	bad := filepath.Join(srcDir, "bad.wav")
+	if err := os.WriteFile(bad, []byte("not a wav"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", bad, err)
+	}
+
+	if _, err := MergeMultiChannel(outDir, []MultiChannelInput{
+		{LegID: "a", FilePath: bad},
+	}, time.Second, 16000); err == nil {
+		t.Fatal("MergeMultiChannel accepted an invalid input WAV, want error")
+	}
+	assertNoStagingResidue(t, outDir)
+
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", outDir, err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("a failed merge left %d files in %s, want none", len(entries), outDir)
+	}
+}

--- a/internal/recording/merge_test.go
+++ b/internal/recording/merge_test.go
@@ -3,6 +3,7 @@ package recording
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -41,6 +42,15 @@ func writeMonoWAV(t *testing.T, path string, sampleRate, samples int) {
 func TestMergeMultiChannel_PublishesDurably(t *testing.T) {
 	const sampleRate = 16000
 
+	// The restrictive umask is what gives assertPublishedMode teeth. Both halves
+	// of the staged publish are umask-independent — os.CreateTemp always opens
+	// 0600, and the explicit chmod always restores 0644 — whereas a merge that
+	// created its output directly would get 0666 &^ umask, i.e. 0600 here. So
+	// under this umask only a genuinely staged-and-chmod'd merge can produce the
+	// 0644 the assertion demands; without it, both routes yield 0644 and the
+	// assertion cannot tell them apart.
+	defer syscall.Umask(syscall.Umask(0o077))
+
 	// Inputs live outside the output directory so the residue check there is
 	// unambiguous.
 	srcDir := t.TempDir()
@@ -64,9 +74,16 @@ func TestMergeMultiChannel_PublishesDurably(t *testing.T) {
 	assertNoStagingResidue(t, outDir)
 }
 
-// TestMergeMultiChannel_InvalidInputLeavesNothingBehind proves a merge that
-// fails part-way publishes nothing and leaves no staging file.
-func TestMergeMultiChannel_InvalidInputLeavesNothingBehind(t *testing.T) {
+// TestMergeMultiChannel_InvalidInputCreatesNoOutput covers the input-validation
+// refusal: an unreadable input is rejected before any output file is created, so
+// the output directory is left untouched.
+//
+// Note what this does NOT cover. The merge returns here at the input-validation
+// loop, before staging has begun, so it never reaches the failure cleanup and
+// that cleanup is not what these assertions observe. Exercising it would need an
+// output write to fail, and the merge opens its own output, so there is no
+// injection point for one.
+func TestMergeMultiChannel_InvalidInputCreatesNoOutput(t *testing.T) {
 	srcDir := t.TempDir()
 	outDir := t.TempDir()
 

--- a/internal/recording/recorder.go
+++ b/internal/recording/recorder.go
@@ -67,6 +67,12 @@ func (r *Recorder) StartAt(ctx context.Context, reader io.Reader, dir string, sa
 
 // StartStereo begins a stereo recording with left and right channel readers.
 // Left channel = participant's incoming audio, right channel = room mix.
+//
+// The right reader is the master clock and must be paced (written every frame,
+// silence included); it alone determines the recording's timeline. The left
+// reader is the companion: it may stall or burst, and must support TryRead so
+// it can be drained without blocking. See recordStereo.
+//
 // Returns the file path of the recording.
 func (r *Recorder) StartStereo(ctx context.Context, left, right io.Reader, dir string, sampleRate uint32) (string, error) {
 	f, fpath, cancel, err := r.initRecording(ctx, dir)
@@ -230,18 +236,56 @@ func (r *Recorder) recordMono(ctx context.Context, reader io.Reader, f *os.File,
 	}
 }
 
-// recordStereo reads one frame at a time from left and right readers,
-// interleaves the samples [L0, R0, L1, R1, ...], and writes a stereo WAV file.
-// While paused, interleaved samples are zeroed.
+// tryReader is a reader that can be drained without blocking. The companion
+// channel must satisfy it so that a companion with nothing to say cannot stall
+// the master clock.
+type tryReader interface {
+	// TryRead reads whatever is immediately available, returning (0, nil) when
+	// nothing is ready rather than waiting. It returns io.EOF only once the
+	// source is closed and drained.
+	TryRead(p []byte) (int, error)
+}
+
+// recordStereo writes a stereo WAV [L0, R0, L1, R1, ...] driven by the right
+// reader's clock.
+//
+// The right channel is the master: it is fed continuously (silence included) by
+// the leg's write loop or the room's mix tick, so each right frame read emits
+// exactly one output slot and the file advances in real time. The left channel
+// is the companion: it is written only when a packet actually arrives, so it is
+// bursty and gap-prone. Reading it in lock-step with the master would park the
+// loop the moment incoming audio stalled, while the master kept being written
+// and silently dropped frames — leaving the two channels permanently skewed for
+// the rest of the call. Instead the companion is drained without blocking into
+// a bounded accumulator, and each slot either pops one companion frame or falls
+// back to silence. The channels therefore stay sample-aligned across a stall.
+//
+// While paused, interleaved samples are zeroed on both channels.
 func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *os.File, sampleRate int) error {
 	defer f.Close()
+
+	// One slot is one 20 ms tap frame, the cadence both tap writers emit at.
+	slotBytes := sampleRate / 50 * 2
+	if slotBytes <= 0 {
+		return fmt.Errorf("stereo recording: sample rate %d is too low", sampleRate)
+	}
+	slotSamples := slotBytes / 2
+
+	// Both wired companions are pipe readers, which are non-blocking-capable.
+	// Anything else would silence the left channel for the entire call, so say
+	// so instead of quietly recording half a conversation.
+	companion, ok := left.(tryReader)
+	if !ok {
+		return fmt.Errorf("stereo recording: companion reader %T cannot be read without blocking", left)
+	}
 
 	enc := wav.NewEncoder(f, sampleRate, 16, 2, 1) // stereo, PCM format=1
 	defer enc.Close()
 
-	const frameSizeBytes = 640 // 320 samples * 2 bytes per sample
-	leftBuf := make([]byte, frameSizeBytes)
-	rightBuf := make([]byte, frameSizeBytes)
+	masterBuf := make([]byte, slotBytes)
+	drainBuf := make([]byte, slotBytes)
+	silence := make([]byte, slotBytes)
+	acc := newCompanionBuffer(slotBytes, companionMaxSlots)
 
 	intBuf := &audio.IntBuffer{
 		Format: &audio.Format{
@@ -257,31 +301,37 @@ func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *o
 		default:
 		}
 
-		ln, lerr := io.ReadFull(left, leftBuf)
-		rn, rerr := io.ReadFull(right, rightBuf)
-
-		// Use whichever has fewer samples to stay aligned.
-		nSamples := ln / 2
-		if rn/2 < nSamples {
-			nSamples = rn / 2
-		}
-
-		if nSamples > 0 {
-			interleaved := make([]int, nSamples*2)
-			if !r.paused.Load() {
-				for i := 0; i < nSamples; i++ {
-					interleaved[i*2] = int(int16(binary.LittleEndian.Uint16(leftBuf[i*2:])))
-					interleaved[i*2+1] = int(int16(binary.LittleEndian.Uint16(rightBuf[i*2:])))
-				}
-			}
-			intBuf.Data = interleaved
-			if werr := enc.Write(intBuf); werr != nil {
-				return werr
-			}
-		}
-
-		if lerr != nil || rerr != nil {
+		// The master paces the recording: one full frame in, one slot out.
+		if _, rerr := io.ReadFull(right, masterBuf); rerr != nil {
 			return nil
+		}
+
+		// Take whatever the companion has ready right now, and no more.
+		for {
+			n, cerr := companion.TryRead(drainBuf)
+			if n > 0 {
+				acc.append(drainBuf[:n])
+			}
+			if cerr != nil || n == 0 {
+				break
+			}
+		}
+
+		leftSlot, popped := acc.pop()
+		if !popped {
+			leftSlot = silence
+		}
+
+		interleaved := make([]int, slotSamples*2)
+		if !r.paused.Load() {
+			for i := 0; i < slotSamples; i++ {
+				interleaved[i*2] = int(int16(binary.LittleEndian.Uint16(leftSlot[i*2:])))
+				interleaved[i*2+1] = int(int16(binary.LittleEndian.Uint16(masterBuf[i*2:])))
+			}
+		}
+		intBuf.Data = interleaved
+		if werr := enc.Write(intBuf); werr != nil {
+			return werr
 		}
 	}
 }

--- a/internal/recording/recorder.go
+++ b/internal/recording/recorder.go
@@ -29,6 +29,7 @@ type Recorder struct {
 	cancel    context.CancelFunc
 	filePath  string
 	published bool
+	finalized bool
 	done      chan struct{}
 	log       *slog.Logger
 	paused    atomic.Bool
@@ -138,6 +139,7 @@ func (r *Recorder) initRecording(ctx context.Context, dir string) (*stagedFile, 
 	r.recording = true
 	r.filePath = fpath
 	r.published = false
+	r.finalized = false
 	r.done = make(chan struct{})
 	r.mu.Unlock()
 
@@ -165,12 +167,25 @@ func (r *Recorder) finish(staged *stagedFile, wrote bool, recErr error) {
 		discardTemp(staged.f, staged.tmpPath)
 		return
 	}
-	if err := publishFile(staged.f, staged.tmpPath, staged.finalPath); err != nil {
-		r.log.Error("publish recording", "error", err, "file", staged.finalPath)
-		return
+	err := publishFile(staged.f, staged.tmpPath, staged.finalPath)
+	// publishFile drops the staging file and leaves nothing at the final path
+	// for any failure up to and including the rename, but the rename is its
+	// point of no return: a failure after it (the closing directory sync) leaves
+	// a complete, readable recording at the final path that is merely not known
+	// to survive a crash. A file present there is the signal that the rename
+	// landed, so the recording is finalized even when publishFile still errors.
+	finalized := err == nil
+	if err != nil {
+		if _, statErr := os.Stat(staged.finalPath); statErr == nil {
+			finalized = true
+			r.log.Warn("recording published with degraded durability", "error", err, "file", staged.finalPath)
+		} else {
+			r.log.Error("publish recording", "error", err, "file", staged.finalPath)
+		}
 	}
 	r.mu.Lock()
-	r.published = true
+	r.finalized = finalized
+	r.published = err == nil
 	r.mu.Unlock()
 }
 
@@ -218,11 +233,28 @@ func (r *Recorder) IsRecording() bool {
 //
 // False means "do not rely on this path", not "this path is provably empty":
 // a publish that failed only at the closing directory sync leaves the recording
-// present at its final name and still reports false.
+// present at its final name and still reports false. Finalized separates that
+// case, and is what callers deciding whether a usable file exists should check.
 func (r *Recorder) Published() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.published
+}
+
+// Finalized reports whether the recording's bytes reached the path Stop returns
+// — the staging file was fully written and renamed there, so a complete,
+// readable recording exists at that path. Unlike Published it stays true when
+// the publish failed only at the closing directory sync: the file is present
+// and readable, merely not known to survive a crash, which is a durability
+// concern rather than a corrupt-file one. A capture that wrote no frame, errored
+// mid-write, or failed its header rewrite is discarded and reports false here
+// too, because no file was renamed into place. Callers deciding whether a usable
+// recording exists — to report it or hand it on — check this rather than
+// Published, which demands the stronger durability guarantee.
+func (r *Recorder) Finalized() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.finalized
 }
 
 // Pause instructs the recorder to replace incoming audio with silence

--- a/internal/recording/recorder.go
+++ b/internal/recording/recorder.go
@@ -57,13 +57,13 @@ func (r *Recorder) StartAt(ctx context.Context, reader io.Reader, dir string, sa
 		// blocked on Wait() observe IsRecording()==false the moment they wake.
 		defer close(r.done)
 		defer r.clearRecording()
-		err := r.recordMono(cancel.ctx, reader, staged.f, int(sampleRate))
+		wrote, err := r.recordMono(cancel.ctx, reader, staged.f, int(sampleRate))
 		if err != nil && cancel.ctx.Err() == nil {
 			r.log.Error("recording error", "error", err)
 		}
 		// Publishing runs ahead of the deferred handshake so that Wait callers
 		// find the recording at its final path the moment they wake.
-		r.finish(staged, err)
+		r.finish(staged, wrote, err)
 	}()
 
 	return staged.finalPath, nil
@@ -89,13 +89,13 @@ func (r *Recorder) StartStereo(ctx context.Context, left, right io.Reader, dir s
 		// blocked on Wait() observe IsRecording()==false the moment they wake.
 		defer close(r.done)
 		defer r.clearRecording()
-		err := r.recordStereo(cancel.ctx, left, right, staged.f, int(sampleRate))
+		wrote, err := r.recordStereo(cancel.ctx, left, right, staged.f, int(sampleRate))
 		if err != nil && cancel.ctx.Err() == nil {
 			r.log.Error("stereo recording error", "error", err)
 		}
 		// Publishing runs ahead of the deferred handshake so that Wait callers
 		// find the recording at its final path the moment they wake.
-		r.finish(staged, err)
+		r.finish(staged, wrote, err)
 	}()
 
 	return staged.finalPath, nil
@@ -151,8 +151,17 @@ func (r *Recorder) initRecording(ctx context.Context, dir string) (*stagedFile, 
 // ended: Stop cancels the context, and both capture loops report a cancelled
 // context as a successful end of recording. Treating cancellation as a failure
 // would discard every normally stopped recording.
-func (r *Recorder) finish(staged *stagedFile, recErr error) {
-	if recErr != nil {
+//
+// A capture that never wrote a frame is discarded too, even though it reports
+// no error. The encoder only emits the RIFF header on its first write, so a
+// zero-frame capture's file has no header, is not a readable WAV, and Close
+// reports no error for it — publishing it would report success for a file
+// nothing can open, and hand the merge an input it fails on. wrote tracks
+// enc.Write having been called rather than a sample count, because enc.Write
+// emits the header even for an empty buffer: "enc.Write ran" is exactly the
+// condition that makes the file readable.
+func (r *Recorder) finish(staged *stagedFile, wrote bool, recErr error) {
+	if recErr != nil || !wrote {
 		discardTemp(staged.f, staged.tmpPath)
 		return
 	}
@@ -201,9 +210,11 @@ func (r *Recorder) IsRecording() bool {
 
 // Published reports whether the last recording's bytes actually reached the
 // path Stop returns. It is false while a recording is still running, and false
-// afterwards if the capture failed mid-write, because a failed capture's bytes
-// are discarded rather than published — leaving nothing at that path. Callers
-// that hand the path on to something else should check this after Wait.
+// afterwards if the capture failed mid-write or never captured a frame, because
+// both are discarded rather than published — leaving nothing at that path. A
+// capture that stopped before its first frame is discarded because the file it
+// would publish has no WAV header at all; see finish. Callers that hand the
+// path on to something else should check this after Wait.
 //
 // False means "do not rely on this path", not "this path is provably empty":
 // a publish that failed only at the closing directory sync leaves the recording
@@ -250,7 +261,11 @@ func (r *Recorder) IsPaused() bool {
 // the encoder is what rewrites the WAV size header, so a close failure means the
 // header is still a placeholder; it is reported as a capture error and the
 // caller discards the file rather than publishing an unreadable recording.
-func (r *Recorder) recordMono(ctx context.Context, reader io.Reader, f *os.File, sampleRate int) (err error) {
+//
+// wrote reports whether any frame reached the encoder. A capture that ends
+// before its first write leaves a file with no header at all, which the caller
+// discards for the same reason.
+func (r *Recorder) recordMono(ctx context.Context, reader io.Reader, f *os.File, sampleRate int) (wrote bool, err error) {
 	enc := wav.NewEncoder(f, sampleRate, 16, 1, 1) // mono, PCM format=1
 	// A capture error wins over a close error: it is the earlier and more
 	// specific failure, and both lead to the same discard.
@@ -271,7 +286,7 @@ func (r *Recorder) recordMono(ctx context.Context, reader io.Reader, f *os.File,
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return wrote, nil
 		default:
 		}
 		n, rerr := reader.Read(buf)
@@ -282,11 +297,12 @@ func (r *Recorder) recordMono(ctx context.Context, reader io.Reader, f *os.File,
 			}
 			intBuf.Data = samples
 			if werr := enc.Write(intBuf); werr != nil {
-				return werr
+				return wrote, werr
 			}
+			wrote = true
 		}
 		if rerr != nil {
-			return nil
+			return wrote, nil
 		}
 	}
 }
@@ -330,11 +346,15 @@ type tryReader interface {
 // the encoder is what rewrites the WAV size header, so a close failure means the
 // header is still a placeholder; it is reported as a capture error and the
 // caller discards the file rather than publishing an unreadable recording.
-func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *os.File, sampleRate int) (err error) {
+//
+// wrote reports whether any slot reached the encoder. A capture that ends
+// before its first write leaves a file with no header at all, which the caller
+// discards for the same reason.
+func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *os.File, sampleRate int) (wrote bool, err error) {
 	// One slot is one 20 ms tap frame, the cadence both tap writers emit at.
 	slotBytes := sampleRate / 50 * 2
 	if slotBytes <= 0 {
-		return fmt.Errorf("stereo recording: sample rate %d is too low", sampleRate)
+		return false, fmt.Errorf("stereo recording: sample rate %d is too low", sampleRate)
 	}
 	slotSamples := slotBytes / 2
 
@@ -343,7 +363,7 @@ func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *o
 	// so instead of quietly recording half a conversation.
 	companion, ok := left.(tryReader)
 	if !ok {
-		return fmt.Errorf("stereo recording: companion reader %T cannot be read without blocking", left)
+		return false, fmt.Errorf("stereo recording: companion reader %T cannot be read without blocking", left)
 	}
 
 	enc := wav.NewEncoder(f, sampleRate, 16, 2, 1) // stereo, PCM format=1
@@ -370,13 +390,13 @@ func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *o
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return wrote, nil
 		default:
 		}
 
 		// The master paces the recording: one full frame in, one slot out.
 		if _, rerr := io.ReadFull(right, masterBuf); rerr != nil {
-			return nil
+			return wrote, nil
 		}
 
 		// Take whatever the companion has ready right now, and no more.
@@ -404,8 +424,9 @@ func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *o
 		}
 		intBuf.Data = interleaved
 		if werr := enc.Write(intBuf); werr != nil {
-			return werr
+			return wrote, werr
 		}
+		wrote = true
 	}
 }
 

--- a/internal/recording/recorder.go
+++ b/internal/recording/recorder.go
@@ -204,6 +204,10 @@ func (r *Recorder) IsRecording() bool {
 // afterwards if the capture failed mid-write, because a failed capture's bytes
 // are discarded rather than published — leaving nothing at that path. Callers
 // that hand the path on to something else should check this after Wait.
+//
+// False means "do not rely on this path", not "this path is provably empty":
+// a publish that failed only at the closing directory sync leaves the recording
+// present at its final name and still reports false.
 func (r *Recorder) Published() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/recording/recorder.go
+++ b/internal/recording/recorder.go
@@ -242,12 +242,19 @@ func (r *Recorder) IsPaused() bool {
 // recordMono writes raw PCM data as a mono WAV file using go-audio/wav.
 // While paused, incoming samples are replaced with silence so the written
 // WAV preserves real-time duration.
-// The file is left open on return: the caller publishes or discards it, and the
-// deferred enc.Close must have rewritten the WAV size header before that
-// happens.
-func (r *Recorder) recordMono(ctx context.Context, reader io.Reader, f *os.File, sampleRate int) error {
+// The file is left open on return: the caller publishes or discards it. Closing
+// the encoder is what rewrites the WAV size header, so a close failure means the
+// header is still a placeholder; it is reported as a capture error and the
+// caller discards the file rather than publishing an unreadable recording.
+func (r *Recorder) recordMono(ctx context.Context, reader io.Reader, f *os.File, sampleRate int) (err error) {
 	enc := wav.NewEncoder(f, sampleRate, 16, 1, 1) // mono, PCM format=1
-	defer enc.Close()
+	// A capture error wins over a close error: it is the earlier and more
+	// specific failure, and both lead to the same discard.
+	defer func() {
+		if cerr := enc.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close recording: %w", cerr)
+		}
+	}()
 
 	buf := make([]byte, 640)
 	intBuf := &audio.IntBuffer{
@@ -263,7 +270,7 @@ func (r *Recorder) recordMono(ctx context.Context, reader io.Reader, f *os.File,
 			return nil
 		default:
 		}
-		n, err := reader.Read(buf)
+		n, rerr := reader.Read(buf)
 		if n > 0 {
 			samples := bytesToInt(buf[:n])
 			if r.paused.Load() {
@@ -274,7 +281,7 @@ func (r *Recorder) recordMono(ctx context.Context, reader io.Reader, f *os.File,
 				return werr
 			}
 		}
-		if err != nil {
+		if rerr != nil {
 			return nil
 		}
 	}
@@ -315,10 +322,11 @@ type tryReader interface {
 //
 // While paused, interleaved samples are zeroed on both channels.
 //
-// The file is left open on return: the caller publishes or discards it, and the
-// deferred enc.Close must have rewritten the WAV size header before that
-// happens.
-func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *os.File, sampleRate int) error {
+// The file is left open on return: the caller publishes or discards it. Closing
+// the encoder is what rewrites the WAV size header, so a close failure means the
+// header is still a placeholder; it is reported as a capture error and the
+// caller discards the file rather than publishing an unreadable recording.
+func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *os.File, sampleRate int) (err error) {
 	// One slot is one 20 ms tap frame, the cadence both tap writers emit at.
 	slotBytes := sampleRate / 50 * 2
 	if slotBytes <= 0 {
@@ -335,7 +343,13 @@ func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *o
 	}
 
 	enc := wav.NewEncoder(f, sampleRate, 16, 2, 1) // stereo, PCM format=1
-	defer enc.Close()
+	// A capture error wins over a close error: it is the earlier and more
+	// specific failure, and both lead to the same discard.
+	defer func() {
+		if cerr := enc.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close recording: %w", cerr)
+		}
+	}()
 
 	masterBuf := make([]byte, slotBytes)
 	drainBuf := make([]byte, slotBytes)

--- a/internal/recording/recorder.go
+++ b/internal/recording/recorder.go
@@ -28,6 +28,7 @@ type Recorder struct {
 	recording bool
 	cancel    context.CancelFunc
 	filePath  string
+	published bool
 	done      chan struct{}
 	log       *slog.Logger
 	paused    atomic.Bool
@@ -46,7 +47,7 @@ func (r *Recorder) Start(ctx context.Context, reader io.Reader, dir string) (str
 // StartAt begins recording from reader to a mono WAV file in dir at the specified sample rate.
 // Returns the file path of the recording.
 func (r *Recorder) StartAt(ctx context.Context, reader io.Reader, dir string, sampleRate uint32) (string, error) {
-	f, fpath, cancel, err := r.initRecording(ctx, dir)
+	staged, cancel, err := r.initRecording(ctx, dir)
 	if err != nil {
 		return "", err
 	}
@@ -56,13 +57,16 @@ func (r *Recorder) StartAt(ctx context.Context, reader io.Reader, dir string, sa
 		// blocked on Wait() observe IsRecording()==false the moment they wake.
 		defer close(r.done)
 		defer r.clearRecording()
-		err := r.recordMono(cancel.ctx, reader, f, int(sampleRate))
+		err := r.recordMono(cancel.ctx, reader, staged.f, int(sampleRate))
 		if err != nil && cancel.ctx.Err() == nil {
 			r.log.Error("recording error", "error", err)
 		}
+		// Publishing runs ahead of the deferred handshake so that Wait callers
+		// find the recording at its final path the moment they wake.
+		r.finish(staged, err)
 	}()
 
-	return fpath, nil
+	return staged.finalPath, nil
 }
 
 // StartStereo begins a stereo recording with left and right channel readers.
@@ -75,7 +79,7 @@ func (r *Recorder) StartAt(ctx context.Context, reader io.Reader, dir string, sa
 //
 // Returns the file path of the recording.
 func (r *Recorder) StartStereo(ctx context.Context, left, right io.Reader, dir string, sampleRate uint32) (string, error) {
-	f, fpath, cancel, err := r.initRecording(ctx, dir)
+	staged, cancel, err := r.initRecording(ctx, dir)
 	if err != nil {
 		return "", err
 	}
@@ -85,13 +89,16 @@ func (r *Recorder) StartStereo(ctx context.Context, left, right io.Reader, dir s
 		// blocked on Wait() observe IsRecording()==false the moment they wake.
 		defer close(r.done)
 		defer r.clearRecording()
-		err := r.recordStereo(cancel.ctx, left, right, f, int(sampleRate))
+		err := r.recordStereo(cancel.ctx, left, right, staged.f, int(sampleRate))
 		if err != nil && cancel.ctx.Err() == nil {
 			r.log.Error("stereo recording error", "error", err)
 		}
+		// Publishing runs ahead of the deferred handshake so that Wait callers
+		// find the recording at its final path the moment they wake.
+		r.finish(staged, err)
 	}()
 
-	return fpath, nil
+	return staged.finalPath, nil
 }
 
 // cancelCtx bundles a context with its cancel function for passing to initRecording callers.
@@ -100,37 +107,62 @@ type cancelCtx struct {
 	cancel context.CancelFunc
 }
 
-// initRecording sets up the recording file and state. Returns the open file,
-// its path, and a cancellable context. The caller must call clearRecording when done.
-func (r *Recorder) initRecording(ctx context.Context, dir string) (*os.File, string, cancelCtx, error) {
+// initRecording sets up the recording file and state. Returns the staged
+// recording and a cancellable context. The recording is captured to a staging
+// file and only appears at its final path once the caller publishes it, so the
+// path handed back names a file that does not exist yet. The caller must call
+// clearRecording when done.
+func (r *Recorder) initRecording(ctx context.Context, dir string) (*stagedFile, cancelCtx, error) {
 	r.mu.Lock()
 	if r.recording {
 		r.mu.Unlock()
-		return nil, "", cancelCtx{}, fmt.Errorf("recording already in progress")
+		return nil, cancelCtx{}, fmt.Errorf("recording already in progress")
 	}
 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		r.mu.Unlock()
-		return nil, "", cancelCtx{}, fmt.Errorf("create recording dir: %w", err)
+		return nil, cancelCtx{}, fmt.Errorf("create recording dir: %w", err)
 	}
 
 	filename := fmt.Sprintf("%s_%s.wav", time.Now().Format("20060102_150405"), uuid.New().String()[:8])
 	fpath := filepath.Join(dir, filename)
 
-	f, err := os.Create(fpath)
+	staged, err := createStagedFile(fpath)
 	if err != nil {
 		r.mu.Unlock()
-		return nil, "", cancelCtx{}, fmt.Errorf("create recording file: %w", err)
+		return nil, cancelCtx{}, fmt.Errorf("create recording file: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	r.cancel = cancel
 	r.recording = true
 	r.filePath = fpath
+	r.published = false
 	r.done = make(chan struct{})
 	r.mu.Unlock()
 
-	return f, fpath, cancelCtx{ctx: ctx, cancel: cancel}, nil
+	return staged, cancelCtx{ctx: ctx, cancel: cancel}, nil
+}
+
+// finish publishes or discards the staged recording once the capture loop has
+// returned.
+//
+// Publishing is gated on the capture loop reporting no error, not on how it
+// ended: Stop cancels the context, and both capture loops report a cancelled
+// context as a successful end of recording. Treating cancellation as a failure
+// would discard every normally stopped recording.
+func (r *Recorder) finish(staged *stagedFile, recErr error) {
+	if recErr != nil {
+		discardTemp(staged.f, staged.tmpPath)
+		return
+	}
+	if err := publishFile(staged.f, staged.tmpPath, staged.finalPath); err != nil {
+		r.log.Error("publish recording", "error", err, "file", staged.finalPath)
+		return
+	}
+	r.mu.Lock()
+	r.published = true
+	r.mu.Unlock()
 }
 
 // clearRecording resets the recorder state after recording finishes.
@@ -167,6 +199,17 @@ func (r *Recorder) IsRecording() bool {
 	return r.recording
 }
 
+// Published reports whether the last recording's bytes actually reached the
+// path Stop returns. It is false while a recording is still running, and false
+// afterwards if the capture failed mid-write, because a failed capture's bytes
+// are discarded rather than published — leaving nothing at that path. Callers
+// that hand the path on to something else should check this after Wait.
+func (r *Recorder) Published() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.published
+}
+
 // Pause instructs the recorder to replace incoming audio with silence
 // until Resume is called. Returns true if the state changed (i.e., the
 // recorder was running and not already paused).
@@ -199,9 +242,10 @@ func (r *Recorder) IsPaused() bool {
 // recordMono writes raw PCM data as a mono WAV file using go-audio/wav.
 // While paused, incoming samples are replaced with silence so the written
 // WAV preserves real-time duration.
+// The file is left open on return: the caller publishes or discards it, and the
+// deferred enc.Close must have rewritten the WAV size header before that
+// happens.
 func (r *Recorder) recordMono(ctx context.Context, reader io.Reader, f *os.File, sampleRate int) error {
-	defer f.Close()
-
 	enc := wav.NewEncoder(f, sampleRate, 16, 1, 1) // mono, PCM format=1
 	defer enc.Close()
 
@@ -261,9 +305,11 @@ type tryReader interface {
 // back to silence. The channels therefore stay sample-aligned across a stall.
 //
 // While paused, interleaved samples are zeroed on both channels.
+//
+// The file is left open on return: the caller publishes or discards it, and the
+// deferred enc.Close must have rewritten the WAV size header before that
+// happens.
 func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *os.File, sampleRate int) error {
-	defer f.Close()
-
 	// One slot is one 20 ms tap frame, the cadence both tap writers emit at.
 	slotBytes := sampleRate / 50 * 2
 	if slotBytes <= 0 {

--- a/internal/recording/recorder.go
+++ b/internal/recording/recorder.go
@@ -286,6 +286,54 @@ func (r *Recorder) recordStereo(ctx context.Context, left, right io.Reader, f *o
 	}
 }
 
+// companionMaxSlots bounds the companion accumulator at 16 slots (~320 ms of
+// audio). The companion only builds a backlog when it briefly outruns the
+// master clock; anything past this is stale enough that keeping it would just
+// push the whole channel late for the rest of the call.
+const companionMaxSlots = 16
+
+// companionBuffer accumulates companion-channel bytes between master frames.
+// It is bounded: once it holds more than maxSlots whole slots the oldest slot
+// is dropped, so a companion that outruns the master clock loses its stalest
+// audio instead of growing without limit.
+//
+// It is not safe for concurrent use; the recording loop owns it.
+type companionBuffer struct {
+	buf       []byte
+	slotBytes int
+	maxSlots  int
+}
+
+func newCompanionBuffer(slotBytes, maxSlots int) *companionBuffer {
+	return &companionBuffer{slotBytes: slotBytes, maxSlots: maxSlots}
+}
+
+// append adds b, dropping whole slots from the front while over the bound.
+func (c *companionBuffer) append(b []byte) {
+	c.buf = append(c.buf, b...)
+	bound := c.maxSlots * c.slotBytes
+	for len(c.buf) > bound {
+		c.buf = c.buf[c.slotBytes:]
+	}
+}
+
+// pop removes and returns the oldest whole slot. It reports false when a full
+// slot is not available, which is the caller's cue to emit silence instead.
+//
+// The returned slot aliases the buffer and stays valid until the next append;
+// callers consume it before accumulating more.
+func (c *companionBuffer) pop() ([]byte, bool) {
+	if len(c.buf) < c.slotBytes {
+		return nil, false
+	}
+	slot := c.buf[:c.slotBytes]
+	c.buf = c.buf[c.slotBytes:]
+	return slot, true
+}
+
+// size reports how many bytes are currently held.
+func (c *companionBuffer) size() int { return len(c.buf) }
+
 // zeroInts sets every element of s to 0.
 func zeroInts(s []int) {
 	for i := range s {

--- a/internal/recording/recorder.go
+++ b/internal/recording/recorder.go
@@ -293,16 +293,25 @@ type tryReader interface {
 // recordStereo writes a stereo WAV [L0, R0, L1, R1, ...] driven by the right
 // reader's clock.
 //
-// The right channel is the master: it is fed continuously (silence included) by
-// the leg's write loop or the room's mix tick, so each right frame read emits
-// exactly one output slot and the file advances in real time. The left channel
-// is the companion: it is written only when a packet actually arrives, so it is
-// bursty and gap-prone. Reading it in lock-step with the master would park the
-// loop the moment incoming audio stalled, while the master kept being written
-// and silently dropped frames — leaving the two channels permanently skewed for
-// the rest of the call. Instead the companion is drained without blocking into
-// a bounded accumulator, and each slot either pops one companion frame or falls
-// back to silence. The channels therefore stay sample-aligned across a stall.
+// The right channel is the master and must be paced by whoever feeds it: one
+// frame every tick, silence included. Each master frame read emits exactly one
+// output slot, so a paced master advances the file in real time. That is a
+// contract on the producer, not something this loop can enforce, and the two
+// wired producers both have states that break it: a held SIP leg and an
+// outbound DTMF burst each skip the leg's out-tap write, and the room's mix
+// tick skips the out-tap of a deafened or write-only participant. While the
+// master is stalled the recording freezes with it; on resume the companion has
+// been bounded to companionMaxSlots and the older backlog dropped, so the left
+// channel stays that far behind for the rest of the call.
+//
+// The left channel is the companion: it is written only when a packet actually
+// arrives, so it is bursty and gap-prone. Reading it in lock-step with the
+// master would park the loop the moment incoming audio stalled, while the
+// master kept being written and silently dropped frames — leaving the two
+// channels permanently skewed for the rest of the call. Instead the companion
+// is drained without blocking into a bounded accumulator, and each slot either
+// pops one companion frame or falls back to silence. The channels therefore
+// stay sample-aligned across a stall.
 //
 // While paused, interleaved samples are zeroed on both channels.
 //

--- a/internal/recording/recorder_durable.go
+++ b/internal/recording/recorder_durable.go
@@ -1,0 +1,101 @@
+package recording
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// recordingFileMode is the mode a published recording carries. Recordings are
+// captured to a staging file, and os.CreateTemp opens those 0600 while
+// os.Rename preserves the inode mode, so the mode has to be restored before the
+// rename or every published recording would silently become owner-only.
+const recordingFileMode = 0o644
+
+// stagingPattern names the staging files recordings are captured to. They live
+// in the destination directory alongside the recordings themselves, so the name
+// is dot-prefixed and distinct enough to recognise as residue.
+const stagingPattern = ".rec-*.tmp"
+
+// stagedFile is a recording being captured to a staging file in the directory
+// it will eventually be published to. Nothing exists at finalPath until
+// publishFile renames the staging file there.
+type stagedFile struct {
+	f         *os.File
+	tmpPath   string
+	finalPath string
+}
+
+// createStagedFile opens a staging file for a recording destined for finalPath.
+// The staging file is created in the same directory as finalPath so the
+// publishing rename stays within one filesystem, which is what makes it atomic.
+func createStagedFile(finalPath string) (*stagedFile, error) {
+	f, err := os.CreateTemp(filepath.Dir(finalPath), stagingPattern)
+	if err != nil {
+		return nil, err
+	}
+	return &stagedFile{f: f, tmpPath: f.Name(), finalPath: finalPath}, nil
+}
+
+// publishFile makes a staged recording durable and moves it to its final name
+// in one atomic step, so the final name never refers to a partial file.
+//
+// The caller must have finished writing — including any trailing header rewrite
+// — before calling this, because the sync here is what puts those bytes on
+// disk. On failure the staging file is dropped and nothing is left behind.
+func publishFile(f *os.File, tmpPath, finalPath string) error {
+	if err := syncForPublish(f); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("close recording: %w", err)
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("publish recording: %w", err)
+	}
+	// The rename itself is only durable once the directory entry has reached
+	// the disk, so the recording is not fully published until this returns.
+	return syncDir(filepath.Dir(finalPath))
+}
+
+// syncForPublish flushes f to durable storage and gives it the mode a published
+// recording is expected to carry. Both must happen before the rename: the sync
+// so the final name never refers to unflushed bytes, and the chmod so the file
+// is never visible at its final name with the wrong mode.
+func syncForPublish(f *os.File) error {
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("sync recording: %w", err)
+	}
+	if err := f.Chmod(recordingFileMode); err != nil {
+		return fmt.Errorf("chmod recording: %w", err)
+	}
+	return nil
+}
+
+// syncDir flushes a directory's own entries to disk, which is what makes a
+// rename into it survive a crash.
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open recording dir: %w", err)
+	}
+	if err := d.Sync(); err != nil {
+		d.Close()
+		return fmt.Errorf("sync recording dir: %w", err)
+	}
+	if err := d.Close(); err != nil {
+		return fmt.Errorf("close recording dir: %w", err)
+	}
+	return nil
+}
+
+// discardTemp drops a staged recording that must not be published, leaving
+// nothing at either the staging or the final name.
+func discardTemp(f *os.File, tmpPath string) {
+	f.Close()
+	os.Remove(tmpPath)
+}

--- a/internal/recording/recorder_durable.go
+++ b/internal/recording/recorder_durable.go
@@ -42,7 +42,13 @@ func createStagedFile(finalPath string) (*stagedFile, error) {
 //
 // The caller must have finished writing — including any trailing header rewrite
 // — before calling this, because the sync here is what puts those bytes on
-// disk. On failure the staging file is dropped and nothing is left behind.
+// disk.
+//
+// A failure before the rename drops the staging file and leaves nothing behind
+// at either name. The rename is the point of no return: if the closing
+// directory sync fails after it has landed, the recording stays published at its
+// final name and an error is still returned, because the bytes are readable but
+// their directory entry is not known to have survived a crash.
 func publishFile(f *os.File, tmpPath, finalPath string) error {
 	if err := syncForPublish(f); err != nil {
 		f.Close()

--- a/internal/recording/recorder_durable_test.go
+++ b/internal/recording/recorder_durable_test.go
@@ -3,6 +3,7 @@ package recording
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-audio/audio"
 	"github.com/go-audio/wav"
 )
 
@@ -444,4 +446,118 @@ func TestRecorder_ZeroFrameStereoCaptureIsNotPublished(t *testing.T) {
 	r.Wait()
 
 	assertDiscarded(t, r, dir, fpath)
+}
+
+// closeAfterFrameReader hands over one full frame and then closes the file the
+// encoder writes to before ending the capture. The frame's write lands on a
+// healthy fd and only the encoder's trailing header rewrite fails, which is the
+// shape of a disk that fills after a call has been recording for a while.
+//
+// It is only ever read by the capture loop.
+type closeAfterFrameReader struct {
+	f    *os.File
+	sent bool
+}
+
+func (c *closeAfterFrameReader) Read(p []byte) (int, error) {
+	if !c.sent {
+		c.sent = true
+		return copy(p, bytes.Repeat([]byte{0x11}, 640)), nil
+	}
+	c.f.Close()
+	return 0, io.EOF
+}
+
+// TestRecorder_CloseErrorAfterFramesIsCaptureError pins the pair that
+// TestRecorder_HeaderRewriteFailureIsDiscarded then feeds to finish: a capture
+// can report wrote==true and an error at the same time. Nothing else in the
+// suite produces that combination — the other close-failure case never reaches
+// its first write — so without this the discard gate's error half would look
+// like a state the capture loops cannot actually reach.
+func TestRecorder_CloseErrorAfterFramesIsCaptureError(t *testing.T) {
+	staged, err := createStagedFile(filepath.Join(t.TempDir(), "rewrite.wav"))
+	if err != nil {
+		t.Fatalf("createStagedFile: %v", err)
+	}
+	defer os.Remove(staged.tmpPath)
+
+	r := NewRecorder(slog.Default())
+	wrote, err := r.recordMono(context.Background(), &closeAfterFrameReader{f: staged.f}, staged.f, 8000)
+	if !wrote {
+		t.Error("recordMono reported no frames though one was encoded before the failure")
+	}
+	if err == nil {
+		t.Error("recordMono reported success though the WAV size header could not be rewritten")
+	}
+}
+
+// decodedSamples reports how many samples a decoder reads out of path. That is
+// what the WAV's size header claims, which is not the same as what was written
+// to it when the header rewrite never ran.
+func decodedSamples(t *testing.T, path string) int {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	buf, err := wav.NewDecoder(f).FullPCMBuffer()
+	if err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	return len(buf.Data)
+}
+
+// TestRecorder_HeaderRewriteFailureIsDiscarded pins the discard gate's error
+// half for a capture that did write frames. A leg records normally, then the
+// disk fills and enc.Close — the sole writer of the real RIFF/data sizes —
+// fails. Every frame is on disk and the fd is healthy, so nothing downstream of
+// the gate would object: the sync, chmod and rename all succeed and the file
+// lands at its published name. The capture error is the only thing that knows
+// the header is still a placeholder.
+//
+// The staged file is built the way a failed Close leaves one — frames encoded,
+// enc.Close deliberately not run — so the fd handed to finish is genuinely
+// publishable and the gate is the only thing standing between it and the
+// published name. A staging file broken by closing its fd would not test the
+// gate at all: publishFile would fail on its own and discard the file anyway.
+func TestRecorder_HeaderRewriteFailureIsDiscarded(t *testing.T) {
+	const frameSamples = 320
+
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "rewrite-failed.wav")
+
+	staged, err := createStagedFile(fpath)
+	if err != nil {
+		t.Fatalf("createStagedFile: %v", err)
+	}
+
+	enc := wav.NewEncoder(staged.f, 8000, 16, 1, 1)
+	if err := enc.Write(&audio.IntBuffer{
+		Format: &audio.Format{SampleRate: 8000, NumChannels: 1},
+		Data:   make([]int, frameSamples),
+	}); err != nil {
+		t.Fatalf("encode frame: %v", err)
+	}
+
+	// The harm the gate prevents, stated as an assertion: the file still decodes,
+	// so no consumer errors on it — it just silently yields a fraction of the
+	// audio the capture actually wrote.
+	if got := decodedSamples(t, staged.tmpPath); got >= frameSamples {
+		t.Fatalf("staging file decodes to %d of the %d samples written: its header is not a "+
+			"placeholder, so this test no longer reproduces a failed header rewrite", got, frameSamples)
+	}
+
+	r := NewRecorder(slog.Default())
+	r.finish(staged, true, fmt.Errorf("close recording: %w", os.ErrClosed))
+
+	if _, err := os.Stat(fpath); !os.IsNotExist(err) {
+		t.Errorf("%s exists after a capture whose header rewrite failed, os.Stat err = %v — "+
+			"a recording nothing can fully read was published at its advertised path", fpath, err)
+	}
+	if r.Published() {
+		t.Error("Published() is true after a capture whose header rewrite failed")
+	}
+	assertNoStagingResidue(t, dir)
 }

--- a/internal/recording/recorder_durable_test.go
+++ b/internal/recording/recorder_durable_test.go
@@ -1,12 +1,14 @@
 package recording
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-audio/wav"
 )
@@ -298,29 +300,54 @@ func TestRecorder_CloseErrorIsCaptureFailure(t *testing.T) {
 	}
 }
 
+// cancelOnlyReader hands over exactly one frame and then never ends: every
+// later read returns (0, nil), never data, never an error, never EOF. Nothing
+// about it is cancellable, so the capture loop just keeps cycling and the
+// context cancel is the only exit that exists — which is what makes it a
+// faithful probe of the cancel path. The sleep paces the loop instead of
+// spinning hot; it costs no determinism, because the first iteration after Stop
+// hits the ctx.Done select regardless.
+//
+// It is only ever read by the recording goroutine.
+type cancelOnlyReader struct {
+	first chan struct{}
+	sent  bool
+}
+
+func (c *cancelOnlyReader) Read(p []byte) (int, error) {
+	if !c.sent {
+		c.sent = true
+		n := copy(p, bytes.Repeat([]byte{0x11}, 640))
+		close(c.first)
+		return n, nil
+	}
+	time.Sleep(time.Millisecond)
+	return 0, nil
+}
+
 // TestRecorder_NormalStopPublishes pins the finalize trigger: Stop cancels the
 // recording's context, and a cancelled context is the normal end of a
 // recording, not a failure. Treating it as one would discard every recording
 // that was stopped the ordinary way.
+//
+// The reader deliberately never ends on its own. An input that ends by itself —
+// a closed pipe or a drained buffer — lets the capture loop exit through its EOF
+// path, which publishes too, so the test would pass without the cancel path ever
+// working. Here the cancel is the only way out.
 func TestRecorder_NormalStopPublishes(t *testing.T) {
 	dir := t.TempDir()
 	r := NewRecorder(slog.Default())
 
-	pr, pw := newSyncPipe()
-	gate := &frameGate{r: pr, secondRead: make(chan struct{})}
-
-	fpath, err := r.StartAt(context.Background(), gate, dir, 8000)
+	rd := &cancelOnlyReader{first: make(chan struct{})}
+	fpath, err := r.StartAt(context.Background(), rd, dir, 8000)
 	if err != nil {
 		t.Fatalf("StartAt: %v", err)
 	}
-	if _, err := pw.Write(make([]byte, 640)); err != nil {
-		t.Fatalf("Write: %v", err)
-	}
-	<-gate.secondRead
 
-	// Stop without ever closing the reader: the context cancel alone ends it.
+	// One frame is provably in before the recording is stopped.
+	<-rd.first
+
 	r.Stop()
-	pw.Close()
 	r.Wait()
 
 	if !r.Published() {

--- a/internal/recording/recorder_durable_test.go
+++ b/internal/recording/recorder_durable_test.go
@@ -2,6 +2,7 @@ package recording
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -265,6 +266,36 @@ func TestRecorder_CaptureError_DiscardsStagedFile(t *testing.T) {
 		t.Error("Published() is true after a capture that failed and was discarded")
 	}
 	assertNoStagingResidue(t, dir)
+}
+
+// eofReader yields no data and ends immediately, so a capture loop reading it
+// writes nothing and sees no error of its own.
+type eofReader struct{}
+
+func (eofReader) Read(p []byte) (int, error) { return 0, io.EOF }
+
+// TestRecorder_CloseErrorIsCaptureFailure pins the one capture failure the loop
+// itself cannot see. go-audio's Encoder.Close is the sole writer of the real
+// RIFF/data sizes, so if it fails the file keeps its placeholder header and is
+// not a playable WAV — yet every write the loop made succeeded. Closing the fd
+// out from under the encoder reproduces exactly that: the reader ends at once so
+// enc.Write never runs, and Close's header rewrite is the only thing that fails.
+// Unless that error is surfaced, finish() publishes an unreadable recording and
+// reports Published()==true for it.
+func TestRecorder_CloseErrorIsCaptureFailure(t *testing.T) {
+	f, err := os.Create(filepath.Join(t.TempDir(), "closed.wav"))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Close the fd so the encoder's trailing header rewrite cannot land.
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	r := NewRecorder(slog.Default())
+	if err := r.recordMono(context.Background(), eofReader{}, f, 8000); err == nil {
+		t.Fatal("recordMono reported success though the WAV size header could not be rewritten")
+	}
 }
 
 // TestRecorder_NormalStopPublishes pins the finalize trigger: Stop cancels the

--- a/internal/recording/recorder_durable_test.go
+++ b/internal/recording/recorder_durable_test.go
@@ -1,0 +1,300 @@
+package recording
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-audio/wav"
+)
+
+// stagingFiles lists the staging files sitting in dir.
+func stagingFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	m, err := filepath.Glob(filepath.Join(dir, stagingPattern))
+	if err != nil {
+		t.Fatalf("glob staging files in %s: %v", dir, err)
+	}
+	return m
+}
+
+// assertNoStagingResidue fails if a staging file outlived the recording.
+func assertNoStagingResidue(t *testing.T, dir string) {
+	t.Helper()
+	if got := stagingFiles(t, dir); len(got) != 0 {
+		t.Errorf("staging residue left behind in %s: %v", dir, got)
+	}
+}
+
+// assertPublishedMode fails unless path carries the mode recordings have always
+// been published with. Staging files are opened 0600 and a rename keeps the
+// inode's mode, so a recording published without an explicit chmod would
+// silently become owner-only and lock out consumers running as another user.
+func assertPublishedMode(t *testing.T, path string) {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if got := fi.Mode().Perm(); got != recordingFileMode {
+		t.Errorf("%s published with mode %v, want %v", path, got, os.FileMode(recordingFileMode))
+	}
+}
+
+// assertPlayable fails unless path holds a WAV the standard decoder accepts,
+// which is what proves the size header was rewritten before publishing.
+func assertPlayable(t *testing.T, path string, wantChannels int) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	dec := wav.NewDecoder(f)
+	if !dec.IsValidFile() {
+		t.Fatalf("%s is not a valid WAV — it was published before its header was final", path)
+	}
+	if got := int(dec.NumChans); got != wantChannels {
+		t.Errorf("%s has %d channels, want %d", path, got, wantChannels)
+	}
+	buf, err := dec.FullPCMBuffer()
+	if err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	if len(buf.Data) == 0 {
+		t.Errorf("%s decoded to no audio", path)
+	}
+}
+
+func TestPublishFile(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, "publish.wav")
+
+	staged, err := createStagedFile(final)
+	if err != nil {
+		t.Fatalf("createStagedFile: %v", err)
+	}
+	want := []byte("durable bytes")
+	if _, err := staged.f.Write(want); err != nil {
+		t.Fatalf("write staged: %v", err)
+	}
+
+	// Nothing is at the final name until it is published.
+	if _, err := os.Stat(final); !os.IsNotExist(err) {
+		t.Fatalf("%s exists before publish, os.Stat err = %v", final, err)
+	}
+
+	if err := publishFile(staged.f, staged.tmpPath, staged.finalPath); err != nil {
+		t.Fatalf("publishFile: %v", err)
+	}
+
+	got, err := os.ReadFile(final)
+	if err != nil {
+		t.Fatalf("read published file: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("published content = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(staged.tmpPath); !os.IsNotExist(err) {
+		t.Errorf("staging file %s survived publish, os.Stat err = %v", staged.tmpPath, err)
+	}
+	assertPublishedMode(t, final)
+	assertNoStagingResidue(t, dir)
+}
+
+func TestPublishFile_RenameFailureLeavesNothingBehind(t *testing.T) {
+	dir := t.TempDir()
+	staged, err := createStagedFile(filepath.Join(dir, "unreachable.wav"))
+	if err != nil {
+		t.Fatalf("createStagedFile: %v", err)
+	}
+	if _, err := staged.f.Write([]byte("bytes")); err != nil {
+		t.Fatalf("write staged: %v", err)
+	}
+
+	// A directory that does not exist cannot be renamed into.
+	bad := filepath.Join(dir, "absent", "publish.wav")
+	if err := publishFile(staged.f, staged.tmpPath, bad); err == nil {
+		t.Fatal("publishFile succeeded renaming into a missing directory, want error")
+	}
+	if _, err := os.Stat(bad); !os.IsNotExist(err) {
+		t.Errorf("%s exists after a failed publish, os.Stat err = %v", bad, err)
+	}
+	assertNoStagingResidue(t, dir)
+}
+
+func TestDiscardTemp(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, "discarded.wav")
+
+	staged, err := createStagedFile(final)
+	if err != nil {
+		t.Fatalf("createStagedFile: %v", err)
+	}
+	if _, err := staged.f.Write([]byte("bytes that must not surface")); err != nil {
+		t.Fatalf("write staged: %v", err)
+	}
+
+	discardTemp(staged.f, staged.tmpPath)
+
+	if _, err := os.Stat(final); !os.IsNotExist(err) {
+		t.Errorf("%s exists after discard, os.Stat err = %v", final, err)
+	}
+	if _, err := os.Stat(staged.tmpPath); !os.IsNotExist(err) {
+		t.Errorf("staging file %s survived discard, os.Stat err = %v", staged.tmpPath, err)
+	}
+	assertNoStagingResidue(t, dir)
+}
+
+func TestSyncDir(t *testing.T) {
+	if err := syncDir(t.TempDir()); err != nil {
+		t.Errorf("syncDir: %v", err)
+	}
+	if err := syncDir(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Error("syncDir on a missing directory succeeded, want error")
+	}
+}
+
+// frameGate wraps the recorder's input and reports when the recorder has come
+// back for a second read. That is the moment the first frame has provably been
+// through enc.Write, so the mid-flight assertions below describe a recording
+// that is genuinely capturing audio — established without a sleep, which would
+// make the test both flaky and vacuous.
+//
+// It is read only by the recording goroutine; the test only ever receives on
+// secondRead.
+type frameGate struct {
+	r          *syncPipeReader
+	reads      int
+	secondRead chan struct{}
+}
+
+func (g *frameGate) Read(p []byte) (int, error) {
+	g.reads++
+	if g.reads == 2 {
+		close(g.secondRead)
+	}
+	return g.r.Read(p)
+}
+
+// TestRecorder_StartStop_PublishesFinalOnly is the headline guard: a recording
+// in progress must exist only as a staging file, and its published name must
+// stay absent until the recording stops. Without that, anything listing the
+// directory mid-call can pick up a WAV whose size header has not been written
+// yet.
+//
+// The mid-flight assertion is the load-bearing one. The post-stop state is
+// identical whether or not the recording was staged, so post-stop checks alone
+// would pass against a recorder that wrote straight to its final name.
+func TestRecorder_StartStop_PublishesFinalOnly(t *testing.T) {
+	const sampleRate = 8000
+
+	dir := t.TempDir()
+	r := NewRecorder(slog.Default())
+
+	pr, pw := newSyncPipe()
+	gate := &frameGate{r: pr, secondRead: make(chan struct{})}
+
+	fpath, err := r.StartAt(context.Background(), gate, dir, sampleRate)
+	if err != nil {
+		t.Fatalf("StartAt: %v", err)
+	}
+
+	// One 20 ms frame of audible audio.
+	frame := make([]byte, 640)
+	for i := range frame {
+		frame[i] = 0x11
+	}
+	if _, err := pw.Write(frame); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Mid-flight: the frame is encoded and the recorder is parked on the next read.
+	<-gate.secondRead
+
+	if got := stagingFiles(t, dir); len(got) != 1 {
+		t.Fatalf("mid-recording: found %d staging files in %s (%v), want exactly 1 — the recording is not being staged", len(got), dir, got)
+	}
+	if _, err := os.Stat(fpath); !os.IsNotExist(err) {
+		t.Fatalf("mid-recording: %s already exists, os.Stat err = %v — a partial recording is visible at its published name", fpath, err)
+	}
+	if r.Published() {
+		t.Error("mid-recording: Published() is true before the recording stopped")
+	}
+
+	pw.Close()
+	if got := r.Stop(); got != fpath {
+		t.Errorf("Stop returned %q, want the path StartAt returned, %q", got, fpath)
+	}
+	r.Wait()
+
+	// Post-stop: the recording is at its published name, whole, and nothing else is left.
+	assertPlayable(t, fpath, 1)
+	assertPublishedMode(t, fpath)
+	assertNoStagingResidue(t, dir)
+	if !r.Published() {
+		t.Error("Published() is false after a recording that stopped normally")
+	}
+}
+
+// TestRecorder_CaptureError_DiscardsStagedFile covers the discard branch: a
+// capture that fails must leave nothing at its published name.
+//
+// The error is raised by handing recordStereo a companion it cannot drain
+// without blocking, which is a real, reachable capture failure. A true
+// enc.Write failure needs the underlying file write to fail and is not
+// practically inducible here; it reaches this same branch, which is also
+// covered directly by TestDiscardTemp.
+func TestRecorder_CaptureError_DiscardsStagedFile(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(slog.Default())
+
+	fpath, err := r.StartStereo(context.Background(), &blockingReader{}, &blockingReader{}, dir, 8000)
+	if err != nil {
+		t.Fatalf("StartStereo: %v", err)
+	}
+	r.Wait()
+
+	if _, err := os.Stat(fpath); !os.IsNotExist(err) {
+		t.Errorf("%s exists after a failed capture, os.Stat err = %v", fpath, err)
+	}
+	if r.Published() {
+		t.Error("Published() is true after a capture that failed and was discarded")
+	}
+	assertNoStagingResidue(t, dir)
+}
+
+// TestRecorder_NormalStopPublishes pins the finalize trigger: Stop cancels the
+// recording's context, and a cancelled context is the normal end of a
+// recording, not a failure. Treating it as one would discard every recording
+// that was stopped the ordinary way.
+func TestRecorder_NormalStopPublishes(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(slog.Default())
+
+	pr, pw := newSyncPipe()
+	gate := &frameGate{r: pr, secondRead: make(chan struct{})}
+
+	fpath, err := r.StartAt(context.Background(), gate, dir, 8000)
+	if err != nil {
+		t.Fatalf("StartAt: %v", err)
+	}
+	if _, err := pw.Write(make([]byte, 640)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	<-gate.secondRead
+
+	// Stop without ever closing the reader: the context cancel alone ends it.
+	r.Stop()
+	pw.Close()
+	r.Wait()
+
+	if !r.Published() {
+		t.Fatal("Published() is false after Stop — a normally stopped recording was discarded")
+	}
+	assertPlayable(t, fpath, 1)
+	assertNoStagingResidue(t, dir)
+}

--- a/internal/recording/recorder_durable_test.go
+++ b/internal/recording/recorder_durable_test.go
@@ -280,10 +280,13 @@ func (eofReader) Read(p []byte) (int, error) { return 0, io.EOF }
 // itself cannot see. go-audio's Encoder.Close is the sole writer of the real
 // RIFF/data sizes, so if it fails the file keeps its placeholder header and is
 // not a playable WAV — yet every write the loop made succeeded. Closing the fd
-// out from under the encoder reproduces exactly that: the reader ends at once so
-// enc.Write never runs, and Close's header rewrite is the only thing that fails.
-// Unless that error is surfaced, finish() publishes an unreadable recording and
-// reports Published()==true for it.
+// out from under the encoder reproduces exactly that.
+//
+// What this pins is that a Close failure is surfaced as a capture error at all,
+// which is what matters for a capture that wrote frames and then failed its
+// header rewrite: nothing else would catch it. This case reaches the same
+// discard by a second route — the reader ends at once, so enc.Write never runs
+// and the zero-frame guard in finish() would discard the file regardless.
 func TestRecorder_CloseErrorIsCaptureFailure(t *testing.T) {
 	f, err := os.Create(filepath.Join(t.TempDir(), "closed.wav"))
 	if err != nil {
@@ -295,7 +298,7 @@ func TestRecorder_CloseErrorIsCaptureFailure(t *testing.T) {
 	}
 
 	r := NewRecorder(slog.Default())
-	if err := r.recordMono(context.Background(), eofReader{}, f, 8000); err == nil {
+	if _, err := r.recordMono(context.Background(), eofReader{}, f, 8000); err == nil {
 		t.Fatal("recordMono reported success though the WAV size header could not be rewritten")
 	}
 }
@@ -355,4 +358,90 @@ func TestRecorder_NormalStopPublishes(t *testing.T) {
 	}
 	assertPlayable(t, fpath, 1)
 	assertNoStagingResidue(t, dir)
+}
+
+// assertDiscarded fails unless a capture left nothing behind: nothing at its
+// published name, no staging residue, and Published() reporting false. That is
+// the whole contract a zero-frame capture must meet, so a future change that
+// publishes an unreadable file or leaks a staging file is caught here.
+func assertDiscarded(t *testing.T, r *Recorder, dir, fpath string) {
+	t.Helper()
+	if r.Published() {
+		t.Errorf("Published() is true after a capture that wrote no frames — %s is not a readable WAV", fpath)
+	}
+	if _, err := os.Stat(fpath); !os.IsNotExist(err) {
+		t.Errorf("%s exists after a zero-frame capture, os.Stat err = %v", fpath, err)
+	}
+	assertNoStagingResidue(t, dir)
+}
+
+// TestRecorder_ZeroFrameCaptureIsNotPublished pins the mono zero-frame guard.
+// The encoder writes the RIFF header on its first write, so a capture whose
+// reader ends before a single frame arrives leaves a headerless file that no
+// decoder can open — and Close reports no error for it, so the capture looks
+// successful. Publishing it would report success for a file nothing can read
+// and hand the multi-channel merge an input it fails on, taking every other
+// participant's audio down with it.
+func TestRecorder_ZeroFrameCaptureIsNotPublished(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(slog.Default())
+
+	fpath, err := r.StartAt(context.Background(), eofReader{}, dir, 8000)
+	if err != nil {
+		t.Fatalf("StartAt: %v", err)
+	}
+	r.Wait()
+
+	assertDiscarded(t, r, dir, fpath)
+}
+
+// TestRecorder_StopBeforeFirstFrameIsNotPublished covers the reachable shape:
+// the capture is stopped before it ever reads. A participant who joins and
+// leaves inside one 20 ms mix tick gets exactly this, because the loop checks
+// its context before its first read.
+//
+// The frame is queued in the pipe before the capture starts, so this also pins
+// what the discard decision rests on: audio that was genuinely ready is dropped
+// on this path. That is why a zero-frame leg is omitted and named rather than
+// given a silent channel — a silent channel would assert this participant said
+// nothing, when in fact their audio was discarded.
+func TestRecorder_StopBeforeFirstFrameIsNotPublished(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(slog.Default())
+
+	// One full frame of audible audio, queued and ready before the capture runs.
+	pr, pw := newSyncPipe()
+	if _, err := pw.Write(bytes.Repeat([]byte{0x11}, 640)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Already cancelled: the loop's ctx check precedes its first read, so the
+	// queued frame is never read and no frame reaches the encoder.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fpath, err := r.StartAt(ctx, pr, dir, 8000)
+	if err != nil {
+		t.Fatalf("StartAt: %v", err)
+	}
+	r.Wait()
+
+	assertDiscarded(t, r, dir, fpath)
+}
+
+// TestRecorder_ZeroFrameStereoCaptureIsNotPublished pins the same guard on the
+// stereo loop, which has its own encoder and its own early returns. The master
+// clock EOFs before clocking a single slot, so no slot is ever written.
+func TestRecorder_ZeroFrameStereoCaptureIsNotPublished(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(slog.Default())
+
+	leftPR, _ := newSyncPipe()
+	fpath, err := r.StartStereo(context.Background(), leftPR, bytes.NewReader(nil), dir, 8000)
+	if err != nil {
+		t.Fatalf("StartStereo: %v", err)
+	}
+	r.Wait()
+
+	assertDiscarded(t, r, dir, fpath)
 }

--- a/internal/recording/recorder_syncdir_test.go
+++ b/internal/recording/recorder_syncdir_test.go
@@ -1,0 +1,112 @@
+package recording
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-audio/audio"
+	"github.com/go-audio/wav"
+)
+
+// writeCompleteWAV writes one frame to f through a wav.Encoder and closes the
+// encoder, which rewrites the RIFF/data sizes. The result is a complete,
+// playable WAV on disk; f itself is left open, the way finish receives it.
+func writeCompleteWAV(t *testing.T, f *os.File) {
+	t.Helper()
+	enc := wav.NewEncoder(f, 8000, 16, 1, 1)
+	if err := enc.Write(&audio.IntBuffer{
+		Format: &audio.Format{SampleRate: 8000, NumChannels: 1},
+		Data:   make([]int, 320),
+	}); err != nil {
+		t.Fatalf("encode frame: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("close encoder: %v", err)
+	}
+}
+
+// TestRecorder_FinalizedRecordingSurvivesPublishError pins the durability-not-
+// guaranteed branch of finish. publishFile's rename is the point of no return:
+// once a complete recording has landed at its final path, a failure in the
+// closing directory sync leaves the file present and readable, just not known to
+// survive a crash. That is not a corrupt capture, and gating on Published alone
+// discarded it — losing a complete recording and skipping its upload.
+//
+// A real directory fsync failure is not inducible under the test's privileges,
+// so the post-rename state is reconstructed the way the suite builds staged
+// files elsewhere: the file is renamed into place first, then finish runs, so
+// publishFile errors after the recording is already at its final path — exactly
+// the state a failed syncDir leaves behind. What finish must key on is the file
+// being present there, not the specific error.
+func TestRecorder_FinalizedRecordingSurvivesPublishError(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "degraded.wav")
+
+	staged, err := createStagedFile(fpath)
+	if err != nil {
+		t.Fatalf("createStagedFile: %v", err)
+	}
+	writeCompleteWAV(t, staged.f)
+
+	// The recording has already landed at its final path, as it has once
+	// publishFile's rename returns. publishFile will then error (its own rename
+	// finds no staging file), standing in for the closing directory sync failing
+	// after the rename succeeded.
+	if err := os.Rename(staged.tmpPath, staged.finalPath); err != nil {
+		t.Fatalf("stage rename: %v", err)
+	}
+
+	r := NewRecorder(slog.Default())
+	r.finish(staged, true, nil)
+
+	if !r.Finalized() {
+		t.Error("Finalized() is false though a complete recording is present at its final path")
+	}
+	if r.Published() {
+		t.Error("Published() is true though the publish returned an error")
+	}
+	if _, err := os.Stat(fpath); err != nil {
+		t.Errorf("%s is missing after a publish that only failed its directory sync: %v", fpath, err)
+	}
+	assertPlayable(t, fpath, 1)
+	assertNoStagingResidue(t, dir)
+}
+
+// TestRecorder_PublishErrorWithoutFileIsNotFinalized guards the original
+// contract: a publish that fails before anything lands at the final path leaves
+// no usable file, so it must not be reported as finalized. Only the presence of
+// the file at the final path distinguishes it from the degraded-durability case
+// above.
+func TestRecorder_PublishErrorWithoutFileIsNotFinalized(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "gone.wav")
+
+	staged, err := createStagedFile(fpath)
+	if err != nil {
+		t.Fatalf("createStagedFile: %v", err)
+	}
+	writeCompleteWAV(t, staged.f)
+
+	// Drop the staging file so publishFile's rename fails with nothing at the
+	// final path — the shape of a failure at or before the rename. The capture
+	// itself reported no error, so the failure comes from publishFile alone.
+	if err := os.Remove(staged.tmpPath); err != nil {
+		t.Fatalf("remove staging file: %v", err)
+	}
+
+	r := NewRecorder(slog.Default())
+	r.finish(staged, true, nil)
+
+	if r.Finalized() {
+		t.Error("Finalized() is true though nothing landed at the final path")
+	}
+	if r.Published() {
+		t.Error("Published() is true though the publish failed")
+	}
+	if _, err := os.Stat(fpath); !os.IsNotExist(err) {
+		t.Errorf("final path exists after a publish that never renamed, os.Stat err = %v", err)
+	}
+	assertNoStagingResidue(t, dir)
+}

--- a/internal/recording/recording_test.go
+++ b/internal/recording/recording_test.go
@@ -419,6 +419,35 @@ func (r *syncPipeReader) Read(p []byte) (int, error) {
 	}
 }
 
+// TryRead mirrors the api package's pipeReader.TryRead: non-blocking, buffered
+// remainder first, io.EOF only once closed and drained. It makes syncPipeReader
+// usable as a stereo companion channel.
+func (r *syncPipeReader) TryRead(p []byte) (int, error) {
+	if len(r.buf) > 0 {
+		n := copy(p, r.buf)
+		r.buf = r.buf[n:]
+		return n, nil
+	}
+	select {
+	case data, ok := <-r.ch:
+		if !ok {
+			return 0, io.EOF
+		}
+		n := copy(p, data)
+		if n < len(data) {
+			r.buf = data[n:]
+		}
+		return n, nil
+	default:
+	}
+	select {
+	case <-r.done:
+		return 0, io.EOF
+	default:
+		return 0, nil
+	}
+}
+
 func (w *syncPipeWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/internal/recording/recording_test.go
+++ b/internal/recording/recording_test.go
@@ -61,6 +61,8 @@ func TestRecorder_StartStop(t *testing.T) {
 	if info.Size() == 0 {
 		t.Error("expected non-empty WAV file")
 	}
+	assertNoStagingResidue(t, dir)
+	assertPublishedMode(t, fpath)
 }
 
 func TestRecorder_DoubleStart(t *testing.T) {

--- a/internal/recording/recording_test.go
+++ b/internal/recording/recording_test.go
@@ -28,11 +28,14 @@ func TestRecorder_StartStop(t *testing.T) {
 	dir := t.TempDir()
 	r := NewRecorder(slog.Default())
 
-	// Provide PCM data to read.
-	pcm := generatePCM(8000, 1) // 1 second of silence
-	reader := bytes.NewReader(pcm)
+	// The reader hands over one frame and then never ends, so the capture is
+	// still running when IsRecording is checked, and a frame has provably
+	// reached the encoder before Stop — a capture that wrote nothing is
+	// discarded, so without the handover this would be racing the guard rather
+	// than pinning the happy path.
+	rd := &cancelOnlyReader{first: make(chan struct{})}
 
-	fpath, err := r.Start(context.Background(), reader, dir)
+	fpath, err := r.Start(context.Background(), rd, dir)
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
@@ -42,6 +45,8 @@ func TestRecorder_StartStop(t *testing.T) {
 	if !r.IsRecording() {
 		t.Error("expected IsRecording=true")
 	}
+
+	<-rd.first
 
 	path := r.Stop()
 	r.Wait()

--- a/internal/recording/stereo_test.go
+++ b/internal/recording/stereo_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 )
 
 const (
@@ -392,6 +393,64 @@ func TestRecordStereo_ClosedCompanionKeepsRecording(t *testing.T) {
 		if left[i] != want {
 			t.Fatalf("left[%d] = %d, want %d — a closed companion must silence-fill", i, left[i], want)
 		}
+	}
+}
+
+// endlessMaster is a paced master that never EOFs. The stereo loop checks
+// ctx.Done() only between slots and then blocks in ReadFull, so a master that
+// blocks forever would hang Wait() even on correct code; this one keeps
+// producing so the loop can always reach the cancel check.
+type endlessMaster struct {
+	frame []byte
+	buf   []byte
+}
+
+func (m *endlessMaster) Read(p []byte) (int, error) {
+	if len(m.buf) == 0 {
+		// Pace the stream so the recording does not spin the CPU flat out.
+		time.Sleep(time.Millisecond)
+		m.buf = m.frame
+	}
+	n := copy(p, m.buf)
+	m.buf = m.buf[n:]
+	return n, nil
+}
+
+// TestRecordStereo_ContextCancel_StopsRecording proves the stereo recording
+// goroutine unwinds on teardown. Both production call sites terminate on master
+// EOF, so without this nothing pins that a cancelled recording of a still-live
+// master ever exits.
+func TestRecordStereo_ContextCancel_StopsRecording(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRecorder(slog.Default())
+	leftPR, _ := newSyncPipe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if _, err := r.StartStereo(ctx, leftPR, &endlessMaster{frame: pcmFrame(0x2222, stereoSlotBytes)}, dir, stereoRate); err != nil {
+		t.Fatalf("StartStereo: %v", err)
+	}
+
+	// Let it clock a few slots so cancel lands mid-recording.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	// The master never EOFs, so only the cancel check can end the loop. Guard
+	// with a timeout: a leaked goroutine must fail this test, not hang the suite.
+	done := make(chan struct{})
+	go func() {
+		r.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait() did not return after context cancel — the stereo recording goroutine leaked")
+	}
+
+	if r.IsRecording() {
+		t.Error("IsRecording() = true after context cancel, want false")
 	}
 }
 

--- a/internal/recording/stereo_test.go
+++ b/internal/recording/stereo_test.go
@@ -51,9 +51,10 @@ func (m *scriptedMaster) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-// pcmFrame builds one slot of little-endian PCM whose every sample is v.
-func pcmFrame(v int16) []byte {
-	b := make([]byte, stereoSlotBytes)
+// pcmFrame builds one slotBytes-long slot of little-endian PCM whose every
+// sample is v.
+func pcmFrame(v int16, slotBytes int) []byte {
+	b := make([]byte, slotBytes)
 	for i := 0; i+1 < len(b); i += 2 {
 		binary.LittleEndian.PutUint16(b[i:], uint16(v))
 	}
@@ -78,9 +79,10 @@ func readStereoWAV(t *testing.T, path string) (left, right []int16) {
 	return left, right
 }
 
-// runStereo records a scripted master alongside a companion pipe and returns
-// the resulting channels. Hooks are invoked per master frame.
-func runStereo(t *testing.T, frames [][]byte, hook func(k int, leftPW *syncPipeWriter, r *Recorder)) (left, right []int16) {
+// runStereo records a scripted master alongside a companion pipe at the given
+// sample rate and returns the resulting channels. Hooks are invoked per master
+// frame.
+func runStereo(t *testing.T, rate int, frames [][]byte, hook func(k int, leftPW *syncPipeWriter, r *Recorder)) (left, right []int16) {
 	t.Helper()
 	dir := t.TempDir()
 	r := NewRecorder(slog.Default())
@@ -93,7 +95,7 @@ func runStereo(t *testing.T, frames [][]byte, hook func(k int, leftPW *syncPipeW
 	}
 	master := &scriptedMaster{frames: frames, hooks: hooks}
 
-	fpath, err := r.StartStereo(context.Background(), leftPR, master, dir, stereoRate)
+	fpath, err := r.StartStereo(context.Background(), leftPR, master, dir, uint32(rate))
 	if err != nil {
 		t.Fatalf("StartStereo: %v", err)
 	}
@@ -109,12 +111,12 @@ func runStereo(t *testing.T, frames [][]byte, hook func(k int, leftPW *syncPipeW
 	return readStereoWAV(t, fpath)
 }
 
-// masterRamp builds n distinct, strictly positive master frames so that a
-// dropped or duplicated master frame is detectable by value.
-func masterRamp(n int) [][]byte {
+// masterRamp builds n distinct, strictly positive master frames of slotBytes
+// each, so that a dropped or duplicated master frame is detectable by value.
+func masterRamp(n, slotBytes int) [][]byte {
 	frames := make([][]byte, n)
 	for k := range frames {
-		frames[k] = pcmFrame(masterVal(k))
+		frames[k] = pcmFrame(masterVal(k), slotBytes)
 	}
 	return frames
 }
@@ -135,13 +137,13 @@ func TestRecordStereo_SilenceFillOnCompanionStall(t *testing.T) {
 
 	frames := make([][]byte, nSlots)
 	for k := range frames {
-		frames[k] = pcmFrame(masterSample)
+		frames[k] = pcmFrame(masterSample, stereoSlotBytes)
 	}
 
-	left, right := runStereo(t, frames, func(k int, leftPW *syncPipeWriter, _ *Recorder) {
+	left, right := runStereo(t, stereoRate, frames, func(k int, leftPW *syncPipeWriter, _ *Recorder) {
 		// The companion delivers a few frames and then goes quiet for good.
 		if k < companionSlots {
-			leftPW.Write(pcmFrame(compSample))
+			leftPW.Write(pcmFrame(compSample, stereoSlotBytes))
 		}
 	})
 
@@ -184,12 +186,12 @@ func TestRecordStereo_StaysAligned(t *testing.T) {
 		burst  = 8 // ahead of the master, but within the accumulator bound
 	)
 
-	left, right := runStereo(t, masterRamp(nSlots), func(k int, leftPW *syncPipeWriter, _ *Recorder) {
+	left, right := runStereo(t, stereoRate, masterRamp(nSlots, stereoSlotBytes), func(k int, leftPW *syncPipeWriter, _ *Recorder) {
 		// The companion dumps its whole burst before the first master slot,
 		// then never speaks again.
 		if k == 0 {
 			for c := 0; c < burst; c++ {
-				leftPW.Write(pcmFrame(companionVal(c)))
+				leftPW.Write(pcmFrame(companionVal(c), stereoSlotBytes))
 			}
 		}
 	})
@@ -228,60 +230,72 @@ func TestRecordStereo_StaysAligned(t *testing.T) {
 // TestRecordStereo_DropOldestBound proves the companion accumulator is bounded:
 // a companion that floods far past the bound loses its oldest audio, and the
 // master stream is untouched by the flood.
+//
+// It runs at every rate the mixer admits (mixer.go's 8000/16000/48000), which
+// is what pins the slot size to the sample rate. companionMaxSlots is a slot
+// COUNT — the one quantity in the design that does not scale with slotBytes —
+// so a slot size that stops tracking the rate shifts which companion frames
+// survive the flood, and the retained audio no longer starts at firstKept.
 func TestRecordStereo_DropOldestBound(t *testing.T) {
-	const (
-		nSlots = 24
-		flood  = 40 // far beyond companionMaxSlots
-	)
+	for _, rate := range []int{8000, 16000, 48000} {
+		t.Run(rateName(rate), func(t *testing.T) {
+			const (
+				nSlots = 24
+				flood  = 40 // far beyond companionMaxSlots
+			)
+			slotBytes := rate / 50 * 2 // one real 20 ms frame at this rate
+			slotSamples := slotBytes / 2
 
-	left, right := runStereo(t, masterRamp(nSlots), func(k int, leftPW *syncPipeWriter, _ *Recorder) {
-		if k == 0 {
-			for c := 0; c < flood; c++ {
-				leftPW.Write(pcmFrame(companionVal(c)))
+			left, right := runStereo(t, rate, masterRamp(nSlots, slotBytes), func(k int, leftPW *syncPipeWriter, _ *Recorder) {
+				if k == 0 {
+					for c := 0; c < flood; c++ {
+						leftPW.Write(pcmFrame(companionVal(c), slotBytes))
+					}
+				}
+			})
+
+			if want := nSlots * slotSamples; len(right) != want {
+				t.Fatalf("recorded %d frames, want %d", len(right), want)
 			}
-		}
-	})
 
-	if want := nSlots * stereoSlotSamples; len(right) != want {
-		t.Fatalf("recorded %d frames, want %d", len(right), want)
-	}
+			// Only the newest companionMaxSlots survive the flood; the rest are
+			// dropped oldest-first, so the retained audio starts at this frame.
+			firstKept := flood - companionMaxSlots
 
-	// Only the newest companionMaxSlots survive the flood; the rest are dropped
-	// oldest-first, so the retained audio starts at this frame.
-	firstKept := flood - companionMaxSlots
+			for slot := 0; slot < nSlots; slot++ {
+				base := slot * slotSamples
 
-	for slot := 0; slot < nSlots; slot++ {
-		base := slot * stereoSlotSamples
+				// The flood must not perturb the master stream at all.
+				for i := base; i < base+slotSamples; i++ {
+					if right[i] != masterVal(slot) {
+						t.Fatalf("right[%d] (slot %d) = %d, want %d — companion flood disturbed the master",
+							i, slot, right[i], masterVal(slot))
+					}
+				}
 
-		// The flood must not perturb the master stream at all.
-		for i := base; i < base+stereoSlotSamples; i++ {
-			if right[i] != masterVal(slot) {
-				t.Fatalf("right[%d] (slot %d) = %d, want %d — companion flood disturbed the master",
-					i, slot, right[i], masterVal(slot))
+				want := int16(0)
+				if slot < companionMaxSlots {
+					want = companionVal(firstKept + slot)
+				}
+				for i := base; i < base+slotSamples; i++ {
+					if left[i] != want {
+						t.Fatalf("left[%d] (slot %d) = %d, want %d — accumulator did not bound at %d slots dropping oldest",
+							i, slot, left[i], want, companionMaxSlots)
+					}
+				}
 			}
-		}
 
-		want := int16(0)
-		if slot < companionMaxSlots {
-			want = companionVal(firstKept + slot)
-		}
-		for i := base; i < base+stereoSlotSamples; i++ {
-			if left[i] != want {
-				t.Fatalf("left[%d] (slot %d) = %d, want %d — accumulator did not bound at %d slots dropping oldest",
-					i, slot, left[i], want, companionMaxSlots)
+			// The dropped frames must be gone entirely, not merely reordered.
+			dropped := make(map[int16]bool, firstKept)
+			for c := 0; c < firstKept; c++ {
+				dropped[companionVal(c)] = true
 			}
-		}
-	}
-
-	// The dropped frames must be gone entirely, not merely reordered.
-	dropped := make(map[int16]bool, firstKept)
-	for c := 0; c < firstKept; c++ {
-		dropped[companionVal(c)] = true
-	}
-	for i, s := range left {
-		if dropped[s] {
-			t.Fatalf("left[%d] = %d — a companion frame past the bound was retained", i, s)
-		}
+			for i, s := range left {
+				if dropped[s] {
+					t.Fatalf("left[%d] = %d — a companion frame past the bound was retained", i, s)
+				}
+			}
+		})
 	}
 }
 
@@ -296,9 +310,9 @@ func TestRecordStereo_Pause_ZeroesBothChannels(t *testing.T) {
 		compSample = int16(0x1111)
 	)
 
-	left, right := runStereo(t, masterRamp(nSlots), func(k int, leftPW *syncPipeWriter, r *Recorder) {
+	left, right := runStereo(t, stereoRate, masterRamp(nSlots, stereoSlotBytes), func(k int, leftPW *syncPipeWriter, r *Recorder) {
 		// The companion keeps talking throughout, including while paused.
-		leftPW.Write(pcmFrame(compSample))
+		leftPW.Write(pcmFrame(compSample, stereoSlotBytes))
 
 		// The hook runs after slot k-1 is written and before slot k is read,
 		// so these land exactly on a slot boundary.
@@ -334,44 +348,6 @@ func TestRecordStereo_Pause_ZeroesBothChannels(t *testing.T) {
 				t.Fatalf("right[%d] (slot %d, paused=%v) = %d, want %d", i, slot, paused, right[i], wantRight)
 			}
 		}
-	}
-}
-
-// TestRecordStereo_SlotBytesFollowSampleRate proves a slot is one real 20 ms
-// frame at whatever rate the recording runs at, rather than a fixed byte count.
-func TestRecordStereo_SlotBytesFollowSampleRate(t *testing.T) {
-	for _, rate := range []int{8000, 16000, 48000} {
-		t.Run(rateName(rate), func(t *testing.T) {
-			slotBytes := rate / 50 * 2
-			const nSlots = 4
-
-			dir := t.TempDir()
-			r := NewRecorder(slog.Default())
-			leftPR, leftPW := newSyncPipe()
-
-			frames := make([][]byte, nSlots)
-			hooks := make(map[int]func(), nSlots)
-			for k := range frames {
-				frames[k] = make([]byte, slotBytes)
-				for i := 0; i+1 < slotBytes; i += 2 {
-					binary.LittleEndian.PutUint16(frames[k][i:], uint16(masterVal(k)))
-				}
-				hooks[k] = func() { leftPW.Write(make([]byte, slotBytes)) }
-			}
-
-			fpath, err := r.StartStereo(context.Background(), leftPR, &scriptedMaster{frames: frames, hooks: hooks}, dir, uint32(rate))
-			if err != nil {
-				t.Fatalf("StartStereo: %v", err)
-			}
-			r.Wait()
-
-			_, right := readStereoWAV(t, fpath)
-			// Every 20 ms master frame must produce exactly one slot of output.
-			if want := nSlots * (slotBytes / 2); len(right) != want {
-				t.Fatalf("at %d Hz recorded %d frames, want %d — slot size must track the sample rate",
-					rate, len(right), want)
-			}
-		})
 	}
 }
 

--- a/internal/recording/stereo_test.go
+++ b/internal/recording/stereo_test.go
@@ -219,10 +219,6 @@ func TestRecordStereo_StaysAligned(t *testing.T) {
 				t.Fatalf("left[%d] (slot %d) = %d, want %d — companion drifted off the master clock",
 					i, slot, left[i], want)
 			}
-			// A right-channel value on the left would mean the channels crossed.
-			if left[i] == masterVal(slot) {
-				t.Fatalf("left[%d] (slot %d) leaked the right-channel value %d", i, slot, left[i])
-			}
 		}
 	}
 }

--- a/internal/recording/stereo_test.go
+++ b/internal/recording/stereo_test.go
@@ -1,0 +1,381 @@
+package recording
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+const (
+	stereoRate        = 8000
+	stereoSlotBytes   = stereoRate / 50 * 2 // one 20 ms tap frame
+	stereoSlotSamples = stereoSlotBytes / 2
+)
+
+// scriptedMaster feeds the stereo recorder's master (right) channel from a
+// fixed script and EOFs when it runs out.
+//
+// The recorder reads the master synchronously at the top of every slot, so a
+// hook attached to frame k runs at an exact point in the recording: after slot
+// k-1 has been written and before slot k is read. That lets a test inject
+// companion audio or flip pause state at a precise slot boundary without
+// depending on sleeps or scheduler timing.
+type scriptedMaster struct {
+	frames [][]byte
+	hooks  map[int]func()
+	i      int
+	buf    []byte
+}
+
+func (m *scriptedMaster) Read(p []byte) (int, error) {
+	if len(m.buf) > 0 {
+		n := copy(p, m.buf)
+		m.buf = m.buf[n:]
+		return n, nil
+	}
+	if m.i >= len(m.frames) {
+		return 0, io.EOF
+	}
+	if h, ok := m.hooks[m.i]; ok {
+		h()
+	}
+	frame := m.frames[m.i]
+	m.i++
+	n := copy(p, frame)
+	if n < len(frame) {
+		m.buf = frame[n:]
+	}
+	return n, nil
+}
+
+// pcmFrame builds one slot of little-endian PCM whose every sample is v.
+func pcmFrame(v int16) []byte {
+	b := make([]byte, stereoSlotBytes)
+	for i := 0; i+1 < len(b); i += 2 {
+		binary.LittleEndian.PutUint16(b[i:], uint16(v))
+	}
+	return b
+}
+
+// readStereoWAV splits a stereo WAV's interleaved PCM into its two channels.
+func readStereoWAV(t *testing.T, path string) (left, right []int16) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if len(data) < 44 {
+		t.Fatalf("WAV too small: %d bytes", len(data))
+	}
+	pcm := data[44:] // skip the WAV header
+	for i := 0; i+3 < len(pcm); i += 4 {
+		left = append(left, int16(binary.LittleEndian.Uint16(pcm[i:])))
+		right = append(right, int16(binary.LittleEndian.Uint16(pcm[i+2:])))
+	}
+	return left, right
+}
+
+// runStereo records a scripted master alongside a companion pipe and returns
+// the resulting channels. Hooks are invoked per master frame.
+func runStereo(t *testing.T, frames [][]byte, hook func(k int, leftPW *syncPipeWriter, r *Recorder)) (left, right []int16) {
+	t.Helper()
+	dir := t.TempDir()
+	r := NewRecorder(slog.Default())
+	leftPR, leftPW := newSyncPipe()
+
+	hooks := make(map[int]func(), len(frames))
+	for k := range frames {
+		k := k
+		hooks[k] = func() { hook(k, leftPW, r) }
+	}
+	master := &scriptedMaster{frames: frames, hooks: hooks}
+
+	fpath, err := r.StartStereo(context.Background(), leftPR, master, dir, stereoRate)
+	if err != nil {
+		t.Fatalf("StartStereo: %v", err)
+	}
+	// The master EOFs at the end of the script, which ends the recording.
+	r.Wait()
+
+	return readStereoWAV(t, fpath)
+}
+
+// masterRamp builds n distinct, strictly positive master frames so that a
+// dropped or duplicated master frame is detectable by value.
+func masterRamp(n int) [][]byte {
+	frames := make([][]byte, n)
+	for k := range frames {
+		frames[k] = pcmFrame(masterVal(k))
+	}
+	return frames
+}
+
+func masterVal(k int) int16    { return int16(1000 + k) }
+func companionVal(k int) int16 { return int16(-(1000 + k)) }
+
+// TestRecordStereo_SilenceFillOnCompanionStall is the headline guard: when the
+// companion stops arriving mid-call, the master must keep clocking the file and
+// the companion side must silence-fill rather than stall the recording.
+func TestRecordStereo_SilenceFillOnCompanionStall(t *testing.T) {
+	const (
+		nSlots         = 20
+		companionSlots = 3
+		masterSample   = int16(0x2222)
+		compSample     = int16(0x1111)
+	)
+
+	frames := make([][]byte, nSlots)
+	for k := range frames {
+		frames[k] = pcmFrame(masterSample)
+	}
+
+	left, right := runStereo(t, frames, func(k int, leftPW *syncPipeWriter, _ *Recorder) {
+		// The companion delivers a few frames and then goes quiet for good.
+		if k < companionSlots {
+			leftPW.Write(pcmFrame(compSample))
+		}
+	})
+
+	// The master drives the timeline: one slot out per master frame in, so the
+	// file covers the whole call rather than stopping when the companion did.
+	if want := nSlots * stereoSlotSamples; len(right) != want {
+		t.Fatalf("recorded %d frames, want %d — master clock did not drive the recording", len(right), want)
+	}
+	if len(left) != len(right) {
+		t.Fatalf("channel lengths differ: left=%d right=%d", len(left), len(right))
+	}
+
+	// The master channel survives the companion stall untouched.
+	for i, s := range right {
+		if s != masterSample {
+			t.Fatalf("right[%d] = %d, want %d — master audio lost during the companion stall", i, s, masterSample)
+		}
+	}
+
+	// The companion is audible while it is delivering...
+	for i := 0; i < companionSlots*stereoSlotSamples; i++ {
+		if left[i] != compSample {
+			t.Fatalf("left[%d] = %d, want %d — companion audio lost", i, left[i], compSample)
+		}
+	}
+	// ...and silence-filled once it stops, keeping it aligned with the master.
+	for i := companionSlots * stereoSlotSamples; i < len(left); i++ {
+		if left[i] != 0 {
+			t.Fatalf("left[%d] = %d, want 0 — a stalled companion must silence-fill", i, left[i])
+		}
+	}
+}
+
+// TestRecordStereo_StaysAligned proves the companion maps onto master slots in
+// order even when it bursts ahead and then pauses: slot k carries companion
+// frame k, and the master sequence is neither dropped nor duplicated.
+func TestRecordStereo_StaysAligned(t *testing.T) {
+	const (
+		nSlots = 20
+		burst  = 8 // ahead of the master, but within the accumulator bound
+	)
+
+	left, right := runStereo(t, masterRamp(nSlots), func(k int, leftPW *syncPipeWriter, _ *Recorder) {
+		// The companion dumps its whole burst before the first master slot,
+		// then never speaks again.
+		if k == 0 {
+			for c := 0; c < burst; c++ {
+				leftPW.Write(pcmFrame(companionVal(c)))
+			}
+		}
+	})
+
+	if want := nSlots * stereoSlotSamples; len(right) != want {
+		t.Fatalf("recorded %d frames, want %d", len(right), want)
+	}
+
+	for slot := 0; slot < nSlots; slot++ {
+		base := slot * stereoSlotSamples
+		for i := base; i < base+stereoSlotSamples; i++ {
+			// The master sequence must appear exactly once, in order.
+			if right[i] != masterVal(slot) {
+				t.Fatalf("right[%d] (slot %d) = %d, want %d — master frame dropped or duplicated",
+					i, slot, right[i], masterVal(slot))
+			}
+
+			// The companion rides the master's clock: burst frame k lands on
+			// slot k, and the tail silence-fills.
+			want := int16(0)
+			if slot < burst {
+				want = companionVal(slot)
+			}
+			if left[i] != want {
+				t.Fatalf("left[%d] (slot %d) = %d, want %d — companion drifted off the master clock",
+					i, slot, left[i], want)
+			}
+			// A right-channel value on the left would mean the channels crossed.
+			if left[i] == masterVal(slot) {
+				t.Fatalf("left[%d] (slot %d) leaked the right-channel value %d", i, slot, left[i])
+			}
+		}
+	}
+}
+
+// TestRecordStereo_DropOldestBound proves the companion accumulator is bounded:
+// a companion that floods far past the bound loses its oldest audio, and the
+// master stream is untouched by the flood.
+func TestRecordStereo_DropOldestBound(t *testing.T) {
+	const (
+		nSlots = 24
+		flood  = 40 // far beyond companionMaxSlots
+	)
+
+	left, right := runStereo(t, masterRamp(nSlots), func(k int, leftPW *syncPipeWriter, _ *Recorder) {
+		if k == 0 {
+			for c := 0; c < flood; c++ {
+				leftPW.Write(pcmFrame(companionVal(c)))
+			}
+		}
+	})
+
+	if want := nSlots * stereoSlotSamples; len(right) != want {
+		t.Fatalf("recorded %d frames, want %d", len(right), want)
+	}
+
+	// Only the newest companionMaxSlots survive the flood; the rest are dropped
+	// oldest-first, so the retained audio starts at this frame.
+	firstKept := flood - companionMaxSlots
+
+	for slot := 0; slot < nSlots; slot++ {
+		base := slot * stereoSlotSamples
+
+		// The flood must not perturb the master stream at all.
+		for i := base; i < base+stereoSlotSamples; i++ {
+			if right[i] != masterVal(slot) {
+				t.Fatalf("right[%d] (slot %d) = %d, want %d — companion flood disturbed the master",
+					i, slot, right[i], masterVal(slot))
+			}
+		}
+
+		want := int16(0)
+		if slot < companionMaxSlots {
+			want = companionVal(firstKept + slot)
+		}
+		for i := base; i < base+stereoSlotSamples; i++ {
+			if left[i] != want {
+				t.Fatalf("left[%d] (slot %d) = %d, want %d — accumulator did not bound at %d slots dropping oldest",
+					i, slot, left[i], want, companionMaxSlots)
+			}
+		}
+	}
+
+	// The dropped frames must be gone entirely, not merely reordered.
+	dropped := make(map[int16]bool, firstKept)
+	for c := 0; c < firstKept; c++ {
+		dropped[companionVal(c)] = true
+	}
+	for i, s := range left {
+		if dropped[s] {
+			t.Fatalf("left[%d] = %d — a companion frame past the bound was retained", i, s)
+		}
+	}
+}
+
+// TestRecordStereo_Pause_ZeroesBothChannels mirrors TestRecorder_Pause_WritesSilence
+// for the stereo path: pausing must silence left and right together, and the
+// timeline must still cover the paused stretch.
+func TestRecordStereo_Pause_ZeroesBothChannels(t *testing.T) {
+	const (
+		nSlots     = 15
+		pauseAt    = 5
+		resumeAt   = 10
+		compSample = int16(0x1111)
+	)
+
+	left, right := runStereo(t, masterRamp(nSlots), func(k int, leftPW *syncPipeWriter, r *Recorder) {
+		// The companion keeps talking throughout, including while paused.
+		leftPW.Write(pcmFrame(compSample))
+
+		// The hook runs after slot k-1 is written and before slot k is read,
+		// so these land exactly on a slot boundary.
+		switch k {
+		case pauseAt:
+			if !r.Pause() {
+				t.Errorf("Pause() = false, want true")
+			}
+		case resumeAt:
+			if !r.Resume() {
+				t.Errorf("Resume() = false, want true")
+			}
+		}
+	})
+
+	// Pausing preserves the timeline rather than shortening the file.
+	if want := nSlots * stereoSlotSamples; len(right) != want {
+		t.Fatalf("recorded %d frames, want %d — pause must not shorten the recording", len(right), want)
+	}
+
+	for slot := 0; slot < nSlots; slot++ {
+		paused := slot >= pauseAt && slot < resumeAt
+		wantLeft, wantRight := compSample, masterVal(slot)
+		if paused {
+			wantLeft, wantRight = 0, 0
+		}
+		base := slot * stereoSlotSamples
+		for i := base; i < base+stereoSlotSamples; i++ {
+			if left[i] != wantLeft {
+				t.Fatalf("left[%d] (slot %d, paused=%v) = %d, want %d", i, slot, paused, left[i], wantLeft)
+			}
+			if right[i] != wantRight {
+				t.Fatalf("right[%d] (slot %d, paused=%v) = %d, want %d", i, slot, paused, right[i], wantRight)
+			}
+		}
+	}
+}
+
+// TestRecordStereo_SlotBytesFollowSampleRate proves a slot is one real 20 ms
+// frame at whatever rate the recording runs at, rather than a fixed byte count.
+func TestRecordStereo_SlotBytesFollowSampleRate(t *testing.T) {
+	for _, rate := range []int{8000, 16000, 48000} {
+		t.Run(rateName(rate), func(t *testing.T) {
+			slotBytes := rate / 50 * 2
+			const nSlots = 4
+
+			dir := t.TempDir()
+			r := NewRecorder(slog.Default())
+			leftPR, leftPW := newSyncPipe()
+
+			frames := make([][]byte, nSlots)
+			hooks := make(map[int]func(), nSlots)
+			for k := range frames {
+				frames[k] = make([]byte, slotBytes)
+				for i := 0; i+1 < slotBytes; i += 2 {
+					binary.LittleEndian.PutUint16(frames[k][i:], uint16(masterVal(k)))
+				}
+				hooks[k] = func() { leftPW.Write(make([]byte, slotBytes)) }
+			}
+
+			fpath, err := r.StartStereo(context.Background(), leftPR, &scriptedMaster{frames: frames, hooks: hooks}, dir, uint32(rate))
+			if err != nil {
+				t.Fatalf("StartStereo: %v", err)
+			}
+			r.Wait()
+
+			_, right := readStereoWAV(t, fpath)
+			// Every 20 ms master frame must produce exactly one slot of output.
+			if want := nSlots * (slotBytes / 2); len(right) != want {
+				t.Fatalf("at %d Hz recorded %d frames, want %d — slot size must track the sample rate",
+					rate, len(right), want)
+			}
+		})
+	}
+}
+
+func rateName(rate int) string {
+	switch rate {
+	case 8000:
+		return "8kHz"
+	case 16000:
+		return "16kHz"
+	default:
+		return "48kHz"
+	}
+}

--- a/internal/recording/stereo_test.go
+++ b/internal/recording/stereo_test.go
@@ -100,6 +100,12 @@ func runStereo(t *testing.T, frames [][]byte, hook func(k int, leftPW *syncPipeW
 	// The master EOFs at the end of the script, which ends the recording.
 	r.Wait()
 
+	// Every stereo case also pins the publish contract: the staging file must
+	// not outlive the recording, and the published file must keep the mode
+	// consumers have always seen it with.
+	assertNoStagingResidue(t, dir)
+	assertPublishedMode(t, fpath)
+
 	return readStereoWAV(t, fpath)
 }
 

--- a/internal/recording/stereo_test.go
+++ b/internal/recording/stereo_test.go
@@ -347,6 +347,54 @@ func TestRecordStereo_Pause_ZeroesBothChannels(t *testing.T) {
 	}
 }
 
+// TestRecordStereo_ClosedCompanionKeepsRecording pins the item's central
+// semantic change: only the master ends the recording. A companion that closes
+// mid-call must silence-fill for the rest of the timeline rather than cutting
+// the file short, which is what the previous lock-step loop did.
+func TestRecordStereo_ClosedCompanionKeepsRecording(t *testing.T) {
+	const (
+		nSlots     = 20
+		closeAt    = 5
+		compSample = int16(0x1111)
+	)
+
+	left, right := runStereo(t, stereoRate, masterRamp(nSlots, stereoSlotBytes), func(k int, leftPW *syncPipeWriter, _ *Recorder) {
+		// The companion talks for a few slots and then closes for good.
+		switch {
+		case k < closeAt:
+			leftPW.Write(pcmFrame(compSample, stereoSlotBytes))
+		case k == closeAt:
+			leftPW.Close()
+		}
+	})
+
+	// The master ran to its own EOF: the companion closing did not end the file.
+	if want := nSlots * stereoSlotSamples; len(right) != want {
+		t.Fatalf("recorded %d frames, want %d — a closed companion must not end the recording", len(right), want)
+	}
+	if len(left) != len(right) {
+		t.Fatalf("channel lengths differ: left=%d right=%d", len(left), len(right))
+	}
+
+	// The master stream is untouched by the companion's close.
+	for i, s := range right {
+		if want := masterVal(i / stereoSlotSamples); s != want {
+			t.Fatalf("right[%d] = %d, want %d — master audio lost when the companion closed", i, s, want)
+		}
+	}
+
+	// The companion is audible up to the close, then silence-fills in place.
+	for i := 0; i < len(left); i++ {
+		want := int16(0)
+		if i < closeAt*stereoSlotSamples {
+			want = compSample
+		}
+		if left[i] != want {
+			t.Fatalf("left[%d] = %d, want %d — a closed companion must silence-fill", i, left[i], want)
+		}
+	}
+}
+
 func rateName(rate int) string {
 	switch rate {
 	case 8000:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4536,7 +4536,7 @@ x-webhooks:
                                         type: string
                                     file:
                                         type: string
-                                        description: Recording file path or S3 URI
+                                        description: Recording file path or S3 URI — does not exist yet; the path only appears when the recording stops
     recording.finished:
         post:
             summary: Recording ended
@@ -4564,6 +4564,11 @@ x-webhooks:
                                         type: object
                                         additionalProperties:
                                             $ref: '#/components/schemas/ChannelInfo'
+                                    omitted_legs:
+                                        type: array
+                                        items:
+                                            type: string
+                                        description: Participants whose audio is missing from multi_channel_file because their capture failed. Absent when the recording is complete
     recording.paused:
         post:
             summary: Recording paused (audio replaced with silence)

--- a/tests/integration/recording_pause_test.go
+++ b/tests/integration/recording_pause_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -33,6 +34,14 @@ func TestRecording_PauseResume_Leg(t *testing.T) {
 	}
 	var recStart recordingResponse
 	decodeJSON(t, recResp, &recStart)
+
+	// The path a start response advertises must not exist yet. API.md states the
+	// recording only appears there once it stops, so nothing can observe it
+	// half-written; this is the only end-to-end check of that contract, and it
+	// has to run now, while the recording is still in progress.
+	if _, err := os.Stat(recStart.File); !os.IsNotExist(err) {
+		t.Fatalf("%s exists while the recording is in progress, os.Stat err = %v — a partial recording is visible at its published name", recStart.File, err)
+	}
 
 	// Let audio flow for a bit.
 	time.Sleep(300 * time.Millisecond)
@@ -112,6 +121,17 @@ func TestRecording_PauseResume_Leg(t *testing.T) {
 	}
 	if len(buf.Data) == 0 {
 		t.Fatal("empty WAV")
+	}
+
+	// The staging file the recording was captured to must not outlive it. The
+	// literal mirrors stagingPattern in internal/recording, which is unexported
+	// and so cannot be referenced from here.
+	residue, err := filepath.Glob(filepath.Join(filepath.Dir(recStart.File), ".rec-*.tmp"))
+	if err != nil {
+		t.Fatalf("glob staging files: %v", err)
+	}
+	if len(residue) != 0 {
+		t.Errorf("staging residue left behind after the recording stopped: %v", residue)
 	}
 
 	// Pause after stop should 404.

--- a/tests/integration/stereo_recorder_sync_test.go
+++ b/tests/integration/stereo_recorder_sync_test.go
@@ -1,0 +1,213 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/leg"
+	"github.com/go-audio/wav"
+)
+
+const (
+	stallCallRate  = 8000 // PCMU
+	stallFrameLen  = stallCallRate / 50 * 2
+	stallFrameTime = 20 * time.Millisecond
+	stallBurstAmp  = int16(20000)
+	// Comfortably above mu-law's quantization of digital silence, and well
+	// below the burst amplitude.
+	stallBurstFloor = 8000
+)
+
+// sipLegOf fetches a leg by ID from an instance as a concrete *leg.SIPLeg.
+func sipLegOf(t *testing.T, inst *testInstance, legID string) *leg.SIPLeg {
+	t.Helper()
+	l, ok := inst.legMgr.Get(legID)
+	if !ok {
+		t.Fatalf("leg %s not found on %s", legID, inst.name)
+	}
+	sl, ok := l.(*leg.SIPLeg)
+	if !ok {
+		t.Fatalf("leg %s is %T, want *leg.SIPLeg", legID, l)
+	}
+	return sl
+}
+
+// readStereoChannels splits a stereo WAV into its two channels.
+func readStereoChannels(t *testing.T, path string) (left, right []int) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	dec := wav.NewDecoder(f)
+	buf, err := dec.FullPCMBuffer()
+	if err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	if int(dec.NumChans) != 2 {
+		t.Fatalf("recording has %d channels, want 2", dec.NumChans)
+	}
+	for i := 0; i+1 < len(buf.Data); i += 2 {
+		left = append(left, buf.Data[i])
+		right = append(right, buf.Data[i+1])
+	}
+	return left, right
+}
+
+// burstOnsets returns the sample index at which each loud burst begins. Samples
+// louder than threshold that are within debounce of the previous loud sample
+// belong to the burst already found.
+func burstOnsets(samples []int, threshold, debounce int) []int {
+	var onsets []int
+	last := -debounce - 1
+	for i, s := range samples {
+		if s < 0 {
+			s = -s
+		}
+		if s < threshold {
+			continue
+		}
+		if i-last > debounce {
+			onsets = append(onsets, i)
+		}
+		last = i
+	}
+	return onsets
+}
+
+// TestStereoRecording_StaysAlignedAcrossIncomingStall drives a real loopback
+// SIP call, stalls the incoming RTP mid-recording while outgoing keeps flowing,
+// resumes it, and proves the stall introduced no lasting skew between the
+// recording's two channels.
+//
+// A stereo leg recording taps incoming audio to the left channel (written only
+// when a packet decodes) and outgoing audio to the right (written every 20 ms
+// tick, silence included). A marker burst is injected on both sides at the same
+// moment before and after the stall. The recorded gap between the two channels'
+// copies of a marker is the call's transport latency, which is not zero and not
+// the thing under test; what must hold is that this gap does not *change* across
+// the stall. It changing means the channels drifted apart permanently and the
+// recording is no longer usable for review.
+func TestStereoRecording_StaysAlignedAcrossIncomingStall(t *testing.T) {
+	instA := newTestInstance(t, "instance-a")
+	instB := newTestInstance(t, "instance-b")
+
+	// establishCall leaves the legs standalone (not in a room), which is the
+	// stereo SIP tap path.
+	outboundID, inboundID := establishCall(t, instA, instB)
+
+	legA := sipLegOf(t, instA, outboundID)
+	legB := sipLegOf(t, instB, inboundID)
+
+	recResp := httpPost(t, fmt.Sprintf("%s/v1/legs/%s/record", instA.baseURL(), outboundID), nil)
+	if recResp.StatusCode != http.StatusOK {
+		t.Fatalf("start recording: unexpected status %d", recResp.StatusCode)
+	}
+	var recStart recordingResponse
+	decodeJSON(t, recResp, &recStart)
+
+	wA := legA.AudioWriter()
+	wB := legB.AudioWriter()
+	if wA == nil || wB == nil {
+		t.Fatal("leg has no audio writer")
+	}
+
+	silence := make([]byte, stallFrameLen)
+	burst := make([]byte, stallFrameLen)
+	for i := 0; i+1 < len(burst); i += 2 {
+		binary.LittleEndian.PutUint16(burst[i:], uint16(stallBurstAmp))
+	}
+
+	// feed writes n frames to both ends at the leg's own frame cadence. A's
+	// frames become the recording's right channel directly; B's travel over RTP
+	// and become the recording's left channel.
+	feed := func(n int, loud bool) {
+		frame := silence
+		if loud {
+			frame = burst
+		}
+		for i := 0; i < n; i++ {
+			wA.Write(frame)
+			wB.Write(frame)
+			time.Sleep(stallFrameTime)
+		}
+	}
+
+	start := time.Now()
+	feed(25, false) // settle
+	feed(3, true)   // marker 1, before the stall
+	feed(25, false)
+
+	// Stall the incoming RTP without signalling, so A never learns and its
+	// outgoing side keeps ticking. This is the failure the recorder must ride
+	// out: hold, packet loss, or a DTMF-only stretch all look like this.
+	legB.SetHeld(true)
+	feed(30, false) // ~600 ms of incoming silence
+	legB.SetHeld(false)
+
+	feed(25, false) // settle after resume
+	feed(3, true)   // marker 2, after the stall
+	feed(25, false)
+	elapsed := time.Since(start)
+
+	stopResp := httpDelete(t, fmt.Sprintf("%s/v1/legs/%s/record", instA.baseURL(), outboundID))
+	if stopResp.StatusCode != http.StatusOK {
+		t.Fatalf("stop recording: unexpected status %d", stopResp.StatusCode)
+	}
+	stopResp.Body.Close()
+
+	assertWAVAudio(t, recStart.File, 2, stallCallRate, 100)
+	left, right := readStereoChannels(t, recStart.File)
+
+	// The master clock keeps the file advancing through the stall, so the
+	// recording covers the call rather than stopping where incoming did.
+	wantSamples := int(elapsed.Seconds() * stallCallRate)
+	if len(right) < wantSamples*3/4 {
+		t.Errorf("recorded %d samples/channel, want ~%d (%.0f%% of the %v call): the stall shortened the recording",
+			len(right), wantSamples, 100*float64(len(right))/float64(wantSamples), elapsed.Round(time.Millisecond))
+	}
+	if len(left) != len(right) {
+		t.Fatalf("channel lengths differ: left=%d right=%d", len(left), len(right))
+	}
+
+	const debounce = 10 * (stallFrameLen / 2) // 200 ms: far below the marker spacing
+	onsetsL := burstOnsets(left, stallBurstFloor, debounce)
+	onsetsR := burstOnsets(right, stallBurstFloor, debounce)
+
+	if len(onsetsL) != 2 {
+		t.Fatalf("left channel has %d marker bursts at %v, want 2 (incoming audio lost)", len(onsetsL), onsetsL)
+	}
+	if len(onsetsR) != 2 {
+		t.Fatalf("right channel has %d marker bursts at %v, want 2 (outgoing audio lost)", len(onsetsR), onsetsR)
+	}
+
+	// Each marker went onto both sides at the same instant, so the offset
+	// between the channels is the call's transport latency. It must not change
+	// across the stall.
+	offsetBefore := onsetsL[0] - onsetsR[0]
+	offsetAfter := onsetsL[1] - onsetsR[1]
+	drift := offsetAfter - offsetBefore
+	if drift < 0 {
+		drift = -drift
+	}
+
+	// One slot is 20 ms; allow a few for RTP jitter and the resync after the
+	// gap. The regression this guards against skews by the whole stall (~600 ms
+	// / 30 slots), so this stays far away from a false pass.
+	const tolerance = 5 * (stallFrameLen / 2) // 100 ms
+	t.Logf("marker offsets: before=%d samples, after=%d samples, drift=%d samples (%.1f ms), tolerance=%d",
+		offsetBefore, offsetAfter, drift, 1000*float64(drift)/stallCallRate, tolerance)
+	if drift > tolerance {
+		t.Errorf("channels drifted %d samples (%.0f ms) across the incoming stall, want <= %d: "+
+			"left and right are permanently misaligned for the rest of the call",
+			drift, 1000*float64(drift)/stallCallRate, tolerance)
+	}
+}


### PR DESCRIPTION
Two problems.

Stereo capture read both channels in lock-step, so a stall on the incoming side parked the loop while the master tap kept writing into a bounded pipe that dropped its overflow. The two channels of the recording stayed skewed for the rest of the call.
Capture now runs off the outbound tap that paces it (the mix tick in a room, the leg's out-tap standalone), with a bounded drop-oldest companion buffer, so a stalled incoming stream leaves a gap instead of a permanent offset. A stalled outbound tap still freezes the recording with it.

Recordings were also written in place, so a crash mid-write left a file at the final path with the encoder's placeholder size header still in it. It opens as a valid WAV but decodes as near-empty, however much audio actually reached the disk. They now stage and publish with fsync + rename, and …and captures that can't be trusted are discarded rather than published: one that never wrote a frame, one that failed mid-write, and one whose WAV header rewrite failed. When a room recording has several legs and one capture dies, the survivors are still
merged and the dead leg is named in `omitted_legs` on `recording.finished` instead of the whole
recording being lost.

A note on the tests, since it took a while to get right: the discard gate was previously
unreachable in the suite — every test hitting that branch also had `wrote == false`, so deleting
half the condition left everything green. That's fixed, and the stereo test no longer relies on a
sleep for synchronisation.

