### PR TITLE
fix(sip): answer OPTIONS with 200 OK for dispatcher health probes

### DIFF
--- a/internal/sip/engine.go
+++ b/internal/sip/engine.go
@@ -866,6 +866,15 @@ func (e *Engine) registerHandlers() {
 		}
 	}))
 
+	e.server.OnOptions(wrap(func(req *sip.Request, tx sip.ServerTransaction) {
+		res := sip.NewResponseFromRequest(req, sip.StatusOK, "OK", nil)
+		res.AppendHeader(e.ServerHeader())
+		res.AppendHeader(e.AllowHeader())
+		if rerr := e.respondMaybeFromSource(tx, req, res); rerr != nil {
+			e.log.Error("OPTIONS: respond 200 failed", "error", rerr)
+		}
+	}))
+
 	e.server.OnUpdate(wrap(e.handleUpdate))
 	e.server.OnRefer(wrap(e.handleRefer))
 	e.server.OnNotify(wrap(e.handleNotify))

--- a/internal/sip/engine_test.go
+++ b/internal/sip/engine_test.go
@@ -182,7 +182,7 @@ func TestEngine_AllowHeader(t *testing.T) {
 		t.Fatalf("header name = %q, want Allow", h.Name())
 	}
 	val := h.Value()
-	for _, m := range []string{"INVITE", "ACK", "CANCEL", "BYE", "UPDATE", "REFER", "NOTIFY", "REGISTER"} {
+	for _, m := range []string{"INVITE", "ACK", "CANCEL", "BYE", "UPDATE", "REFER", "NOTIFY", "OPTIONS", "REGISTER"} {
 		if !strings.Contains(val, m) {
 			t.Errorf("Allow header %q missing method %s", val, m)
 		}

--- a/internal/sip/engine_tls_test.go
+++ b/internal/sip/engine_tls_test.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"github.com/VoiceBlender/voiceblender/internal/codec"
+	"github.com/emiago/sipgo"
+	"github.com/emiago/sipgo/sip"
 )
 
 func writeSelfSignedCert(t *testing.T, dir string) (certPath, keyPath string) {
@@ -168,6 +170,71 @@ func TestEngine_Serve_AcceptsTLSHandshake(t *testing.T) {
 	}
 	if lastErr != nil {
 		t.Fatalf("TLS handshake never succeeded: %v", lastErr)
+	}
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Serve did not return after ctx cancel")
+	}
+}
+
+func TestEngine_OPTIONSReturnsOK(t *testing.T) {
+	udpPort := pickFreePort(t, "udp")
+	engine, err := NewEngine(EngineConfig{
+		BindIP:   "127.0.0.1",
+		BindPort: udpPort,
+		SIPHost:  "test-vb",
+		Codecs:   []codec.CodecType{codec.CodecPCMU},
+		Log:      slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- engine.Serve(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+
+	clientPort := pickFreePort(t, "udp")
+	ua, err := sipgo.NewUA(sipgo.WithUserAgent("options-test"))
+	if err != nil {
+		t.Fatalf("NewUA: %v", err)
+	}
+	cli, err := sipgo.NewClient(ua,
+		sipgo.WithClientHostname("127.0.0.1"),
+		sipgo.WithClientPort(clientPort),
+		sipgo.WithClientConnectionAddr(fmt.Sprintf("127.0.0.1:%d", clientPort)),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	target := sip.Uri{Scheme: "sip", Host: "127.0.0.1", Port: udpPort}
+	req := sip.NewRequest(sip.OPTIONS, target)
+	req.AppendHeader(&sip.ToHeader{Address: target})
+	fromHdr := &sip.FromHeader{Address: target, Params: sip.NewParams()}
+	fromHdr.Params.Add("tag", sip.GenerateTagN(8))
+	req.AppendHeader(fromHdr)
+	req.AppendHeader(sip.NewHeader("User-Agent", "options-test/1.0"))
+
+	reqCtx, reqCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer reqCancel()
+	resp, err := cli.Do(reqCtx, req)
+	if err != nil {
+		t.Fatalf("OPTIONS: %v", err)
+	}
+	if resp.StatusCode != sip.StatusOK {
+		t.Fatalf("OPTIONS status = %d, want 200", resp.StatusCode)
+	}
+	if allow := resp.GetHeader("Allow"); allow == nil || allow.Value() == "" {
+		t.Fatalf("OPTIONS response missing Allow header")
+	}
+	if server := resp.GetHeader("Server"); server == nil || server.Value() != "test-vb" {
+		t.Fatalf("OPTIONS Server = %v, want test-vb", server)
 	}
 
 	cancel()


### PR DESCRIPTION
## Summary
- Add OnOptions handler that responds 200 OK with Server and Allow headers.
- Kamailio dispatcher health checks send OPTIONS every 10s; sipgo default 405 marks the target inactive.
- Adds TestEngine_OPTIONSReturnsOK integration-style unit test over UDP.
