### PR TITLE
Stable event IDs and webhook egress drop/delivery metrics

### DIFF
--- a/API.md
+++ b/API.md
@@ -2810,7 +2810,7 @@ Every delivery carries an `X-Event-Id` header equal to the `event_id` field in t
 X-Event-Id: 550e8400-e29b-41d4-a716-446655440000
 ```
 
-`event_id` is a UUID assigned once when the event is published, so it is **stable across all 3 delivery attempts** of the same event and identical for every subscriber that receives it (webhook and VSI alike). Delivery is at-least-once, so a receiver should treat `event_id` as an idempotency key: record it and ignore an event whose id has already been processed. Distinct events never share an id.
+`event_id` is a UUID assigned once when the event is published, so it is **stable across all 3 delivery attempts** of the same event and identical for every subscriber that receives it (webhook and VSI alike). The same event may be delivered more than once (retry attempts, and once per subscriber), so a receiver should treat `event_id` as an idempotency key: record it and ignore an event whose id has already been processed. Delivery is best-effort, not guaranteed — an event dropped by a full queue or abandoned after 3 failed attempts (see Delivery above) is not redelivered. Distinct events never share an id.
 
 ### Event Envelope
 

--- a/API.md
+++ b/API.md
@@ -2453,16 +2453,18 @@ websocat "ws://localhost:8080/v1/vsi?app_id=^billing$"
 **Server → Client (event):**
 
 ```json
-{"type": "leg.connected", "timestamp": "2026-04-15T12:00:00Z", "instance_id": "i-abc", "leg_id": "550e8400-...", "leg_type": "sip_outbound"}
+{"type": "leg.connected", "timestamp": "2026-04-15T12:00:00Z", "event_id": "8f14e45f-...", "instance_id": "i-abc", "leg_id": "550e8400-...", "leg_type": "sip_outbound"}
 ```
 
-Events use the same flattened JSON envelope as webhook POSTs. Clients already parsing webhook payloads can reuse the same deserializer.
+Events use the same flattened JSON envelope as webhook POSTs — including `event_id`, the same per-event idempotency key webhook receivers see. Clients already parsing webhook payloads can reuse the same deserializer.
 
 **Server → Client (keepalive ping):**
 
 ```json
