### PR TITLE
fix(sip): inbound SIP webhook signing when using global WEBHOOK_SECRET

### DIFF
--- a/internal/api/legs.go
+++ b/internal/api/legs.go
@@ -1069,6 +1069,9 @@ func (s *Server) HandleInboundCall(call *sipmod.InboundCall) {
 	if h := call.Request.GetHeader("X-Webhook-Secret"); h != nil {
 		webhookSecret = h.Value()
 	}
+	if webhookSecret == "" {
+		webhookSecret = s.Config.WebhookSecret
+	}
 	if webhookURL != "" {
 		s.Webhooks.SetLegWebhook(l.ID(), webhookURL, webhookSecret)
 	}

--- a/internal/api/whatsapp.go
+++ b/internal/api/whatsapp.go
@@ -116,6 +116,9 @@ func (s *Server) handleWhatsAppInbound(call *sipmod.InboundCall) {
 	if h := call.Request.GetHeader("X-Webhook-Secret"); h != nil {
 		webhookSecret = h.Value()
 	}
+	if webhookSecret == "" {
+		webhookSecret = s.Config.WebhookSecret
+	}
 	if webhookURL != "" {
 		s.Webhooks.SetLegWebhook(l.ID(), webhookURL, webhookSecret)
 	}


### PR DESCRIPTION
## Summary

Inbound SIP and WhatsApp calls register a per-leg webhook when `WEBHOOK_URL` is configured. The URL correctly falls back from `X-Webhook-URL` to the global `WEBHOOK_URL` env var, but the secret did not fall back to `WEBHOOK_SECRET` when `X-Webhook-Secret` was absent.

Because per-leg webhooks take precedence over the global webhook, events were delivered to the correct URL with an **empty secret**, so `X-Signature-256` was never set and receivers with HMAC verification enabled returned 401.

This adds the same fallback for `webhookSecret` that already exists for `webhookURL`.