### PR TITLE
Watch a REFER-transferred leg's dialog so a remote BYE ends the leg

### DIFF
--- a/internal/api/transfer.go
+++ b/internal/api/transfer.go
@@ -315,6 +315,7 @@ func (s *Server) originateForRefer(referrer *leg.SIPLeg, target string, replaces
 
 	newLeg := leg.NewSIPOutboundPendingLeg(s.SIPEngine, nil, s.Log)
 	newLeg.SetJitterBuffer(s.Config.SIPJitterBufferMs, s.Config.SIPJitterBufferMaxMs)
+	s.setupLegEventForwarding(newLeg)
 	s.LegMgr.Add(newLeg)
 	s.Bus.Publish(events.LegRinging, &events.LegRingingData{
 		LegScope: events.LegScope{LegID: newLeg.ID(), AppID: newLeg.AppID()},
@@ -354,6 +355,14 @@ func (s *Server) originateForRefer(referrer *leg.SIPLeg, target string, replaces
 		return
 	}
 
+	// Wire session timer expiry to hangup + event.
+	newLeg.OnSessionExpired(func() {
+		if newLeg.State() != leg.StateHungUp {
+			s.cleanupLeg(newLeg)
+			s.publishDisconnect(newLeg, "session_expired")
+		}
+	})
+
 	s.Bus.Publish(events.LegConnected, &events.LegConnectedData{
 		LegScope: events.LegScope{LegID: newLeg.ID(), AppID: newLeg.AppID()},
 		LegType:  string(newLeg.Type()),
@@ -370,6 +379,28 @@ func (s *Server) originateForRefer(referrer *leg.SIPLeg, target string, replaces
 
 	s.cleanupLeg(referrer)
 	s.publishDisconnect(referrer, "transfer_completed")
+
+	// The referrer is gone, so nothing else observes the transferred leg's
+	// dialog: the engine's BYE handling publishes no event of its own.
+	s.watchLegDialogEnd(newLeg, call.Dialog.Context())
+}
+
+// watchLegDialogEnd blocks until the leg's dialog ends, then disconnects the
+// leg unless it was already torn down locally. It also returns when the leg's
+// own context is cancelled: a local teardown (an API hangup, or a room delete)
+// hangs the leg up and cancels its context, but our BYE to a vanished peer may
+// never get the 200 that ends the sipgo dialog, so waiting on the dialog alone
+// would block for the process lifetime. The local teardown already published
+// the disconnect, so the state guard skips a second one.
+func (s *Server) watchLegDialogEnd(l *leg.SIPLeg, dialogCtx context.Context) {
+	select {
+	case <-dialogCtx.Done():
+	case <-l.Context().Done():
+	}
+	if l.State() != leg.StateHungUp {
+		s.cleanupLeg(l)
+		s.publishDisconnect(l, "remote_bye")
+	}
 }
 
 func (s *Server) notifyAndFail(referrer *leg.SIPLeg, statusCode int, reason string) {

--- a/internal/api/transfer_watch_test.go
+++ b/internal/api/transfer_watch_test.go
@@ -1,0 +1,191 @@
+package api
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+	"github.com/VoiceBlender/voiceblender/internal/leg"
+	sipmod "github.com/VoiceBlender/voiceblender/internal/sip"
+)
+
+// referTestEngine builds a bound SIP engine for tests that need to construct a
+// real SIPLeg. newTestServer passes nil for the engine, and the outbound-leg
+// constructor dereferences it.
+func referTestEngine(t *testing.T) *sipmod.Engine {
+	t.Helper()
+	eng, err := sipmod.NewEngine(sipmod.EngineConfig{
+		BindIP:   "127.0.0.1",
+		BindPort: 5060,
+		Log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return eng
+}
+
+// TestWatchLegDialogEndDisconnectsOnRemoteBye pins the monitor a
+// REFER-originated leg depends on. Once the transfer completes the referrer is
+// torn down and nothing else observes the transferred leg's dialog: the engine
+// only drops the dialog from its cache on BYE, so without this monitor the
+// remote's BYE produces no leg.disconnected at all and the leg stays in the
+// manager for the process lifetime.
+func TestWatchLegDialogEndDisconnectsOnRemoteBye(t *testing.T) {
+	s := newTestServer(t)
+	s.SIPEngine = referTestEngine(t)
+
+	l := leg.NewSIPOutboundPendingLeg(s.SIPEngine, nil, s.Log)
+	s.LegMgr.Add(l)
+
+	got := make(chan events.Event, 4)
+	unsub := s.Bus.Subscribe(func(e events.Event) {
+		if e.Type == events.LegDisconnected {
+			got <- e
+		}
+	})
+	t.Cleanup(unsub)
+
+	// The dialog context is what sipgo cancels when the remote sends BYE.
+	dialogCtx, remoteBye := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.watchLegDialogEnd(l, dialogCtx)
+	}()
+
+	remoteBye()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchLegDialogEnd did not return after the dialog ended")
+	}
+
+	select {
+	case e := <-got:
+		data, ok := e.Data.(*events.LegDisconnectedData)
+		if !ok {
+			t.Fatalf("leg.disconnected data = %T, want *events.LegDisconnectedData", e.Data)
+		}
+		if data.LegID != l.ID() {
+			t.Errorf("leg_id = %q, want %q", data.LegID, l.ID())
+		}
+		if data.CDR.Reason != "remote_bye" {
+			t.Errorf("cdr.reason = %q, want remote_bye", data.CDR.Reason)
+		}
+	default:
+		t.Fatal("no leg.disconnected published — a remote BYE on a transferred leg must end the leg")
+	}
+
+	if _, ok := s.LegMgr.Get(l.ID()); ok {
+		t.Error("leg still registered after remote BYE — cleanupLeg must remove it")
+	}
+}
+
+// TestWatchLegDialogEndExitsOnLocalTeardown pins the local-teardown exit. A leg
+// torn down through the API (or by the RTP-timeout hook) hangs up locally and
+// sends a BYE, but a vanished peer may never return the 200 that ends the
+// sipgo dialog — so the dialog context never fires. The monitor must still
+// exit off the leg's own cancelled context, and must not publish a second,
+// contradictory disconnect on top of the one the local teardown already
+// claimed. With the dialog context wired as the only wake-up, the monitor
+// blocks for the process lifetime and this test fails.
+func TestWatchLegDialogEndExitsOnLocalTeardown(t *testing.T) {
+	s := newTestServer(t)
+	s.SIPEngine = referTestEngine(t)
+
+	l := leg.NewSIPOutboundPendingLeg(s.SIPEngine, nil, s.Log)
+	s.LegMgr.Add(l)
+
+	// Local teardown wins first, exactly as DELETE /legs/{id} would: cleanupLeg
+	// hangs the leg up (cancelling its context) and publishDisconnect claims
+	// the sole disconnect.
+	s.cleanupLeg(l)
+	s.publishDisconnect(l, "api_hangup")
+
+	var extra int
+	unsub := s.Bus.Subscribe(func(e events.Event) {
+		if e.Type == events.LegDisconnected {
+			extra++
+		}
+	})
+	t.Cleanup(unsub)
+
+	// The peer never answers our BYE, so the dialog context never ends.
+	dialogCtx := context.Background()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.watchLegDialogEnd(l, dialogCtx)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchLegDialogEnd did not exit after local teardown — it leaks when the peer never answers the BYE")
+	}
+
+	if extra != 0 {
+		t.Errorf("watchLegDialogEnd published %d extra leg.disconnected events, want 0", extra)
+	}
+}
+
+// TestOriginateForReferWatchesDialogAfterConnect covers the wiring the unit
+// tests above cannot reach: that originateForRefer actually installs the
+// monitor, and that it does so only after leg.connected is published. Driving
+// the real SIP INVITE would need a live peer, so the sequence is asserted on
+// the source of originateForRefer instead — a call to watchLegDialogEnd must
+// be present, must follow the LegConnected publish, and must not be spawned in
+// a goroutine (which would let leg.disconnected race ahead of leg.connected for
+// a call that ends immediately).
+func TestOriginateForReferWatchesDialogAfterConnect(t *testing.T) {
+	body := funcBody(t, "transfer.go", "originateForRefer")
+
+	watch := strings.Index(body, "s.watchLegDialogEnd(newLeg,")
+	if watch < 0 {
+		t.Fatal("originateForRefer does not call watchLegDialogEnd — a transferred leg is left unwatched, so a remote BYE publishes nothing and the leg leaks")
+	}
+
+	connected := strings.Index(body, "events.LegConnected")
+	if connected < 0 {
+		t.Fatal("originateForRefer no longer publishes events.LegConnected")
+	}
+	if watch < connected {
+		t.Error("watchLegDialogEnd is wired before leg.connected is published — leg.disconnected could be published first")
+	}
+
+	if strings.Contains(body, "go s.watchLegDialogEnd(") {
+		t.Error("watchLegDialogEnd is spawned in a goroutine — it must block in originateForRefer's own goroutine so leg.connected always precedes leg.disconnected")
+	}
+}
+
+// funcBody returns the source text of the named func's body in path, which is
+// relative to this package's directory.
+func funcBody(t *testing.T, path, name string) string {
+	t.Helper()
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	file, err := parser.ParseFile(token.NewFileSet(), path, src, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if ok && fn.Name.Name == name && fn.Body != nil {
+			return string(src[fn.Body.Pos()-1 : fn.Body.End()-1])
+		}
+	}
+	t.Fatalf("func %s not found in %s", name, path)
+	return ""
+}


### PR DESCRIPTION
`originateForRefer` is the third SIP-leg construction site, and the only one whose success path leaves the new leg unobserved.

The other two wire the leg up and then wait on its dialog; the REFER site does neither:

| construction site | event forwarding | dialog watch |
|---|---|---|
| `legs.go:795` — outbound API | `legs.go:808` | `legs.go:980` / `:993` |
| `legs.go:1048` — inbound | `legs.go:1116` | `legs.go:1134` / `:1141` |
| `transfer.go:316` — REFER | — | — |

Once the transfer completes the referrer is torn down (`transfer.go:371-372`), so nothing else is holding the transferred leg. The engine's BYE handler (`internal/sip/engine.go:840`) only reads the request into the dialog cache and replies 481 when nothing matches — it publishes no event of its own. So when the remote hangs up a transferred call:

- **No `leg.disconnected` is published at all**, on the webhook surface or the VSI socket, so that call's CDR never arrives.
- **The leg stays in `LegMgr` for the process lifetime.** The four non-test `LegMgr.Remove` sites are `inbound_auth.go:103`, `cleanupLeg` (`legs.go:631`), `DELETE /legs/{id}` (`legs.go:684`), and the answer-failure path (`legs.go:1111`) — none can fire for this leg once the referrer is gone, and there is no sweep to catch it.
- **The RTP-timeout teardown is never wired** (`setupLegEventForwarding` also carries DTMF and RTT forwarding), so a transferred leg that simply goes silent is not reaped either.

## The change

Wire the leg like the other two sites do — `setupLegEventForwarding` plus `OnSessionExpired` — then block on `watchLegDialogEnd` at the tail of `originateForRefer`, which already runs in its own goroutine.

Blocking there rather than spawning the wait earlier is deliberate: it keeps `leg.connected` strictly ahead of `leg.disconnected` for a call that ends immediately, which is the ordering the other two sites get structurally.

`watchLegDialogEnd` selects on the leg's own context as well as the dialog context. sipgo's dialog context only cancels on `DialogStateEnded` — a remote BYE, or our BYE getting its 200 — so on a local teardown whose BYE goes to a peer that has vanished, the dialog alone never fires and the watcher would block for the process lifetime, one goroutine per such call. The `State() != StateHungUp` guard keeps the local teardown's disconnect the only one published.

## Tests

`internal/api/transfer_watch_test.go`:

- a remote BYE ends the leg with `cdr.reason=remote_bye` and removes it from `LegMgr`;
- a local teardown makes the watcher exit without publishing a second, contradictory disconnect;
- `originateForRefer` installs the watcher, after the `leg.connected` publish, and not in a goroutine — asserted against the function's source, since driving a real INVITE would need a live peer.

Both guards are mutation-tested rather than just observed green: removing the `watchLegDialogEnd` call, and removing the leg-context case from the select, each turn the corresponding test red with its own message.

`gofmt`, `go build ./...`, `CGO_ENABLED=0 go build ./...`, `go vet ./...` and `go test ./internal/...` are clean on this branch against `5b5e336`.
