### PR TITLE
test(sip): move OPTIONS test out of the TLS file and poll for readiness

### DIFF
--- a/internal/sip/engine_test.go
+++ b/internal/sip/engine_test.go
@@ -1,11 +1,16 @@
 package sip
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/VoiceBlender/voiceblender/internal/codec"
+	"github.com/emiago/sipgo"
 	"github.com/emiago/sipgo/sip"
 )
 
@@ -190,6 +195,92 @@ func TestEngine_AllowHeader(t *testing.T) {
 	// INVITE should always come first to match the conventional method ordering.
 	if !strings.HasPrefix(val, "INVITE") {
 		t.Errorf("Allow header %q does not start with INVITE", val)
+	}
+}
+
+// Kamailio's dispatcher probes targets with OPTIONS and only treats a 2xx as
+// healthy, so sipgo's default 405 would take the instance out of rotation.
+func TestEngine_OPTIONSReturnsOK(t *testing.T) {
+	udpPort := pickFreePort(t, "udp")
+	engine, err := NewEngine(EngineConfig{
+		BindIP:   "127.0.0.1",
+		BindPort: udpPort,
+		SIPHost:  "test-vb",
+		Codecs:   []codec.CodecType{codec.CodecPCMU},
+		Log:      slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- engine.Serve(ctx) }()
+
+	clientPort := pickFreePort(t, "udp")
+	ua, err := sipgo.NewUA(sipgo.WithUserAgent("options-test"))
+	if err != nil {
+		t.Fatalf("NewUA: %v", err)
+	}
+	defer ua.Close()
+	cli, err := sipgo.NewClient(ua,
+		sipgo.WithClientHostname("127.0.0.1"),
+		sipgo.WithClientPort(clientPort),
+		sipgo.WithClientConnectionAddr(fmt.Sprintf("127.0.0.1:%d", clientPort)),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	target := sip.Uri{Scheme: "sip", Host: "127.0.0.1", Port: udpPort}
+	newOptions := func() *sip.Request {
+		req := sip.NewRequest(sip.OPTIONS, target)
+		req.AppendHeader(&sip.ToHeader{Address: target})
+		fromHdr := &sip.FromHeader{Address: target, Params: sip.NewParams()}
+		fromHdr.Params.Add("tag", sip.GenerateTagN(8))
+		req.AppendHeader(fromHdr)
+		req.AppendHeader(sip.NewHeader("User-Agent", "options-test/1.0"))
+		return req
+	}
+
+	// Poll with real OPTIONS until the listener answers — Serve binds
+	// asynchronously, and a fixed sleep is a flake waiting to happen on a
+	// loaded CI box. Each attempt gets its own request: sipgo populates Via
+	// and Call-ID in place, so retrying one instance would reuse the branch.
+	var (
+		resp     *sip.Response
+		lastErr  error
+		deadline = time.Now().Add(3 * time.Second)
+	)
+	for time.Now().Before(deadline) {
+		reqCtx, reqCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		resp, lastErr = cli.Do(reqCtx, newOptions())
+		reqCancel()
+		if lastErr == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if lastErr != nil {
+		t.Fatalf("OPTIONS never answered: %v", lastErr)
+	}
+
+	if resp.StatusCode != sip.StatusOK {
+		t.Fatalf("OPTIONS status = %d, want 200", resp.StatusCode)
+	}
+	if allow := resp.GetHeader("Allow"); allow == nil || allow.Value() == "" {
+		t.Fatalf("OPTIONS response missing Allow header")
+	}
+	if server := resp.GetHeader("Server"); server == nil || server.Value() != "test-vb" {
+		t.Fatalf("OPTIONS Server = %v, want test-vb", server)
+	}
+
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Serve did not return after ctx cancel")
 	}
 }
 

--- a/internal/sip/engine_tls_test.go
+++ b/internal/sip/engine_tls_test.go
@@ -19,8 +19,6 @@ import (
 	"time"
 
 	"github.com/VoiceBlender/voiceblender/internal/codec"
-	"github.com/emiago/sipgo"
-	"github.com/emiago/sipgo/sip"
 )
 
 func writeSelfSignedCert(t *testing.T, dir string) (certPath, keyPath string) {
@@ -170,71 +168,6 @@ func TestEngine_Serve_AcceptsTLSHandshake(t *testing.T) {
 	}
 	if lastErr != nil {
 		t.Fatalf("TLS handshake never succeeded: %v", lastErr)
-	}
-
-	cancel()
-	select {
-	case <-errCh:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("Serve did not return after ctx cancel")
-	}
-}
-
-func TestEngine_OPTIONSReturnsOK(t *testing.T) {
-	udpPort := pickFreePort(t, "udp")
-	engine, err := NewEngine(EngineConfig{
-		BindIP:   "127.0.0.1",
-		BindPort: udpPort,
-		SIPHost:  "test-vb",
-		Codecs:   []codec.CodecType{codec.CodecPCMU},
-		Log:      slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
-	})
-	if err != nil {
-		t.Fatalf("NewEngine: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	errCh := make(chan error, 1)
-	go func() { errCh <- engine.Serve(ctx) }()
-	time.Sleep(100 * time.Millisecond)
-
-	clientPort := pickFreePort(t, "udp")
-	ua, err := sipgo.NewUA(sipgo.WithUserAgent("options-test"))
-	if err != nil {
-		t.Fatalf("NewUA: %v", err)
-	}
-	cli, err := sipgo.NewClient(ua,
-		sipgo.WithClientHostname("127.0.0.1"),
-		sipgo.WithClientPort(clientPort),
-		sipgo.WithClientConnectionAddr(fmt.Sprintf("127.0.0.1:%d", clientPort)),
-	)
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-
-	target := sip.Uri{Scheme: "sip", Host: "127.0.0.1", Port: udpPort}
-	req := sip.NewRequest(sip.OPTIONS, target)
-	req.AppendHeader(&sip.ToHeader{Address: target})
-	fromHdr := &sip.FromHeader{Address: target, Params: sip.NewParams()}
-	fromHdr.Params.Add("tag", sip.GenerateTagN(8))
-	req.AppendHeader(fromHdr)
-	req.AppendHeader(sip.NewHeader("User-Agent", "options-test/1.0"))
-
-	reqCtx, reqCancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer reqCancel()
-	resp, err := cli.Do(reqCtx, req)
-	if err != nil {
-		t.Fatalf("OPTIONS: %v", err)
-	}
-	if resp.StatusCode != sip.StatusOK {
-		t.Fatalf("OPTIONS status = %d, want 200", resp.StatusCode)
-	}
-	if allow := resp.GetHeader("Allow"); allow == nil || allow.Value() == "" {
-		t.Fatalf("OPTIONS response missing Allow header")
-	}
-	if server := resp.GetHeader("Server"); server == nil || server.Value() != "test-vb" {
-		t.Fatalf("OPTIONS Server = %v, want test-vb", server)
 	}
 
 	cancel()


### PR DESCRIPTION
    Follow-up cleanup to #94. Two test-hygiene fixes, no behaviour change:

    TestEngine_OPTIONSReturnsOK landed in engine_tls_test.go but exercises
    nothing TLS-related, so it moves next to TestEngine_AllowHeader — the
    assertion it complements. pickFreePort is package-scoped, so the move is
    free; engine_tls_test.go drops the sipgo imports it no longer needs.

    The test also waited for the listener with a fixed 100ms sleep, which is
    a flake on a loaded CI box. It now retries real OPTIONS requests against
    a 3s deadline, matching the poll-until-ready loop already used by
    TestEngine_Serve_AcceptsTLSHandshake. This is not theoretical: under
    -count=5 one run took 550ms to get its first answer, which the old sleep
    would have failed. Each attempt builds a fresh request because sipgo
    populates Via and Call-ID in place.