-{"type": "ping", "event_id": 1}
+{"type": "ping", "seq": 1}
 ```
+
+`seq` is a monotonic per-connection counter for the keepalive itself. It is unrelated to the `event_id` on streamed events; the ping is not an event and carries no `event_id`.
 
 **Client → Server (keepalive pong):**
 
@@ -2800,6 +2802,16 @@ X-Signature-256: sha256=<hex-encoded-hmac-sha256>
 
 The signature is computed over the raw JSON request body using HMAC-SHA256 with the webhook secret as the key.
 
+### Deduplication
+
+Every delivery carries an `X-Event-Id` header equal to the `event_id` field in the body:
+
+```
+X-Event-Id: 550e8400-e29b-41d4-a716-446655440000
+```
+
+`event_id` is a UUID assigned once when the event is published, so it is **stable across all 3 delivery attempts** of the same event and identical for every subscriber that receives it (webhook and VSI alike). Delivery is at-least-once, so a receiver should treat `event_id` as an idempotency key: record it and ignore an event whose id has already been processed. Distinct events never share an id.
+
 ### Event Envelope
 
 Event data fields are flattened into the top-level JSON object alongside the envelope fields — there is no `"data"` wrapper.
@@ -2808,6 +2820,7 @@ Event data fields are flattened into the top-level JSON object alongside the env
 {
   "type": "leg.ringing",
   "timestamp": "2026-03-01T11:05:00.123Z",
+  "event_id": "8f14e45f-ceea-467a-9575-9b0ba1f0e3a1",
   "instance_id": "550e8400-e29b-41d4-a716-446655440000",
   "leg_id": "550e8400-e29b-41d4-a716-446655440000",
   "leg_type": "sip_inbound",
@@ -2827,7 +2840,7 @@ Event data fields are flattened into the top-level JSON object alongside the env
 
 **`authenticated`** / **`auth_username`** (inbound SIP only) are present and set when the INVITE carried digest credentials that VoiceBlender verified against a prior `/challenge` — i.e. the credentialed retry surfaced as a new, authenticated leg. They are omitted for un-challenged calls.
 
-All events include `instance_id` alongside the event-specific fields.
+All events include `event_id` and `instance_id` alongside the event-specific fields.
 
 ### Event Types
 

--- a/API.md
+++ b/API.md
@@ -3501,7 +3501,7 @@ Returns Prometheus-format metrics for the VoiceBlender instance. No request body
 | `voiceblender_disconnect_reasons_total` | Counter | `type`, `reason` | Total disconnected legs by type and reason (e.g. `remote_bye`, `api_hangup`, `rtp_timeout`) |
 | `voiceblender_call_duration_seconds` | Histogram | `type` | Answered call duration (time from answer to hangup). Use `rate(sum)/rate(count)` for ACD |
 | `voiceblender_call_total_duration_seconds` | Histogram | `type` | Total leg lifetime including ringing time (time from leg creation to hangup) |
-| `voiceblender_webhook_enqueued_total` | Counter | — | Total events accepted onto the webhook delivery queue. Denominator for the drop ratio |
+| `voiceblender_webhook_enqueued_total` | Counter | — | Total events accepted onto the webhook delivery queue. Denominator for the drop ratio alongside `voiceblender_webhook_dropped_total` — use `dropped / (dropped + enqueued)` |
 | `voiceblender_webhook_dropped_total` | Counter | — | Total events dropped because the webhook delivery queue was full (backpressure) |
 | `voiceblender_webhook_deliveries_total` | Counter | `outcome` | Total terminal webhook delivery outcomes. `outcome`: `success`, `exhausted` (all 3 attempts failed), `marshal_error`, `request_error` (malformed webhook URL). Closed set, so cardinality is fixed at 4 |
 | `voiceblender_vsi_events_dropped_total` | Counter | — | Total events dropped because a VSI WebSocket client's buffer was full (slow consumer) |

--- a/API.md
+++ b/API.md
@@ -3488,7 +3488,16 @@ Returns Prometheus-format metrics for the VoiceBlender instance. No request body
 | `voiceblender_disconnect_reasons_total` | Counter | `type`, `reason` | Total disconnected legs by type and reason (e.g. `remote_bye`, `api_hangup`, `rtp_timeout`) |
 | `voiceblender_call_duration_seconds` | Histogram | `type` | Answered call duration (time from answer to hangup). Use `rate(sum)/rate(count)` for ACD |
 | `voiceblender_call_total_duration_seconds` | Histogram | `type` | Total leg lifetime including ringing time (time from leg creation to hangup) |
+| `voiceblender_webhook_enqueued_total` | Counter | — | Total events accepted onto the webhook delivery queue. Denominator for the drop ratio |
+| `voiceblender_webhook_dropped_total` | Counter | — | Total events dropped because the webhook delivery queue was full (backpressure) |
+| `voiceblender_webhook_deliveries_total` | Counter | `outcome` | Total terminal webhook delivery outcomes. `outcome`: `success`, `exhausted` (all 3 attempts failed), `marshal_error`, `request_error` (malformed webhook URL). Closed set, so cardinality is fixed at 4 |
+| `voiceblender_vsi_events_dropped_total` | Counter | — | Total events dropped because a VSI WebSocket client's buffer was full (slow consumer) |
 | Go runtime metrics | — | — | Standard `go_*` and `process_*` metrics from the Prometheus Go client |
+
+Every delivery that reaches a terminal exit increments exactly one
+`voiceblender_webhook_deliveries_total{outcome}`. This is not a global
+`enqueued == sum(outcomes)` identity: jobs still queued at shutdown are
+abandoned without an outcome, so a small, shutdown-only skew is expected.
 
 #### PromQL Examples
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A Go service that bridges SIP and WebRTC voice calls with multi-party audio mixi
 - **Answering Machine Detection (AMD)** -- per-call analysis of outbound call audio to classify the answerer as human, machine, no-speech, or not-sure; optional voicemail beep detection via Goertzel frequency analysis
 - **Webhooks** -- real-time event delivery with HMAC-SHA256 signing and retry; typed event data with CDR-style `leg.disconnected` (disposition, timing, quality)
 - **WebSocket event stream (VSI)** -- `GET /v1/vsi` streams all events and accepts commands (mute, hold, DTMF, room management) over a single persistent WebSocket; filter by `app_id` regex for multi-tenant isolation
-- **Prometheus metrics** -- operational metrics exposed at `GET /metrics` (active legs/rooms, call durations, disconnect reasons, Go runtime). See [API.md](API.md) for the full metric reference. Profiling via `go tool pprof` is available at `/debug/pprof/` when built with `-tags pprof`.
+- **Prometheus metrics** -- operational metrics exposed at `GET /metrics` (active legs/rooms, call durations, disconnect reasons, event-egress drop/delivery counters, Go runtime). See [API.md](API.md) for the full metric reference. Profiling via `go tool pprof` is available at `/debug/pprof/` when built with `-tags pprof`.
 
 ## Quick Start
 

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -4929,8 +4929,12 @@ components:
                 properties:
                     type:
                         const: ping
+                    seq:
+                        type: integer
+                        description: Per-connection monotonic counter starting at 1; resets on reconnect.
                 required:
                     - type
+                    - seq
         frame_pong:
             name: frame_pong
             title: Optional client keepalive reply to a `ping`. Currently a no-op on the server side.

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -1954,7 +1954,7 @@ operations:
         action: send
         channel:
             $ref: '#/channels/vsi'
-        summary: Periodic application-level keepalive (every ~30 s). Clients may reply with `pong` or ignore.
+        summary: Periodic application-level keepalive (every ~30 s), carrying a monotonic counter in `seq`. Clients may reply with `pong` or ignore.
         messages:
             - $ref: '#/channels/vsi/messages/ping'
     receive_pong:
@@ -4551,364 +4551,364 @@ components:
             name: evt_leg_ringing
             title: SIP call ringing (inbound or outbound)
             summary: SIP call ringing (inbound or outbound)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.ringing. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.ringing. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.ringing/post/requestBody/content/application~1json/schema
         evt_leg_early_media:
             name: evt_leg_early_media
             title: Outbound leg received 183 Session Progress with SDP; media pipeline active
             summary: Outbound leg received 183 Session Progress with SDP; media pipeline active
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.early_media. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.early_media. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.early_media/post/requestBody/content/application~1json/schema
         evt_leg_connected:
             name: evt_leg_connected
             title: Leg answered/connected
             summary: Leg answered/connected
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.connected. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.connected. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.connected/post/requestBody/content/application~1json/schema
         evt_leg_disconnected:
             name: evt_leg_disconnected
             title: Leg hung up (CDR-style nested structure)
             summary: Leg hung up (CDR-style nested structure)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.disconnected. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.disconnected. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.disconnected/post/requestBody/content/application~1json/schema
         evt_leg_joined_room:
             name: evt_leg_joined_room
             title: Leg added to a room
             summary: Leg added to a room
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.joined_room. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.joined_room. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.joined_room/post/requestBody/content/application~1json/schema
         evt_leg_left_room:
             name: evt_leg_left_room
             title: Leg removed from a room
             summary: Leg removed from a room
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.left_room. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.left_room. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.left_room/post/requestBody/content/application~1json/schema
         evt_leg_muted:
             name: evt_leg_muted
             title: Leg muted
             summary: Leg muted
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.muted. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.muted. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.muted/post/requestBody/content/application~1json/schema
         evt_leg_unmuted:
             name: evt_leg_unmuted
             title: Leg unmuted
             summary: Leg unmuted
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.unmuted. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.unmuted. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.unmuted/post/requestBody/content/application~1json/schema
         evt_leg_deaf:
             name: evt_leg_deaf
             title: Leg deafened (stops receiving room audio)
             summary: Leg deafened (stops receiving room audio)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.deaf. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.deaf. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.deaf/post/requestBody/content/application~1json/schema
         evt_leg_undeaf:
             name: evt_leg_undeaf
             title: Leg undeafened (resumes receiving room audio)
             summary: Leg undeafened (resumes receiving room audio)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.undeaf. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.undeaf. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.undeaf/post/requestBody/content/application~1json/schema
         evt_leg_hold:
             name: evt_leg_hold
             title: Leg put on hold (local or remote)
             summary: Leg put on hold (local or remote)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.hold. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.hold. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.hold/post/requestBody/content/application~1json/schema
         evt_leg_unhold:
             name: evt_leg_unhold
             title: Leg taken off hold (local or remote)
             summary: Leg taken off hold (local or remote)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.unhold. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.unhold. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.unhold/post/requestBody/content/application~1json/schema
         evt_leg_command_failed:
             name: evt_leg_command_failed
             title: An asynchronous leg command (202 Accepted) failed during execution
             summary: An asynchronous leg command (202 Accepted) failed during execution
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.command_failed. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.command_failed. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.command_failed/post/requestBody/content/application~1json/schema
         evt_dtmf_received:
             name: evt_dtmf_received
             title: DTMF digit received
             summary: DTMF digit received
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/dtmf.received. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/dtmf.received. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/dtmf.received/post/requestBody/content/application~1json/schema
         evt_rtt_received:
             name: evt_rtt_received
             title: Real-Time Text (T.140 / RFC 4103) chunk received from the remote
             summary: Real-Time Text (T.140 / RFC 4103) chunk received from the remote
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/rtt.received. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/rtt.received. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/rtt.received/post/requestBody/content/application~1json/schema
         evt_speaking_started:
             name: evt_speaking_started
             title: Participant started speaking
             summary: Participant started speaking
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/speaking.started. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/speaking.started. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/speaking.started/post/requestBody/content/application~1json/schema
         evt_speaking_stopped:
             name: evt_speaking_stopped
             title: Participant stopped speaking
             summary: Participant stopped speaking
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/speaking.stopped. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/speaking.stopped. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/speaking.stopped/post/requestBody/content/application~1json/schema
         evt_playback_started:
             name: evt_playback_started
             title: Playback began
             summary: Playback began
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/playback.started. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/playback.started. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/playback.started/post/requestBody/content/application~1json/schema
         evt_playback_finished:
             name: evt_playback_finished
             title: Playback ended
             summary: Playback ended
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/playback.finished. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/playback.finished. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/playback.finished/post/requestBody/content/application~1json/schema
         evt_playback_error:
             name: evt_playback_error
             title: Playback failed
             summary: Playback failed
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/playback.error. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/playback.error. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/playback.error/post/requestBody/content/application~1json/schema
         evt_tts_started:
             name: evt_tts_started
             title: TTS synthesis began playing
             summary: TTS synthesis began playing
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/tts.started. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/tts.started. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/tts.started/post/requestBody/content/application~1json/schema
         evt_tts_finished:
             name: evt_tts_finished
             title: TTS synthesis finished playing
             summary: TTS synthesis finished playing
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/tts.finished. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/tts.finished. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/tts.finished/post/requestBody/content/application~1json/schema
         evt_tts_error:
             name: evt_tts_error
             title: TTS synthesis or playback failed
             summary: TTS synthesis or playback failed
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/tts.error. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/tts.error. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/tts.error/post/requestBody/content/application~1json/schema
         evt_recording_started:
             name: evt_recording_started
             title: Recording began
             summary: Recording began
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/recording.started. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/recording.started. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/recording.started/post/requestBody/content/application~1json/schema
         evt_recording_finished:
             name: evt_recording_finished
             title: Recording ended
             summary: Recording ended
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/recording.finished. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/recording.finished. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/recording.finished/post/requestBody/content/application~1json/schema
         evt_recording_paused:
             name: evt_recording_paused
             title: Recording paused (audio replaced with silence)
             summary: Recording paused (audio replaced with silence)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/recording.paused. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/recording.paused. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/recording.paused/post/requestBody/content/application~1json/schema
         evt_recording_resumed:
             name: evt_recording_resumed
             title: Recording resumed from a paused state
             summary: Recording resumed from a paused state
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/recording.resumed. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/recording.resumed. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/recording.resumed/post/requestBody/content/application~1json/schema
         evt_leg_transfer_initiated:
             name: evt_leg_transfer_initiated
             title: We sent a SIP REFER (transfer initiated by the operator)
             summary: We sent a SIP REFER (transfer initiated by the operator)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.transfer_initiated. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.transfer_initiated. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.transfer_initiated/post/requestBody/content/application~1json/schema
         evt_leg_transfer_requested:
             name: evt_leg_transfer_requested
             title: We received a SIP REFER from the peer; decide via accept_transfer/decline_transfer (unless SIP_REFER_AUTO_DIAL=true)
             summary: We received a SIP REFER from the peer; decide via accept_transfer/decline_transfer (unless SIP_REFER_AUTO_DIAL=true)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.transfer_requested. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.transfer_requested. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.transfer_requested/post/requestBody/content/application~1json/schema
         evt_leg_transfer_progress:
             name: evt_leg_transfer_progress
             title: Transfer progress reported via NOTIFY sipfrag
             summary: Transfer progress reported via NOTIFY sipfrag
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.transfer_progress. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.transfer_progress. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.transfer_progress/post/requestBody/content/application~1json/schema
         evt_leg_transfer_completed:
             name: evt_leg_transfer_completed
             title: Transfer reached terminal 2xx
             summary: Transfer reached terminal 2xx
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.transfer_completed. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.transfer_completed. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.transfer_completed/post/requestBody/content/application~1json/schema
         evt_leg_transfer_failed:
             name: evt_leg_transfer_failed
             title: Transfer failed (REFER rejected, sipfrag non-2xx, or local error)
             summary: Transfer failed (REFER rejected, sipfrag non-2xx, or local error)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.transfer_failed. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.transfer_failed. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.transfer_failed/post/requestBody/content/application~1json/schema
         evt_room_created:
             name: evt_room_created
             title: Room created
             summary: Room created
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.created. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.created. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/room.created/post/requestBody/content/application~1json/schema
         evt_room_deleted:
             name: evt_room_deleted
             title: Room deleted
             summary: Room deleted
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.deleted. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.deleted. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/room.deleted/post/requestBody/content/application~1json/schema
         evt_room_bridged:
             name: evt_room_bridged
             title: Two rooms' mixers were joined
             summary: Two rooms' mixers were joined
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.bridged. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.bridged. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/room.bridged/post/requestBody/content/application~1json/schema
         evt_room_bridge_updated:
             name: evt_room_bridge_updated
             title: A bridge's audio flow direction changed
             summary: A bridge's audio flow direction changed
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.bridge_updated. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.bridge_updated. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/room.bridge_updated/post/requestBody/content/application~1json/schema
         evt_room_unbridged:
             name: evt_room_unbridged
             title: A bridge was torn down
             summary: A bridge was torn down
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.unbridged. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.unbridged. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/room.unbridged/post/requestBody/content/application~1json/schema
         evt_room_routing_changed:
             name: evt_room_routing_changed
             title: The room's audio routing matrix changed
             summary: The room's audio routing matrix changed
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.routing_changed. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/room.routing_changed. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/room.routing_changed/post/requestBody/content/application~1json/schema
         evt_leg_role_changed:
             name: evt_leg_role_changed
             title: A leg's routing role changed
             summary: A leg's routing role changed
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.role_changed. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/leg.role_changed. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/leg.role_changed/post/requestBody/content/application~1json/schema
         evt_stt_text:
             name: evt_stt_text
             title: Speech-to-text transcript
             summary: Speech-to-text transcript
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/stt.text. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/stt.text. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/stt.text/post/requestBody/content/application~1json/schema
         evt_agent_connected:
             name: evt_agent_connected
             title: Agent connected to provider
             summary: Agent connected to provider
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/agent.connected. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/agent.connected. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/agent.connected/post/requestBody/content/application~1json/schema
         evt_agent_disconnected:
             name: evt_agent_disconnected
             title: Agent session ended
             summary: Agent session ended
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/agent.disconnected. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/agent.disconnected. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/agent.disconnected/post/requestBody/content/application~1json/schema
         evt_agent_user_transcript:
             name: evt_agent_user_transcript
             title: User speech transcribed by agent
             summary: User speech transcribed by agent
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/agent.user_transcript. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/agent.user_transcript. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/agent.user_transcript/post/requestBody/content/application~1json/schema
         evt_agent_agent_response:
             name: evt_agent_agent_response
             title: Agent generated a response
             summary: Agent generated a response
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/agent.agent_response. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/agent.agent_response. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/agent.agent_response/post/requestBody/content/application~1json/schema
         evt_amd_result:
             name: evt_amd_result
             title: Answering machine detection completed
             summary: Answering machine detection completed
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/amd.result. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/amd.result. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/amd.result/post/requestBody/content/application~1json/schema
         evt_amd_beep:
             name: evt_amd_beep
             title: Voicemail beep tone detected after machine classification
             summary: Voicemail beep tone detected after machine classification
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/amd.beep. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/amd.beep. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/amd.beep/post/requestBody/content/application~1json/schema
         evt_sip_registration_attempt:
             name: evt_sip_registration_attempt
             title: Inbound REGISTER surfaced for a challenge/accept/reject decision (auto-accepts on consult timeout)
             summary: Inbound REGISTER surfaced for a challenge/accept/reject decision (auto-accepts on consult timeout)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.registration_attempt. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.registration_attempt. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/sip.registration_attempt/post/requestBody/content/application~1json/schema
         evt_sip_registration_active:
             name: evt_sip_registration_active
             title: SIP AOR registration created or refreshed (one event per Contact)
             summary: SIP AOR registration created or refreshed (one event per Contact)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.registration_active. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.registration_active. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/sip.registration_active/post/requestBody/content/application~1json/schema
         evt_sip_registration_expired:
             name: evt_sip_registration_expired
             title: SIP AOR registration removed (TTL, explicit unregister, force-delete, or single-binding replacement)
             summary: SIP AOR registration removed (TTL, explicit unregister, force-delete, or single-binding replacement)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.registration_expired. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.registration_expired. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/sip.registration_expired/post/requestBody/content/application~1json/schema
         evt_sip_outbound_registration_active:
             name: evt_sip_outbound_registration_active
             title: Outbound SIP trunk REGISTER accepted (initial or refresh)
             summary: Outbound SIP trunk REGISTER accepted (initial or refresh)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.outbound_registration_active. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.outbound_registration_active. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/sip.outbound_registration_active/post/requestBody/content/application~1json/schema
         evt_sip_outbound_registration_failed:
             name: evt_sip_outbound_registration_failed
             title: Outbound SIP trunk REGISTER failed (transport error, non-2xx response, or digest auth rejected)
             summary: Outbound SIP trunk REGISTER failed (transport error, non-2xx response, or digest auth rejected)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.outbound_registration_failed. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.outbound_registration_failed. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/sip.outbound_registration_failed/post/requestBody/content/application~1json/schema
         evt_sip_outbound_registration_expired:
             name: evt_sip_outbound_registration_expired
             title: Outbound SIP trunk removed (DELETE, shutdown, or refresh failed past granted lifetime)
             summary: Outbound SIP trunk removed (DELETE, shutdown, or refresh failed past granted lifetime)
-            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.outbound_registration_expired. Full envelope: {type, timestamp, instance_id, ...event-specific fields}.'
+            description: 'Event payload shape is documented in openapi.yaml under x-webhooks/sip.outbound_registration_expired. Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.'
             payload:
                 $ref: openapi.yaml#/x-webhooks/sip.outbound_registration_expired/post/requestBody/content/application~1json/schema
         frame_connected:
@@ -4923,7 +4923,7 @@ components:
                     - type
         frame_ping:
             name: frame_ping
-            title: Periodic application-level keepalive (every ~30 s). Clients may reply with `pong` or ignore.
+            title: Periodic application-level keepalive (every ~30 s), carrying a monotonic counter in `seq`. Clients may reply with `pong` or ignore.
             payload:
                 type: object
                 properties:

--- a/cmd/asyncapi-gen/main.go
+++ b/cmd/asyncapi-gen/main.go
@@ -444,7 +444,7 @@ func eventMessage(ev api.EventMeta) *omap {
 		set("name", eventMsgName(string(ev.Type))).
 		set("title", ev.Summary).
 		set("summary", ev.Summary).
-		set("description", "Event payload shape is documented in openapi.yaml under x-webhooks/"+string(ev.Type)+". Full envelope: {type, timestamp, instance_id, ...event-specific fields}.").
+		set("description", "Event payload shape is documented in openapi.yaml under x-webhooks/"+string(ev.Type)+". Full envelope: {type, timestamp, event_id, instance_id, ...event-specific fields}.").
 		set("payload", newMap().set("$ref", openapiPath))
 }
 

--- a/cmd/asyncapi-gen/main.go
+++ b/cmd/asyncapi-gen/main.go
@@ -450,7 +450,7 @@ func eventMessage(ev api.EventMeta) *omap {
 
 func lifecycleMessage(lf api.VSILifecycleFrame) *omap {
 	switch lf.Name {
-	case "connected", "ping":
+	case "connected":
 		return newMap().
 			set("name", lifecycleMsgName(lf.Name)).
 			set("title", lf.Description).
@@ -459,6 +459,16 @@ func lifecycleMessage(lf api.VSILifecycleFrame) *omap {
 				set("properties", newMap().
 					set("type", newMap().set("const", lf.Name))).
 				set("required", newSeq().add("type")))
+	case "ping":
+		return newMap().
+			set("name", lifecycleMsgName(lf.Name)).
+			set("title", lf.Description).
+			set("payload", newMap().
+				set("type", "object").
+				set("properties", newMap().
+					set("type", newMap().set("const", "ping")).
+					set("seq", newMap().set("type", "integer").set("description", "Per-connection monotonic counter starting at 1; resets on reconnect."))).
+				set("required", newSeq().add("type").add("seq")))
 	case "events_dropped":
 		return newMap().
 			set("name", lifecycleMsgName(lf.Name)).

--- a/cmd/openapi-gen/main.go
+++ b/cmd/openapi-gen/main.go
@@ -819,10 +819,13 @@ func main() {
 	schemaRegistry["WebhookEvent"] = newMap().set("type", "object").
 		set("description", "Event envelope delivered via HTTP POST to registered webhook URLs. "+
 			"Event-specific fields are flattened into the top-level object (no \"data\" wrapper). "+
-			"Includes X-Signature-256 header when a secret is configured.").
+			"Includes X-Signature-256 header when a secret is configured, and an X-Event-Id header "+
+			"equal to the event_id field.").
 		set("properties", newMap().
 			set("type", schemaRef("WebhookEventType")).
 			set("timestamp", newMap().set("type", "string").set("format", "date-time")).
+			set("event_id", newMap().set("type", "string").set("format", "uuid").
+				set("description", "Stable per-event idempotency key; identical across webhook retries and all subscribers.")).
 			set("instance_id", newMap().set("type", "string").set("description", "Instance identifier"))).
 		set("required", newSeq().add("type").add("timestamp"))
 

--- a/cmd/voiceblender/main.go
+++ b/cmd/voiceblender/main.go
@@ -178,6 +178,7 @@ func main() {
 
 	// Prometheus metrics collector
 	metricsCollector := metrics.New(bus)
+	webhookReg.SetMetricsObserver(metricsCollector)
 
 	// HTTP API server
 	allowedIPs, err := api.ParseAllowedIPs(cfg.AllowedIPs)

--- a/internal/api/vsi_meta.go
+++ b/internal/api/vsi_meta.go
@@ -291,7 +291,7 @@ type VSILifecycleFrame struct {
 func VSILifecycleFramesMetadata() []VSILifecycleFrame {
 	return []VSILifecycleFrame{
 		{Name: "connected", Direction: "send", Description: "First frame the server sends after the WebSocket upgrade completes. Carries no data."},
-		{Name: "ping", Direction: "send", Description: "Periodic application-level keepalive (every ~30 s). Clients may reply with `pong` or ignore."},
+		{Name: "ping", Direction: "send", Description: "Periodic application-level keepalive (every ~30 s), carrying a monotonic counter in `seq`. Clients may reply with `pong` or ignore."},
 		{Name: "pong", Direction: "receive", Description: "Optional client keepalive reply to a `ping`. Currently a no-op on the server side."},
 		{Name: "stop", Direction: "receive", Description: "Client-initiated graceful close. The server stops the recv loop and closes the connection."},
 		{Name: "events_dropped", Direction: "send", Description: "Sent when the per-connection event buffer overflowed. The accompanying `count` indicates how many events were dropped since the last notification. Clients should resync via REST after seeing this."},

--- a/internal/api/ws_events.go
+++ b/internal/api/ws_events.go
@@ -91,6 +91,12 @@ func (s *Server) vsi(w http.ResponseWriter, r *http.Request) {
 			// Buffer full → drop. Log on the leading edge of a drop burst
 			// (transition from 0 → 1) and on each power-of-10 threshold so
 			// sustained backpressure is visible without flooding the log.
+			// The counter, unlike the log, records every drop. This runs on
+			// the publisher's goroutine (Bus.Publish is synchronous), so it
+			// must stay non-blocking — a counter increment is.
+			if s.Metrics != nil {
+				s.Metrics.ObserveVSIDropped()
+			}
 			n := dropped.Add(1)
 			if isDropLogThreshold(n) {
 				s.Log.Warn("vsi: event buffer full, dropping event",

--- a/internal/api/ws_events.go
+++ b/internal/api/ws_events.go
@@ -52,6 +52,18 @@ func isDropLogThreshold(n int64) bool {
 	return true
 }
 
+// vsiPingFrame builds the keepalive ping frame the VSI ping loop emits. The
+// counter field is named "seq" rather than "event_id": streamed events on this
+// socket carry an "event_id" of their own (the per-event idempotency key), and
+// one socket must not advertise two meanings for that name.
+func vsiPingFrame(seq int64) []byte {
+	b, _ := json.Marshal(map[string]interface{}{
+		"type": "ping",
+		"seq":  seq,
+	})
+	return b
+}
+
 func (s *Server) vsi(w http.ResponseWriter, r *http.Request) {
 	// Parse optional app_id regex filter before upgrade so we can reject with 400.
 	var appFilter *regexp.Regexp
@@ -162,7 +174,7 @@ func (s *Server) vsi(w http.ResponseWriter, r *http.Request) {
 
 	// Ping loop.
 	go func() {
-		var eventID int64
+		var seq int64
 		ticker := time.NewTicker(wsPingInterval)
 		defer ticker.Stop()
 		for {
@@ -171,11 +183,8 @@ func (s *Server) vsi(w http.ResponseWriter, r *http.Request) {
 				if closed.Load() {
 					return
 				}
-				eventID++
-				msg, _ := json.Marshal(map[string]interface{}{
-					"type":     "ping",
-					"event_id": eventID,
-				})
+				seq++
+				msg := vsiPingFrame(seq)
 				if err := lw.writeText(msg); err != nil {
 					return
 				}

--- a/internal/api/ws_events_metrics_test.go
+++ b/internal/api/ws_events_metrics_test.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+	"github.com/gobwas/ws"
+)
+
+// TestVSI_BufferFullIncrementsDroppedCounter drives the real s.vsi handler and
+// proves that its buffer-full drop branch increments
+// voiceblender_vsi_events_dropped_total. Nothing else in the suite binds that
+// call site to the series: ObserveVSIDropped is not part of
+// events.MetricsObserver, so the compile-time assert gives this path no
+// protection, and a metrics-package test that calls ObserveVSIDropped directly
+// would still pass with the call site deleted. This test must go red if the
+// ObserveVSIDropped call is removed from the drop branch in ws_events.go.
+func TestVSI_BufferFullIncrementsDroppedCounter(t *testing.T) {
+	s := newTestServer(t)
+	// Defeat the 256-event fallback so a small burst overflows the buffer.
+	s.Config.VSIEventBufferSize = 1
+
+	srv := httptest.NewServer(s.Router)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws://" + strings.TrimPrefix(srv.URL, "http://") + "/v1/vsi"
+	conn, _, _, err := ws.Dial(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("dial vsi: %v", err)
+	}
+	defer conn.Close()
+	// Deliberately never read from conn: the send loop stalls once the socket
+	// buffer fills, so the cap-1 channel backs up and the drop branch runs.
+
+	// Bus.Publish is synchronous, so the subscriber's select runs on this
+	// goroutine. Publish in bounded batches until the counter moves or the
+	// deadline elapses. The drop count is nondeterministic (the send loop
+	// drains concurrently), hence "> 0" rather than an exact value.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		for i := 0; i < 200; i++ {
+			s.Bus.Publish(events.LegRinging, &events.LegRingingData{
+				LegScope: events.LegScope{LegID: "leg-1"},
+				From:     "alice",
+				To:       "bob",
+			})
+		}
+
+		got := parseCounter(t, metricsBody(t, s), "voiceblender_vsi_events_dropped_total")
+		if got > 0 {
+			return // Counter moved on the real drop path.
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("voiceblender_vsi_events_dropped_total never exceeded 0; "+
+				"the drop branch in ws_events.go did not increment the counter\n%s",
+				metricsBody(t, s))
+		}
+	}
+}
+
+// metricsBody scrapes the live /metrics endpoint through the router. The
+// Collector's counters and registry are unexported, so testutil.ToFloat64 is
+// unusable from package api; the handler is the only reachable accessor.
+func metricsBody(t *testing.T, s *Server) string {
+	t.Helper()
+	w := doRequest(s, http.MethodGet, "/metrics", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /metrics = %d, want 200", w.Code)
+	}
+	return w.Body.String()
+}
+
+// parseCounter returns the value of an unlabelled counter sample, or 0 if the
+// series has not been emitted yet.
+func parseCounter(t *testing.T, body, name string) float64 {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, val, ok := strings.Cut(line, " ")
+		if !ok || key != name {
+			continue
+		}
+		f, err := strconv.ParseFloat(strings.TrimSpace(val), 64)
+		if err != nil {
+			t.Fatalf("parse %s value %q: %v", name, val, err)
+		}
+		return f
+	}
+	return 0
+}

--- a/internal/api/ws_events_test.go
+++ b/internal/api/ws_events_test.go
@@ -1,6 +1,45 @@
 package api
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestVSIPingFrame_UsesSeq is the only executable proof that the VSI keepalive
+// counter is named "seq" on the wire. It asserts on vsiPingFrame — the helper
+// the ping loop actually calls — so reverting the emitted field name back to
+// "event_id" reddens it. It must not restate the frame as a map literal, which
+// would only assert on itself.
+//
+// The name matters: streamed events on this same socket now carry an "event_id"
+// (the per-event idempotency key), so a ping using that name would advertise two
+// different meanings for one field.
+func TestVSIPingFrame_UsesSeq(t *testing.T) {
+	raw := vsiPingFrame(1)
+
+	if strings.Contains(string(raw), "event_id") {
+		t.Errorf("ping frame must not mention event_id, got %s", raw)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal ping frame: %v", err)
+	}
+	if m["type"] != "ping" {
+		t.Errorf("type = %v, want ping", m["type"])
+	}
+	seq, ok := m["seq"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric seq field, got %#v (frame: %s)", m["seq"], raw)
+	}
+	if seq != 1 {
+		t.Errorf("seq = %v, want 1", seq)
+	}
+	if _, ok := m["event_id"]; ok {
+		t.Errorf("ping frame carries event_id: %s", raw)
+	}
+}
 
 func TestIsDropLogThreshold(t *testing.T) {
 	cases := []struct {

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -3,6 +3,8 @@ package events
 import (
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Handler func(Event)
@@ -35,9 +37,18 @@ func (b *Bus) Subscribe(h Handler) func() {
 	}
 }
 
+// Publish builds the event envelope and invokes every subscribed handler
+// synchronously on the caller's goroutine, so handlers must not block.
+//
+// The event is stamped with a fresh EventID here, before the handler snapshot
+// is taken and before any sink retries. That ordering is what makes the id
+// identical across all subscribers and constant across a webhook's delivery
+// attempts: it is assigned once per event, never per fan-out and never per
+// attempt.
 func (b *Bus) Publish(typ EventType, data EventData) {
 	e := Event{
 		Type:       typ,
+		EventID:    uuid.NewString(),
 		Timestamp:  time.Now().UTC(),
 		InstanceID: b.instanceID,
 		Data:       data,

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -2,12 +2,15 @@ package events
 
 import (
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestNewBus(t *testing.T) {
@@ -95,9 +98,64 @@ func TestBus_PublishSetsTimestamp(t *testing.T) {
 	}
 }
 
+func TestBus_PublishSetsEventID(t *testing.T) {
+	bus := NewBus("test")
+	var got Event
+	bus.Subscribe(func(e Event) { got = e })
+
+	bus.Publish(RoomCreated, nil)
+
+	if _, err := uuid.Parse(got.EventID); err != nil {
+		t.Fatalf("EventID %q is not a UUID: %v", got.EventID, err)
+	}
+}
+
+// TestBus_EventIDUniquePerPublish guards uniqueness: distinct events must not
+// collide, or a consumer deduping on the key would discard real events.
+func TestBus_EventIDUniquePerPublish(t *testing.T) {
+	bus := NewBus("test")
+	var ids []string
+	bus.Subscribe(func(e Event) { ids = append(ids, e.EventID) })
+
+	const n = 100
+	for i := 0; i < n; i++ {
+		bus.Publish(RoomCreated, nil)
+	}
+
+	seen := make(map[string]struct{}, n)
+	for _, id := range ids {
+		if _, dup := seen[id]; dup {
+			t.Fatalf("duplicate EventID %q across distinct publishes", id)
+		}
+		seen[id] = struct{}{}
+	}
+	if len(seen) != n {
+		t.Fatalf("got %d distinct ids across %d publishes", len(seen), n)
+	}
+}
+
+// TestBus_EventIDStableAcrossSubscribers guards the "assign once, before
+// fan-out" invariant: every subscriber of one Publish must observe the same id.
+func TestBus_EventIDStableAcrossSubscribers(t *testing.T) {
+	bus := NewBus("test")
+	var a, b Event
+	bus.Subscribe(func(e Event) { a = e })
+	bus.Subscribe(func(e Event) { b = e })
+
+	bus.Publish(RoomCreated, nil)
+
+	if a.EventID == "" || b.EventID == "" {
+		t.Fatal("expected both subscribers to receive an EventID")
+	}
+	if a.EventID != b.EventID {
+		t.Errorf("subscribers saw different ids for one event: %q vs %q", a.EventID, b.EventID)
+	}
+}
+
 func TestEvent_MarshalJSON(t *testing.T) {
 	e := Event{
 		Type:       LegConnected,
+		EventID:    "ev-1",
 		Timestamp:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 		InstanceID: "inst-1",
 		Data:       &LegConnectedData{LegScope: LegScope{LegID: "leg-1"}, LegType: "sip_inbound"},
@@ -116,6 +174,9 @@ func TestEvent_MarshalJSON(t *testing.T) {
 	if m["type"] != "leg.connected" {
 		t.Errorf("type = %v", m["type"])
 	}
+	if m["event_id"] != "ev-1" {
+		t.Errorf("event_id = %v, want ev-1", m["event_id"])
+	}
 	if m["instance_id"] != "inst-1" {
 		t.Errorf("instance_id = %v", m["instance_id"])
 	}
@@ -128,7 +189,7 @@ func TestEvent_MarshalJSON(t *testing.T) {
 }
 
 func TestEvent_MarshalJSON_NilData(t *testing.T) {
-	e := Event{Type: RoomCreated, Timestamp: time.Now()}
+	e := Event{Type: RoomCreated, EventID: "ev-2", Timestamp: time.Now()}
 	data, err := json.Marshal(e)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -139,6 +200,29 @@ func TestEvent_MarshalJSON_NilData(t *testing.T) {
 	}
 	if m["type"] != "room.created" {
 		t.Errorf("type = %v", m["type"])
+	}
+	// The nil-data branch skips the merge loop; event_id must survive it.
+	if m["event_id"] != "ev-2" {
+		t.Errorf("event_id = %v, want ev-2", m["event_id"])
+	}
+}
+
+// TestEvent_MarshalJSON_NoEventID pins the omitempty contract: an event with no
+// id (e.g. one constructed outside Bus.Publish, or an older replayed payload)
+// omits the key rather than emitting an empty string, keeping it schema-valid
+// against a WebhookEvent that does not list event_id as required.
+func TestEvent_MarshalJSON_NoEventID(t *testing.T) {
+	e := Event{Type: RoomCreated, Timestamp: time.Now()}
+	data, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["event_id"]; ok {
+		t.Errorf("expected event_id to be omitted when unset, got %v", m["event_id"])
 	}
 }
 
@@ -362,6 +446,98 @@ func TestWebhookRegistry_HMAC(t *testing.T) {
 	}
 	if len(sigHeader) < 10 || sigHeader[:7] != "sha256=" {
 		t.Errorf("invalid signature header: %q", sigHeader)
+	}
+}
+
+// TestWebhookRegistry_EventIDHeader asserts the X-Event-Id header agrees with
+// the body's event_id for the same delivery — a receiver must be able to dedupe
+// on the header without parsing the body.
+func TestWebhookRegistry_EventIDHeader(t *testing.T) {
+	type delivery struct {
+		header string
+		body   string
+	}
+	ch := make(chan delivery, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var m map[string]interface{}
+		_ = json.Unmarshal(body, &m)
+		id, _ := m["event_id"].(string)
+		select {
+		case ch <- delivery{header: r.Header.Get("X-Event-Id"), body: id}:
+		default:
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	bus := NewBus("test")
+	reg := NewWebhookRegistry(bus, slog.Default(), srv.URL, "")
+	defer reg.Stop()
+
+	bus.Publish(RoomDeleted, &RoomDeletedData{RoomScope: RoomScope{RoomID: "r1"}})
+
+	var d delivery
+	select {
+	case d = <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for webhook delivery")
+	}
+
+	if _, err := uuid.Parse(d.header); err != nil {
+		t.Fatalf("X-Event-Id %q is not a UUID: %v", d.header, err)
+	}
+	if d.header != d.body {
+		t.Errorf("X-Event-Id %q != body event_id %q", d.header, d.body)
+	}
+}
+
+// TestWebhookRegistry_EventIDStableAcrossRetries is the core stability guard:
+// the id is assigned once at publish, so all three at-least-once delivery
+// attempts of one event must carry the identical key. Re-stamping per attempt
+// would defeat the whole point — the receiver could not dedupe.
+//
+// Slow (~6 s) by construction: the retry backoff is a real time.Sleep and this
+// test deliberately drives it rather than adding a knob that would weaken the
+// production path.
+func TestWebhookRegistry_EventIDStableAcrossRetries(t *testing.T) {
+	const attempts = 3
+	ids := make(chan string, attempts)
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ids <- r.Header.Get("X-Event-Id")
+		// 500 on the first two attempts, 200 on the third.
+		if atomic.AddInt32(&n, 1) < attempts {
+			w.WriteHeader(500)
+			return
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	bus := NewBus("test")
+	reg := NewWebhookRegistry(bus, slog.Default(), srv.URL, "")
+	defer reg.Stop()
+
+	bus.Publish(RoomDeleted, &RoomDeletedData{RoomScope: RoomScope{RoomID: "r1"}})
+
+	got := make([]string, 0, attempts)
+	for i := 0; i < attempts; i++ {
+		select {
+		case id := <-ids:
+			got = append(got, id)
+		case <-time.After(15 * time.Second):
+			t.Fatalf("timeout waiting for attempt %d of %d", i+1, attempts)
+		}
+	}
+
+	if _, err := uuid.Parse(got[0]); err != nil {
+		t.Fatalf("X-Event-Id %q is not a UUID: %v", got[0], err)
+	}
+	for i, id := range got {
+		if id != got[0] {
+			t.Errorf("attempt %d carried X-Event-Id %q, want %q (id must be stable across retries)", i+1, id, got[0])
+		}
 	}
 }
 

--- a/internal/events/observer.go
+++ b/internal/events/observer.go
@@ -1,0 +1,32 @@
+package events
+
+// MetricsObserver receives notifications about webhook egress outcomes so a
+// metrics backend can turn them into time-series. It lives in this package
+// (rather than in internal/metrics) because the metrics package already
+// imports events; defining it there would create an import cycle.
+//
+// Implementations MUST be goroutine-safe and non-blocking. Methods are called
+// inline on the bus dispatch path — which runs handlers synchronously on the
+// publisher's goroutine, potentially a media-plane goroutine — and on the
+// webhook worker goroutines. Any blocking work (I/O, an unbuffered send, a
+// contended lock) inside an implementation adds latency to, or stalls, those
+// paths. A Prometheus counter increment is a suitable amount of work; a
+// network call is not.
+//
+// A nil MetricsObserver is valid: every call site nil-guards, so a registry
+// with no observer wired behaves exactly as it did before.
+type MetricsObserver interface {
+	// OnWebhookEnqueued reports that an event was accepted onto the webhook
+	// delivery queue.
+	OnWebhookEnqueued(webhookID, eventType string)
+
+	// OnWebhookDropped reports that an event was discarded because the
+	// webhook delivery queue was full.
+	OnWebhookDropped(webhookID, eventType string)
+
+	// OnWebhookDelivered reports the terminal outcome of a delivery attempt
+	// sequence. outcome is one of "success", "exhausted", "marshal_error",
+	// or "request_error". Exactly one call is made per job that reaches a
+	// terminal exit, so the label set is closed and its cardinality fixed.
+	OnWebhookDelivered(webhookID, eventType, outcome string)
+}

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -78,7 +78,11 @@ const (
 )
 
 type Event struct {
-	Type       EventType `json:"type"`
+	Type EventType `json:"type"`
+	// EventID is a stable per-event idempotency key assigned once at publish.
+	// It is identical across every subscriber of an event and across every
+	// webhook delivery attempt, so an at-least-once consumer can dedupe on it.
+	EventID    string    `json:"event_id,omitempty"`
 	Timestamp  time.Time `json:"timestamp"`
 	InstanceID string    `json:"instance_id,omitempty"`
 	Data       EventData `json:"-"`
@@ -90,6 +94,9 @@ func (e Event) MarshalJSON() ([]byte, error) {
 	envelope := map[string]interface{}{
 		"type":      e.Type,
 		"timestamp": e.Timestamp,
+	}
+	if e.EventID != "" {
+		envelope["event_id"] = e.EventID
 	}
 	if e.InstanceID != "" {
 		envelope["instance_id"] = e.InstanceID

--- a/internal/events/webhook.go
+++ b/internal/events/webhook.go
@@ -202,6 +202,11 @@ func (r *WebhookRegistry) deliver(job deliveryJob) {
 			return
 		}
 		req.Header.Set("Content-Type", "application/json")
+		if job.event.EventID != "" {
+			// Constant across all attempts: the id lives on the shared event,
+			// assigned at publish, so a receiver can dedupe retries on it.
+			req.Header.Set("X-Event-Id", job.event.EventID)
+		}
 
 		if job.hook.Secret != "" {
 			mac := hmac.New(sha256.New, []byte(job.hook.Secret))

--- a/internal/events/webhook.go
+++ b/internal/events/webhook.go
@@ -32,9 +32,9 @@ type WebhookRegistry struct {
 	stopOnce      sync.Once
 	stopCh        chan struct{}
 
-	// obs is an optional, non-blocking observer for egress metrics. It is
-	// set once at startup via SetMetricsObserver, before any event can be
-	// published, and read-only thereafter. Nil when no collector is wired.
+	// obs is an optional, non-blocking observer for egress metrics. Guarded by
+	// r.mu: it is attached after construction, when events can already be in
+	// flight — see SetMetricsObserver. Nil when no collector is wired.
 	obs MetricsObserver
 }
 

--- a/internal/events/webhook.go
+++ b/internal/events/webhook.go
@@ -31,6 +31,11 @@ type WebhookRegistry struct {
 	workCh        chan deliveryJob
 	stopOnce      sync.Once
 	stopCh        chan struct{}
+
+	// obs is an optional, non-blocking observer for egress metrics. It is
+	// set once at startup via SetMetricsObserver, before any event can be
+	// published, and read-only thereafter. Nil when no collector is wired.
+	obs MetricsObserver
 }
 
 type deliveryJob struct {
@@ -65,6 +70,29 @@ func (r *WebhookRegistry) Stop() {
 	r.stopOnce.Do(func() { close(r.stopCh) })
 }
 
+// SetMetricsObserver attaches o as the egress metrics observer. It exists as
+// a setter rather than a constructor argument because the registry is built
+// before the metrics collector during startup. o must be non-blocking (see
+// MetricsObserver).
+//
+// The registry subscribes to the bus and starts its workers at construction,
+// so events can already be in flight when this is called; obs is therefore
+// guarded by r.mu like the webhook maps.
+func (r *WebhookRegistry) SetMetricsObserver(o MetricsObserver) {
+	r.mu.Lock()
+	r.obs = o
+	r.mu.Unlock()
+}
+
+// observer returns the current observer (possibly nil) without holding the
+// lock across the caller's use of it.
+func (r *WebhookRegistry) observer() MetricsObserver {
+	r.mu.RLock()
+	o := r.obs
+	r.mu.RUnlock()
+	return o
+}
+
 func (r *WebhookRegistry) SetLegWebhook(legID, url, secret string) {
 	r.mu.Lock()
 	r.legWebhooks[legID] = &Webhook{ID: legID, URL: url, Secret: secret}
@@ -90,11 +118,20 @@ func (r *WebhookRegistry) ClearRoomWebhook(roomID string) {
 }
 
 func (r *WebhookRegistry) enqueue(w *Webhook, e Event) {
+	obs := r.observer()
 	select {
 	case r.workCh <- deliveryJob{hook: w, event: e}:
+		if obs != nil {
+			obs.OnWebhookEnqueued(w.ID, string(e.Type))
+		}
 	case <-r.stopCh:
+		// Shutdown: the job is abandoned without an outcome. Deliberately
+		// uncounted — see the note on OnWebhookDelivered.
 	default:
 		r.log.Warn("webhook delivery queue full, dropping event", "webhook_id", w.ID, "event", e.Type)
+		if obs != nil {
+			obs.OnWebhookDropped(w.ID, string(e.Type))
+		}
 	}
 }
 
@@ -131,10 +168,24 @@ func (r *WebhookRegistry) worker() {
 	}
 }
 
+// deliver attempts a webhook POST with up to 3 tries and reports exactly one
+// terminal outcome to the metrics observer. Every path that leaves this
+// function increments exactly one outcome: "marshal_error", "request_error",
+// "success", or "exhausted". Note this is not a global
+// enqueued == sum(outcomes) identity — enqueue and worker abandon jobs at
+// shutdown without an outcome — but no exit from deliver is uncounted.
 func (r *WebhookRegistry) deliver(job deliveryJob) {
+	obs := r.observer()
+	outcome := func(o string) {
+		if obs != nil {
+			obs.OnWebhookDelivered(job.hook.ID, string(job.event.Type), o)
+		}
+	}
+
 	body, err := json.Marshal(job.event)
 	if err != nil {
 		r.log.Error("failed to marshal event", "error", err)
+		outcome("marshal_error")
 		return
 	}
 
@@ -147,6 +198,7 @@ func (r *WebhookRegistry) deliver(job deliveryJob) {
 		req, err := http.NewRequest(http.MethodPost, job.hook.URL, bytes.NewReader(body))
 		if err != nil {
 			r.log.Error("failed to create webhook request", "error", err)
+			outcome("request_error")
 			return
 		}
 		req.Header.Set("Content-Type", "application/json")
@@ -165,9 +217,11 @@ func (r *WebhookRegistry) deliver(job deliveryJob) {
 		}
 		resp.Body.Close()
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			outcome("success")
 			return
 		}
 		r.log.Warn("webhook delivery got non-2xx", "url", job.hook.URL, "status", resp.StatusCode, "attempt", attempt+1)
 	}
 	r.log.Error("webhook delivery exhausted retries", "url", job.hook.URL, "event", job.event.Type)
+	outcome("exhausted")
 }

--- a/internal/events/webhook_test.go
+++ b/internal/events/webhook_test.go
@@ -1,0 +1,278 @@
+package events
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeObserver records MetricsObserver calls. The observer is invoked from the
+// webhook worker goroutines, so every field is mutex-guarded.
+type fakeObserver struct {
+	mu        sync.Mutex
+	enqueued  int
+	dropped   int
+	delivered []string // outcome values, in call order
+
+	// deliveredCh signals each OnWebhookDelivered call so tests can
+	// synchronize instead of sleeping.
+	deliveredCh chan string
+}
+
+func newFakeObserver() *fakeObserver {
+	return &fakeObserver{deliveredCh: make(chan string, 16)}
+}
+
+func (f *fakeObserver) OnWebhookEnqueued(webhookID, eventType string) {
+	f.mu.Lock()
+	f.enqueued++
+	f.mu.Unlock()
+}
+
+func (f *fakeObserver) OnWebhookDropped(webhookID, eventType string) {
+	f.mu.Lock()
+	f.dropped++
+	f.mu.Unlock()
+}
+
+func (f *fakeObserver) OnWebhookDelivered(webhookID, eventType, outcome string) {
+	f.mu.Lock()
+	f.delivered = append(f.delivered, outcome)
+	f.mu.Unlock()
+	select {
+	case f.deliveredCh <- outcome:
+	default:
+	}
+}
+
+func (f *fakeObserver) counts() (enqueued, dropped int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.enqueued, f.dropped
+}
+
+// waitDelivered blocks for one OnWebhookDelivered call and returns its outcome.
+func (f *fakeObserver) waitDelivered(t *testing.T) string {
+	t.Helper()
+	select {
+	case o := <-f.deliveredCh:
+		return o
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for OnWebhookDelivered")
+		return ""
+	}
+}
+
+// newTestRegistry builds a registry without starting workers or subscribing to
+// a bus, so enqueue/deliver can be driven directly and deterministically.
+func newTestRegistry(t *testing.T, queueCap int) *WebhookRegistry {
+	t.Helper()
+	r := &WebhookRegistry{
+		legWebhooks:  make(map[string]*Webhook),
+		roomWebhooks: make(map[string]*Webhook),
+		log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		client:       &http.Client{Timeout: 2 * time.Second},
+		workCh:       make(chan deliveryJob, queueCap),
+		stopCh:       make(chan struct{}),
+	}
+	t.Cleanup(r.Stop)
+	return r
+}
+
+func testEvent() Event {
+	return Event{Type: LegRinging, Data: &LegRingingData{LegScope: LegScope{LegID: "leg-1"}}}
+}
+
+// TestWebhookRegistry_ObserverOnDrop proves the queue-full drop branch reports
+// OnWebhookDropped and not OnWebhookEnqueued.
+func TestWebhookRegistry_ObserverOnDrop(t *testing.T) {
+	r := newTestRegistry(t, 1)
+	obs := newFakeObserver()
+	r.SetMetricsObserver(obs)
+
+	hook := &Webhook{ID: "leg-1", URL: "http://example.invalid/hook"}
+
+	// First fills the cap-1 queue; the rest must hit the default: drop branch.
+	for i := 0; i < 4; i++ {
+		r.enqueue(hook, testEvent())
+	}
+
+	enqueued, dropped := obs.counts()
+	if enqueued != 1 {
+		t.Errorf("enqueued = %d, want 1", enqueued)
+	}
+	if dropped != 3 {
+		t.Errorf("dropped = %d, want 3", dropped)
+	}
+}
+
+// TestWebhookRegistry_NilObserverSafe proves the nil-guards hold: a registry
+// with no observer wired must behave exactly as before.
+func TestWebhookRegistry_NilObserverSafe(t *testing.T) {
+	r := newTestRegistry(t, 1)
+
+	hook := &Webhook{ID: "leg-1", URL: "http://example.invalid/hook"}
+	r.enqueue(hook, testEvent()) // accepted
+	r.enqueue(hook, testEvent()) // dropped
+
+	// deliver with no observer must not panic either. Use a request-error URL
+	// so this returns immediately with no retry sleep.
+	r.deliver(deliveryJob{hook: &Webhook{ID: "leg-1", URL: "http://exa mple.com/hook"}, event: testEvent()})
+}
+
+// TestWebhookRegistry_DeliverSuccess proves the success terminal exit is
+// counted. The test server answers 2xx on the first attempt, so no backoff
+// sleep is incurred.
+func TestWebhookRegistry_DeliverSuccess(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := newTestRegistry(t, 1)
+	obs := newFakeObserver()
+	r.SetMetricsObserver(obs)
+
+	r.deliver(deliveryJob{hook: &Webhook{ID: "leg-1", URL: srv.URL}, event: testEvent()})
+
+	if got := obs.waitDelivered(t); got != "success" {
+		t.Errorf("outcome = %q, want success", got)
+	}
+	if n := hits.Load(); n != 1 {
+		t.Errorf("server hits = %d, want 1", n)
+	}
+}
+
+// TestWebhookRegistry_DeliverRequestError proves the fourth terminal exit:
+// http.NewRequest failing on a malformed URL. Without it,
+// webhook_deliveries_total silently under-counts on exactly the path a
+// user-supplied webhook URL can reach. The URL below fails inside
+// http.NewRequest ("invalid character \" \" in host name"), so no HTTP request
+// is attempted and no retry sleep occurs.
+func TestWebhookRegistry_DeliverRequestError(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+	}))
+	defer srv.Close()
+
+	r := newTestRegistry(t, 1)
+	obs := newFakeObserver()
+	r.SetMetricsObserver(obs)
+
+	start := time.Now()
+	r.deliver(deliveryJob{hook: &Webhook{ID: "leg-1", URL: "http://exa mple.com/hook"}, event: testEvent()})
+
+	if got := obs.waitDelivered(t); got != "request_error" {
+		t.Errorf("outcome = %q, want request_error", got)
+	}
+
+	obs.mu.Lock()
+	n := len(obs.delivered)
+	obs.mu.Unlock()
+	if n != 1 {
+		t.Errorf("delivered calls = %d, want exactly 1", n)
+	}
+	if hits.Load() != 0 {
+		t.Error("expected no HTTP request to be attempted")
+	}
+	// The request-error exit is terminal on attempt 0, so it must not sleep
+	// through the retry backoff.
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("deliver took %v; request_error should return without retrying", elapsed)
+	}
+}
+
+// TestWebhookRegistry_DeliverExhausted proves the exhausted terminal exit.
+// It costs the real 2s+4s backoff (webhook.go), so it is skipped in -short.
+func TestWebhookRegistry_DeliverExhausted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("exercises the real retry backoff (~6s)")
+	}
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	r := newTestRegistry(t, 1)
+	obs := newFakeObserver()
+	r.SetMetricsObserver(obs)
+
+	r.deliver(deliveryJob{hook: &Webhook{ID: "leg-1", URL: srv.URL}, event: testEvent()})
+
+	if got := obs.waitDelivered(t); got != "exhausted" {
+		t.Errorf("outcome = %q, want exhausted", got)
+	}
+	if n := hits.Load(); n != 3 {
+		t.Errorf("server hits = %d, want 3 attempts", n)
+	}
+}
+
+// TestWebhookRegistry_DeliverMarshalError proves the marshal_error terminal
+// exit via event data whose MarshalJSON always fails.
+func TestWebhookRegistry_DeliverMarshalError(t *testing.T) {
+	r := newTestRegistry(t, 1)
+	obs := newFakeObserver()
+	r.SetMetricsObserver(obs)
+
+	r.deliver(deliveryJob{
+		hook:  &Webhook{ID: "leg-1", URL: "http://example.invalid/hook"},
+		event: Event{Type: LegRinging, Data: unmarshalableData{}},
+	})
+
+	if got := obs.waitDelivered(t); got != "marshal_error" {
+		t.Errorf("outcome = %q, want marshal_error", got)
+	}
+}
+
+// unmarshalableData is EventData whose JSON encoding always fails, driving
+// deliver's marshal_error exit.
+type unmarshalableData struct{}
+
+func (unmarshalableData) GetLegID() string  { return "leg-1" }
+func (unmarshalableData) GetRoomID() string { return "" }
+func (unmarshalableData) GetAppID() string  { return "" }
+func (unmarshalableData) MarshalJSON() ([]byte, error) {
+	return nil, io.ErrUnexpectedEOF
+}
+
+// TestWebhookRegistry_ObserverRace exercises the observer from the real worker
+// goroutines concurrently with SetMetricsObserver, which is how startup wires
+// it (the registry subscribes and starts workers before the collector exists).
+func TestWebhookRegistry_ObserverRace(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	bus := NewBus("test")
+	r := NewWebhookRegistry(bus, slog.New(slog.NewTextHandler(io.Discard, nil)), srv.URL, "")
+	defer r.Stop()
+
+	obs := newFakeObserver()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			bus.Publish(LegRinging, &LegRingingData{LegScope: LegScope{LegID: "leg-1"}})
+		}
+	}()
+	r.SetMetricsObserver(obs)
+	wg.Wait()
+
+	// Only assert no race/panic: how many events land before the observer is
+	// attached is inherently timing-dependent.
+	obs.waitDelivered(t)
+}

--- a/internal/events/webhook_test.go
+++ b/internal/events/webhook_test.go
@@ -233,6 +233,18 @@ func TestWebhookRegistry_DeliverMarshalError(t *testing.T) {
 	if got := obs.waitDelivered(t); got != "marshal_error" {
 		t.Errorf("outcome = %q, want marshal_error", got)
 	}
+
+	// Pin deliver's documented exactly-one-outcome invariant, not just the
+	// first outcome: without a return after outcome("marshal_error"), execution
+	// falls into the retry loop and also reports "exhausted", which
+	// waitDelivered alone cannot see. deliver runs synchronously here
+	// (newTestRegistry starts no workers), so every increment has landed.
+	obs.mu.Lock()
+	n := len(obs.delivered)
+	obs.mu.Unlock()
+	if n != 1 {
+		t.Errorf("delivered calls = %d, want exactly 1", n)
+	}
 }
 
 // unmarshalableData is EventData whose JSON encoding always fails, driving

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -36,8 +36,29 @@ type Collector struct {
 	// Labels: type, reason.
 	callTotalDurationSeconds *prometheus.HistogramVec
 
+	// webhookEnqueued counts events accepted onto the webhook delivery queue.
+	// Denominator for the drop ratio alongside webhookDropped.
+	webhookEnqueued prometheus.Counter
+
+	// webhookDropped counts events discarded because the delivery queue was full.
+	webhookDropped prometheus.Counter
+
+	// webhookDeliveries counts terminal webhook delivery outcomes.
+	// Labels: outcome ("success"|"exhausted"|"marshal_error"|"request_error").
+	// Closed set, so cardinality is fixed at 4.
+	webhookDeliveries *prometheus.CounterVec
+
+	// vsiEventsDropped counts events discarded because a VSI WebSocket
+	// client's send buffer was full.
+	vsiEventsDropped prometheus.Counter
+
 	registry *prometheus.Registry
 }
+
+// Collector observes webhook egress on behalf of the events package. The
+// methods below are counter increments only: goroutine-safe and non-blocking,
+// as events.MetricsObserver requires.
+var _ events.MetricsObserver = (*Collector)(nil)
 
 var durationBuckets = []float64{5, 15, 30, 60, 120, 300, 600, 1800, 3600}
 
@@ -81,6 +102,26 @@ func New(bus *events.Bus) *Collector {
 			Buckets: durationBuckets,
 		}, []string{"type"}),
 
+		webhookEnqueued: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "voiceblender_webhook_enqueued_total",
+			Help: "Total events accepted onto the webhook delivery queue.",
+		}),
+
+		webhookDropped: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "voiceblender_webhook_dropped_total",
+			Help: "Total events dropped because the webhook delivery queue was full.",
+		}),
+
+		webhookDeliveries: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "voiceblender_webhook_deliveries_total",
+			Help: "Total terminal webhook delivery outcomes.",
+		}, []string{"outcome"}),
+
+		vsiEventsDropped: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "voiceblender_vsi_events_dropped_total",
+			Help: "Total events dropped because a VSI WebSocket client's buffer was full.",
+		}),
+
 		registry: reg,
 	}
 
@@ -98,10 +139,48 @@ func New(bus *events.Bus) *Collector {
 		c.disconnectReasons,
 		c.callDurationSeconds,
 		c.callTotalDurationSeconds,
+		c.webhookEnqueued,
+		c.webhookDropped,
+		c.webhookDeliveries,
+		c.vsiEventsDropped,
 	)
 
 	_ = bus.Subscribe(c.handle)
 	return c
+}
+
+// The webhookID and eventType arguments are deliberately not used as label
+// values: webhookID is a leg or room ID and eventType is open-ended, so either
+// would give these series unbounded cardinality. They stay on the interface
+// because they are what a non-Prometheus observer (or a debug logger) would
+// need, and because the drop log line already carries both.
+
+// OnWebhookEnqueued implements events.MetricsObserver.
+func (c *Collector) OnWebhookEnqueued(webhookID, eventType string) {
+	c.webhookEnqueued.Inc()
+}
+
+// OnWebhookDropped implements events.MetricsObserver.
+func (c *Collector) OnWebhookDropped(webhookID, eventType string) {
+	c.webhookDropped.Inc()
+}
+
+// OnWebhookDelivered implements events.MetricsObserver. outcome comes from a
+// closed set fixed by deliver's terminal exits, so it is safe as a label.
+func (c *Collector) OnWebhookDelivered(webhookID, eventType, outcome string) {
+	c.webhookDeliveries.WithLabelValues(outcome).Inc()
+}
+
+// ObserveVSIDropped records one event dropped because a VSI WebSocket
+// client's send buffer was full. Called inline from the VSI subscriber's
+// drop branch, which runs on the publisher's goroutine — a counter increment
+// is non-blocking, so this is safe there.
+//
+// This is deliberately not part of events.MetricsObserver: the VSI path lives
+// in internal/api, which already imports internal/metrics and can call the
+// concrete collector without the interface indirection.
+func (c *Collector) ObserveVSIDropped() {
+	c.vsiEventsDropped.Inc()
 }
 
 // Handler returns an http.Handler that serves the Prometheus metrics page.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -124,6 +124,51 @@ func TestMetrics_RoomCreatedDeleted(t *testing.T) {
 	}
 }
 
+// TestCollector_ImplementsObserver is an interface/registration conformance
+// check: it proves each observer method reaches its counter and that every new
+// series renders in the /metrics body.
+//
+// Scope: it calls the methods directly, so it CANNOT prove any production call
+// site is wired. The webhook call sites are proven in internal/events
+// (TestWebhookRegistry_*) and the VSI call site in internal/api
+// (TestVSI_BufferFullIncrementsDroppedCounter). A registered-but-never-
+// incremented counter would still satisfy this test.
+func TestCollector_ImplementsObserver(t *testing.T) {
+	bus := events.NewBus("test")
+	c := New(bus)
+
+	// Compile-time conformance is asserted in metrics.go; this pins the
+	// runtime behavior of each method.
+	var obs events.MetricsObserver = c
+	obs.OnWebhookEnqueued("leg-1", "leg.ringing")
+	obs.OnWebhookEnqueued("leg-1", "leg.ringing")
+	obs.OnWebhookDropped("leg-1", "leg.ringing")
+	obs.OnWebhookDelivered("leg-1", "leg.ringing", "success")
+	obs.OnWebhookDelivered("leg-1", "leg.ringing", "request_error")
+	c.ObserveVSIDropped()
+
+	// Assert by value off the rendered body. (prometheus/testutil would read
+	// the counters directly, but it pulls in module requirements this repo
+	// does not have; the body is the same source of truth and needs no new
+	// dependency.)
+	body := getMetrics(t, c)
+	for _, tc := range []struct {
+		sample string
+		want   string
+	}{
+		{"voiceblender_webhook_enqueued_total", "2"},
+		{"voiceblender_webhook_dropped_total", "1"},
+		{`voiceblender_webhook_deliveries_total{outcome="success"}`, "1"},
+		{`voiceblender_webhook_deliveries_total{outcome="request_error"}`, "1"},
+		{"voiceblender_vsi_events_dropped_total", "1"},
+	} {
+		want := tc.sample + " " + tc.want
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %q in /metrics body:\n%s", want, body)
+		}
+	}
+}
+
 func getMetrics(t *testing.T, c *Collector) string {
 	t.Helper()
 	rec := httptest.NewRecorder()

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,10 +1,13 @@
 package metrics
 
 import (
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/VoiceBlender/voiceblender/internal/events"
 )
@@ -166,6 +169,59 @@ func TestCollector_ImplementsObserver(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("expected %q in /metrics body:\n%s", want, body)
 		}
+	}
+}
+
+// TestCollector_ObservesRealWebhookRegistry joins the two halves of the feature
+// that every other test leaves apart: TestWebhookRegistry_* prove webhook.go
+// calls *an interface* (they pass a fake observer), and
+// TestCollector_ImplementsObserver proves each method reaches its counter (it
+// calls the methods directly). Neither binds a real *Collector to a real
+// WebhookRegistry, so a Collector that satisfies the interface but never gets
+// attached would satisfy both. This drives a real event through a real registry
+// into a real counter and reads the value back off /metrics.
+//
+// Scope, honestly: this closes the composition gap, not the main() gap. It does
+// not make the SetMetricsObserver call in cmd/voiceblender deletable-and-red —
+// no main() wiring in this repo is test-covered.
+func TestCollector_ObservesRealWebhookRegistry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	bus := events.NewBus("test")
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// The global-webhook argument is what routes the event, so no SetLegWebhook.
+	reg := events.NewWebhookRegistry(bus, log, srv.URL, "")
+	defer reg.Stop()
+
+	c := New(bus)
+	reg.SetMetricsObserver(c)
+
+	bus.Publish(events.LegRinging, &events.LegRingingData{
+		LegScope: events.LegScope{LegID: "leg-1"},
+	})
+
+	// enqueue runs inline on the publisher's goroutine, so enqueued is already
+	// counted here; only the delivery leg is handed to a worker goroutine.
+	body := getMetrics(t, c)
+	if !strings.Contains(body, "voiceblender_webhook_enqueued_total 1") {
+		t.Errorf("enqueued counter did not move, body:\n%s", body)
+	}
+
+	const wantDelivered = `voiceblender_webhook_deliveries_total{outcome="success"} 1`
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		body = getMetrics(t, c)
+		if strings.Contains(body, wantDelivered) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Errorf("deliveries counter did not move: want %q, body:\n%s", wantDelivered, body)
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3919,13 +3919,17 @@ components:
                 - sdp
         WebhookEvent:
             type: object
-            description: Event envelope delivered via HTTP POST to registered webhook URLs. Event-specific fields are flattened into the top-level object (no "data" wrapper). Includes X-Signature-256 header when a secret is configured.
+            description: Event envelope delivered via HTTP POST to registered webhook URLs. Event-specific fields are flattened into the top-level object (no "data" wrapper). Includes X-Signature-256 header when a secret is configured, and an X-Event-Id header equal to the event_id field.
             properties:
                 type:
                     $ref: '#/components/schemas/WebhookEventType'
                 timestamp:
                     type: string
                     format: date-time
+                event_id:
+                    type: string
+                    format: uuid
+                    description: Stable per-event idempotency key; identical across webhook retries and all subscribers.
                 instance_id:
                     type: string
                     description: Instance identifier


### PR DESCRIPTION
Webhook egress is non-blocking and drops on a full queue, and the only signal was a log line.
This adds an observer interface on the events package, drop and delivery counters, and a metrics
collector wired into webhook egress. Events dropped on a full VSI client buffer are counted too.

Every event now carries a stable `event_id`, set once at publish and surfaced as the `X-Event-Id`
header on webhook deliveries, so a receiver can deduplicate redeliveries.

**Breaking change for VSI clients:** the keepalive ping's counter is renamed from `event_id` to
`seq`, so it no longer collides with the new per-event `event_id`. A client reading `ping.event_id`
will need updating. The generated specs declare `seq` on the ping message.

Two wordings were self-corrected within this branch rather than against the base: the delivery
guarantee is described as best-effort rather than at-least-once, and the drop ratio is documented
as `dropped/(dropped+enqueued)`. Both texts were added earlier in this same branch, so neither
changes the docs relative to master.
