### PR TITLE
Derive the outbound From identity from the registered trunk's AOR

### DIFF
--- a/API.md
+++ b/API.md
@@ -99,7 +99,7 @@ Originate an outbound SIP call.
 | `type` | string | yes | `"sip"`, `"whatsapp"` (see [WhatsApp Business Calling](#whatsapp-business-calling) below), `"websocket"` (see [WebSocket Legs](#websocket-legs)), or `"livekit_room"` (see [LiveKit Room Legs](#livekit-room-legs)) |
 | `to` | string | yes | Destination. For `sip` legs, a SIP URI (e.g. `"sip:alice@example.com"`). For `whatsapp` legs, an E.164 phone number (with or without `+`). |
 | `uri` | string | no | Deprecated alias for `to` (sip legs only). Kept for backward compat; prefer `to`. |
-| `from` | string | no | Caller ID — sets the user part of the SIP From header (e.g. `"+15551234567"`, `"alice"`) |
+| `from` | string | no | Caller ID. A bare user-part (e.g. `"+15551234567"`, `"alice"`) sets the user of the SIP From header. A full SIP URI (e.g. `"sip:alice@pbx.example.com"`) sets both the user and the host; otherwise the host comes from the matched trunk's AOR realm, falling back to `SIP_DOMAIN`. |
 | `privacy` | string | no | SIP Privacy header value (e.g. `"id"`, `"none"`) |
 | `ring_timeout` | integer | no | Seconds to wait for answer; 0 = no timeout |
 | `max_duration` | integer | no | Maximum call duration in seconds after connect. The call is automatically hung up when reached. 0 or omitted = no limit. |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All configuration is via environment variables:
 | `SIP_TLS_CERT` | | Path to PEM-encoded TLS certificate (e.g. `fullchain.pem`). Meta rejects self-signed certs — use a CA-signed cert matching a public FQDN. |
 | `SIP_TLS_KEY` | | Path to PEM-encoded TLS private key (e.g. `privkey.pem`). |
 | `SIP_DEBUG` | `false` | When `true`, log the full RFC 3261 wire form of every inbound and outbound SIP request and response. Very verbose — use only for troubleshooting. |
-| `SIP_DOMAIN` | *(falls back to advertised IP)* | FQDN advertised in From, Contact and Via on **all** outbound SIP signalling (classic trunks and WhatsApp). Should match the SAN on `SIP_TLS_CERT` and any allowlist your carrier or Meta keeps. |
+| `SIP_DOMAIN` | *(falls back to advertised IP)* | FQDN advertised in From, Contact and Via on outbound SIP signalling (classic trunks and WhatsApp). Two exceptions apply to the From host only: a call matched to a registered SIP trunk uses that trunk's AOR realm, and a `from` given as a full SIP URI uses the host in that URI. Should match the SAN on `SIP_TLS_CERT` and any allowlist your carrier or Meta keeps. |
 | `SIP_HOST` | `voiceblender` | SIP User-Agent name |
 | `ICE_SERVERS` | `stun:stun.l.google.com:19302` | STUN/TURN URLs (comma-separated) |
 | `WEBRTC_EXTERNAL_IPS` | *(empty)* | Comma-separated public IPs advertised as host ICE candidates (pion `SetNAT1To1IPs`). Set this when VoiceBlender runs behind NAT/Docker and the gathered host interface IPs aren't routable from the remote peer — otherwise WebRTC peers behind firewalls won't be able to reach VB. Supports IPv4 and IPv6 literals. The literal value `auto` performs STUN-based public-IP discovery at startup against the first reachable `ICE_SERVERS` entry; discovery failure is non-fatal and logs a warning. |
@@ -314,6 +314,23 @@ DELETE /v1/sip/trunks/{id}                 # Unregister + remove (202 Accepted, 
 Outbound calls placed with `POST /v1/legs` whose `from` matches a registered
 trunk's AOR (or AOR user-part) automatically attach the trunk's digest
 credentials and traverse the trunk's upstream proxy via a Route header.
+Such calls also send `From` and `P-Asserted-Identity` in the trunk's AOR realm
+rather than `SIP_DOMAIN`, so the call claims the identity the registrar
+actually authenticated. An AOR port, if configured, is not carried into the
+From — `sip:alice@pbx.example.com:5070` yields a From host of
+`pbx.example.com`.
+
+> **Changed outcome.** This can flip how an upstream responds to calls that
+> previously went out under `SIP_DOMAIN`. A registrar that accepted them
+> un-challenged may now challenge them — which resolves on its own for a
+> correctly provisioned trunk, since the digest credentials are already
+> attached, but surfaces as a `401`/`407` failure for one with stale
+> credentials. It can flip the other way too: a registrar that rejected an
+> unknown From domain may now accept the call. There is no toggle. The only
+> way to keep `SIP_DOMAIN` on the From is to use a `from` that matches no
+> trunk AOR and no trunk AOR user-part, which also drops the trunk's
+> credentials and Route.
+
 Inbound INVITEs arriving from a registered trunk's registrar are tagged with
 `trunk_id` on the `leg.ringing` event.
 

--- a/internal/api/from_identity_test.go
+++ b/internal/api/from_identity_test.go
@@ -1,0 +1,48 @@
+package api
+
+import "testing"
+
+// TestSplitFromIdentity pins how a POST /v1/legs `from` value is split into the
+// user and host parts of the outbound From URI.
+//
+// Every expected value below was produced by running sip.ParseUri from the
+// pinned github.com/emiago/sipgo release against that exact input.
+func TestSplitFromIdentity(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantUser string
+		wantHost string
+	}{
+		// A full SIP URI is split. Before this existed the whole string
+		// landed in the user-part and produced a From with two '@'.
+		{"full uri", "sip:alice@pbx.example.com", "alice", "pbx.example.com"},
+		{"bare user", "alice", "alice", ""},
+		{"e164", "+15551234567", "+15551234567", ""},
+		{"empty", "", "", ""},
+		// Port and URI params are deliberately discarded — a From URI
+		// should carry neither.
+		{"sips with port", "sips:bob@tls.example.com:5061", "bob", "tls.example.com"},
+		{"uri params", "sip:alice@pbx.example.com;transport=tcp", "alice", "pbx.example.com"},
+		// sipgo parses tel: as host-only (user is empty), so this falls
+		// through to the raw-value behaviour rather than becoming a
+		// host-only From. This row is what makes the `u.User != ""`
+		// conjunct of the accept condition load-bearing.
+		{"tel uri", "tel:+15551234567", "tel:+15551234567", ""},
+		// sipgo parses "sip:alice@" as user with an EMPTY host — the only
+		// shape where the parse succeeds and the user is set but the host
+		// is not. This row is what makes the `u.Host != ""` conjunct
+		// load-bearing; without it the From would silently lose its host.
+		{"user with no host", "sip:alice@", "sip:alice@", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			user, host := splitFromIdentity(tc.in)
+			if user != tc.wantUser || host != tc.wantHost {
+				t.Errorf("splitFromIdentity(%q) = (%q, %q), want (%q, %q)",
+					tc.in, user, host, tc.wantUser, tc.wantHost)
+			}
+		})
+	}
+}

--- a/internal/api/legs.go
+++ b/internal/api/legs.go
@@ -760,6 +760,29 @@ func (s *Server) createSIPOutboundLeg(w http.ResponseWriter, r *http.Request, re
 	writeJSON(w, http.StatusCreated, view)
 }
 
+// splitFromIdentity splits a POST /v1/legs `from` value into the user and host
+// parts of the outbound From URI.
+//
+// A full SIP URI ("sip:alice@pbx.example.com") yields both parts. Anything else
+// ("alice", "+15551234567", "tel:+15551234567") yields the raw value as the
+// user with an empty host, leaving the host to the matched trunk's AOR realm or
+// the engine's public host.
+//
+// The accept condition deliberately mirrors the trunk-matching parse below, so
+// the identity split and the trunk lookup can never disagree about what counts
+// as a full URI. Port and URI params are discarded on purpose: a From URI
+// should carry neither.
+func splitFromIdentity(from string) (user, host string) {
+	if from == "" {
+		return "", ""
+	}
+	u := sip.Uri{}
+	if err := sip.ParseUri(from, &u); err == nil && u.User != "" && u.Host != "" {
+		return u.User, u.Host
+	}
+	return from, ""
+}
+
 // doCreateSIPOutboundLeg performs the synchronous validation + leg setup for an
 // outbound SIP originate and kicks off the async INVITE, returning the leg view.
 // Shared by the REST handler and the VSI create_leg dispatch.
@@ -837,7 +860,8 @@ func (s *Server) doCreateSIPOutboundLeg(req CreateLegRequest) (LegView, error) {
 	}
 
 	// Build invite options.
-	inviteOpts := sipmod.InviteOptions{Codecs: codecs, FromUser: req.From}
+	fromUser, fromHost := splitFromIdentity(req.From)
+	inviteOpts := sipmod.InviteOptions{Codecs: codecs, FromUser: fromUser, FromHost: fromHost}
 	if req.Auth != nil {
 		inviteOpts.AuthUsername = req.Auth.Username
 		inviteOpts.AuthPassword = req.Auth.Password
@@ -848,7 +872,8 @@ func (s *Server) doCreateSIPOutboundLeg(req CreateLegRequest) (LegView, error) {
 
 	// Implicit trunk match: if `from` matches a registered outbound trunk's
 	// AOR (either as a full URI or just a user-part), auto-attach digest
-	// credentials and route the INVITE through the trunk's upstream proxy.
+	// credentials, route the INVITE through the trunk's upstream proxy, and
+	// place the From / P-Asserted-Identity in the trunk's AOR realm.
 	// Caller-supplied auth wins.
 	var trunkIDForLeg string
 	var matchedTrunk sipmod.Trunk
@@ -871,6 +896,11 @@ func (s *Server) doCreateSIPOutboundLeg(req CreateLegRequest) (LegView, error) {
 			}
 			regURI := reg.RegistrarURI()
 			inviteOpts.RouteURI = &regURI
+			// The registrar authenticated us under the AOR realm; claim that
+			// identity on the wire unless the caller named a host explicitly.
+			if inviteOpts.FromHost == "" {
+				inviteOpts.FromHost = reg.FromHost()
+			}
 		}
 	}
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -25,7 +25,7 @@ type CreateLegRequest struct {
 	Type            string            `json:"type"`                       // "sip", "whatsapp", or "websocket"
 	To              string            `json:"to,omitempty"`               // destination — SIP URI for sip legs, E.164 phone number for whatsapp legs
 	URI             string            `json:"uri,omitempty"`              // deprecated alias for `to` (sip legs only)
-	From            string            `json:"from,omitempty"`             // caller ID (user part of the SIP From header, e.g. "+15551234567")
+	From            string            `json:"from,omitempty"`             // caller ID — a bare user-part ("+15551234567") or a full SIP URI ("sip:alice@pbx.example.com")
 	Privacy         string            `json:"privacy,omitempty"`          // SIP Privacy header value (e.g. "id", "none")
 	RingTimeout     int               `json:"ring_timeout,omitempty"`     // seconds; 0 = no timeout
 	MaxDuration     int               `json:"max_duration,omitempty"`     // seconds; 0 = no limit
@@ -79,7 +79,7 @@ var createLegRequestFields = map[string]FieldEnrichment{
 	"type":             {Description: "Leg type", Enum: []string{"sip", "whatsapp", "websocket", "livekit_room"}},
 	"to":               {Description: "Destination. For sip legs, a SIP URI (e.g. \"sip:alice@example.com\"). For whatsapp legs, an E.164 phone number (with or without '+')."},
 	"uri":              {Description: "Deprecated alias for `to` (sip legs only). Prefer `to`."},
-	"from":             {Description: `Caller ID — sets the user part of the SIP From header (e.g. "+15551234567", "alice")`},
+	"from":             {Description: `Caller ID. A bare user-part (e.g. "+15551234567", "alice") sets the user of the SIP From header. A full SIP URI (e.g. "sip:alice@pbx.example.com") sets both the user and the host; otherwise the host comes from the matched trunk's AOR realm, falling back to SIP_DOMAIN.`},
 	"privacy":          {Description: `SIP Privacy header value (e.g. "id", "none")`},
 	"ring_timeout":     {Description: "Seconds to wait for answer; 0 = no timeout", Default: 0},
 	"max_duration":     {Description: "Maximum call duration in seconds after connect. Automatically hung up when reached. 0 or omitted = no limit.", Default: 0},
@@ -595,7 +595,7 @@ type SIPRegisterTrunkSpec struct {
 
 var sipRegisterTrunkSpecFields = map[string]FieldEnrichment{
 	"registrar_uri":   {Description: "Upstream registrar SIP URI (e.g. \"sip:pbx.example.com:5060\" or \"sips:pbx.example.com:5061;transport=tls\")."},
-	"aor":             {Description: "Address-of-record this trunk REGISTERs (e.g. \"sip:alice@pbx.example.com\"). Becomes the From URI for inbound REGISTER and outbound calls placed `from` this AOR."},
+	"aor":             {Description: "Address-of-record this trunk REGISTERs (e.g. \"sip:alice@pbx.example.com\"). Becomes the From URI on outbound REGISTER, and the From / P-Asserted-Identity host on outbound INVITEs placed `from` this AOR."},
 	"username":        {Description: "Digest auth username. Defaults to the AOR user-part when empty."},
 	"password":        {Description: "Digest auth password. Required. Never returned in any response."},
 	"contact_user":    {Description: "Override the user-part of the Contact header sent in REGISTER. Defaults to the AOR user-part."},

--- a/internal/sip/engine.go
+++ b/internal/sip/engine.go
@@ -1077,6 +1077,7 @@ type InviteOptions struct {
 	Codecs       []codec.CodecType                              // Override engine codecs for this call; nil = use engine default
 	Headers      []sip.Header                                   // Extra SIP headers to include in the INVITE
 	FromUser     string                                         // Override the user part of the From header (caller ID)
+	FromHost     string                                         // Override the host part of the From/P-Asserted-Identity URI (e.g. a registered trunk's AOR realm); empty = engine publicHost
 	OnEarlyMedia func(remoteSDP *SDPMedia, rtpSess *RTPSession) // Called on first 183 with SDP
 	AuthUsername string                                         // SIP digest auth username (optional)
 	AuthPassword string                                         // SIP digest auth password (optional)
@@ -1097,6 +1098,33 @@ type InviteOptions struct {
 	// (0 = plain T.140, no RED).
 	RTTEnabled    bool
 	RTTRedundancy int
+}
+
+// fromIdentity builds the From header and the matching P-Asserted-Identity
+// header for an outbound INVITE. The host part comes from opts.FromHost,
+// falling back to the engine's publicHost when that is empty.
+//
+// Returns (nil, nil) when no caller ID was supplied, so the request goes out
+// with no explicit From and sipgo synthesizes one (a tagged From derived from
+// the client hostname). sipgo only fills in a From when the request has none —
+// it never rewrites one we supplied — so callers that do set FromUser keep
+// full control of both headers.
+//
+// P-Asserted-Identity is derived from the same URI as From by construction,
+// which is what keeps the asserted identity and the signalled identity in
+// lock-step (RFC 3325).
+func (e *Engine) fromIdentity(opts InviteOptions) (*sip.FromHeader, sip.Header) {
+	if opts.FromUser == "" {
+		return nil, nil
+	}
+	host := opts.FromHost
+	if host == "" {
+		host = e.publicHost
+	}
+	fromURI := sip.Uri{Scheme: "sip", User: opts.FromUser, Host: host}
+	from := &sip.FromHeader{Address: fromURI}
+	from.Params.Add("tag", sip.GenerateTagN(16))
+	return from, sip.NewHeader("P-Asserted-Identity", fromURI.String())
 }
 
 // Invite sends an outbound INVITE and returns an OutboundCall on success.
@@ -1176,16 +1204,9 @@ func (e *Engine) Invite(ctx context.Context, recipient sip.Uri, opts InviteOptio
 	req.AppendHeader(e.AllowHeader())
 	req.AppendHeader(e.UserAgentHeader())
 
-	if opts.FromUser != "" {
-		fromURI := sip.Uri{
-			Scheme: "sip",
-			User:   opts.FromUser,
-			Host:   e.publicHost,
-		}
-		from := &sip.FromHeader{Address: fromURI}
-		from.Params.Add("tag", sip.GenerateTagN(16))
+	if from, pai := e.fromIdentity(opts); from != nil {
 		req.AppendHeader(from)
-		req.AppendHeader(sip.NewHeader("P-Asserted-Identity", fromURI.String()))
+		req.AppendHeader(pai)
 	}
 
 	for _, h := range opts.Headers {

--- a/internal/sip/engine_fork.go
+++ b/internal/sip/engine_fork.go
@@ -80,12 +80,10 @@ func (e *Engine) inviteFork(ctx context.Context, recipient sip.Uri, opts InviteO
 		req.AppendHeader(e.AllowHeader())
 		toURI := recipient
 		req.AppendHeader(&sip.ToHeader{Address: toURI})
-		if opts.FromUser != "" {
-			fromURI := sip.Uri{Scheme: "sip", User: opts.FromUser, Host: e.publicHost}
-			from := &sip.FromHeader{Address: fromURI}
-			from.Params.Add("tag", sip.GenerateTagN(16))
+		// Called per branch, so each forked INVITE gets its own From tag.
+		if from, pai := e.fromIdentity(opts); from != nil {
 			req.AppendHeader(from)
-			req.AppendHeader(sip.NewHeader("P-Asserted-Identity", fromURI.String()))
+			req.AppendHeader(pai)
 		}
 		for _, h := range opts.Headers {
 			req.AppendHeader(h)

--- a/internal/sip/engine_from_identity_test.go
+++ b/internal/sip/engine_from_identity_test.go
@@ -1,0 +1,66 @@
+package sip
+
+import (
+	"testing"
+)
+
+// engineFromIdentityPublicHost is deliberately different from every FromHost
+// used below, so an implementation that ignores InviteOptions.FromHost and
+// always reaches for the engine's publicHost cannot pass by coincidence.
+const engineFromIdentityPublicHost = "vb.public.example"
+
+func TestEngineFromIdentity(t *testing.T) {
+	e := &Engine{publicHost: engineFromIdentityPublicHost}
+
+	t.Run("no caller id", func(t *testing.T) {
+		from, pai := e.fromIdentity(InviteOptions{})
+		if from != nil || pai != nil {
+			t.Fatalf("want (nil, nil) with no FromUser, got from=%v pai=%v", from, pai)
+		}
+	})
+
+	t.Run("default host", func(t *testing.T) {
+		from, _ := e.fromIdentity(InviteOptions{FromUser: "alice"})
+		if from == nil {
+			t.Fatal("want a From header, got nil")
+		}
+		if got := from.Address.Host; got != engineFromIdentityPublicHost {
+			t.Errorf("From host = %q, want the engine publicHost %q", got, engineFromIdentityPublicHost)
+		}
+		if got := from.Address.User; got != "alice" {
+			t.Errorf("From user = %q, want %q", got, "alice")
+		}
+	})
+
+	t.Run("explicit host", func(t *testing.T) {
+		from, _ := e.fromIdentity(InviteOptions{FromUser: "alice", FromHost: "pbx.example.com"})
+		if from == nil {
+			t.Fatal("want a From header, got nil")
+		}
+		if got := from.Address.Host; got != "pbx.example.com" {
+			t.Errorf("From host = %q, want the FromHost override %q", got, "pbx.example.com")
+		}
+	})
+
+	t.Run("pai tracks from", func(t *testing.T) {
+		from, pai := e.fromIdentity(InviteOptions{FromUser: "alice", FromHost: "pbx.example.com"})
+		if from == nil || pai == nil {
+			t.Fatal("want both headers, got nil")
+		}
+		const want = "sip:alice@pbx.example.com"
+		if got := pai.Value(); got != want {
+			t.Errorf("P-Asserted-Identity = %q, want %q (must track the From URI)", got, want)
+		}
+	})
+
+	t.Run("from tag present", func(t *testing.T) {
+		from, _ := e.fromIdentity(InviteOptions{FromUser: "alice", FromHost: "pbx.example.com"})
+		if from == nil {
+			t.Fatal("want a From header, got nil")
+		}
+		tag, ok := from.Params.Get("tag")
+		if !ok || tag == "" {
+			t.Errorf("From tag = %q (present=%v), want a non-empty tag", tag, ok)
+		}
+	})
+}

--- a/internal/sip/outbound_registration.go
+++ b/internal/sip/outbound_registration.go
@@ -195,6 +195,16 @@ func (r *OutboundRegistration) PeerSocket() (host string, port int, transport st
 // outbound INVITE path to attach a Route header.
 func (r *OutboundRegistration) RegistrarURI() sip.Uri { return r.registrarURI }
 
+// FromHost returns the AOR realm host — the domain the upstream registrar
+// authenticated us under. Used as the host part of the From and
+// P-Asserted-Identity URIs on outbound INVITEs placed from this trunk, so the
+// call claims the identity the trunk actually registered rather than the
+// engine's own public host.
+//
+// No lock: r.aor is assigned once in the constructor and never mutated, the
+// same reason AOR() reads it lock-free.
+func (r *OutboundRegistration) FromHost() string { return r.aor.Host }
+
 // Credentials returns the trunk's digest username/password. Used by the
 // outbound INVITE path; never exposed over the API.
 func (r *OutboundRegistration) Credentials() (string, string) {

--- a/internal/sip/outbound_registration_test.go
+++ b/internal/sip/outbound_registration_test.go
@@ -29,6 +29,24 @@ func TestParseGrantedExpires_FallsBackToRequested(t *testing.T) {
 	}
 }
 
+// TestOutboundRegistration_FromHost pins FromHost to the AOR realm.
+//
+// The registrar host and the AOR host are deliberately DIFFERENT strings. The
+// struct holds both registrarURI and aor, so a getter that reached for the
+// wrong one would still look plausible; only a differing registrar host makes
+// that substitution observable.
+func TestOutboundRegistration_FromHost(t *testing.T) {
+	r := NewOutboundRegistration(nil, nil, nil, OutboundRegistrationConfig{}, OutboundRegistrationParams{
+		ID:           "t1",
+		RegistrarURI: sip.Uri{Scheme: "sip", Host: "sbc.carrier.net", Port: 5060},
+		AOR:          sip.Uri{Scheme: "sip", User: "alice", Host: "pbx.example.com"},
+		Password:     "x",
+	})
+	if got := r.FromHost(); got != "pbx.example.com" {
+		t.Errorf("FromHost() = %q, want the AOR realm %q (not the registrar host)", got, "pbx.example.com")
+	}
+}
+
 func TestOutboundRegistrationConfig_DefaultsApplied(t *testing.T) {
 	c := OutboundRegistrationConfig{}.withDefaults()
 	if c.DefaultExpiresSeconds != 3600 {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3089,7 +3089,7 @@ components:
                     description: Deprecated alias for `to` (sip legs only). Prefer `to`.
                 from:
                     type: string
-                    description: Caller ID — sets the user part of the SIP From header (e.g. "+15551234567", "alice")
+                    description: Caller ID. A bare user-part (e.g. "+15551234567", "alice") sets the user of the SIP From header. A full SIP URI (e.g. "sip:alice@pbx.example.com") sets both the user and the host; otherwise the host comes from the matched trunk's AOR realm, falling back to SIP_DOMAIN.
                 privacy:
                     type: string
                     description: SIP Privacy header value (e.g. "id", "none")
@@ -3836,7 +3836,7 @@ components:
                     description: Upstream registrar SIP URI (e.g. "sip:pbx.example.com:5060" or "sips:pbx.example.com:5061;transport=tls").
                 aor:
                     type: string
-                    description: Address-of-record this trunk REGISTERs (e.g. "sip:alice@pbx.example.com"). Becomes the From URI for inbound REGISTER and outbound calls placed `from` this AOR.
+                    description: Address-of-record this trunk REGISTERs (e.g. "sip:alice@pbx.example.com"). Becomes the From URI on outbound REGISTER, and the From / P-Asserted-Identity host on outbound INVITEs placed `from` this AOR.
                 username:
                     type: string
                     description: Digest auth username. Defaults to the AOR user-part when empty.

--- a/tests/integration/sip_trunks_test.go
+++ b/tests/integration/sip_trunks_test.go
@@ -429,8 +429,18 @@ func TestTrunk_SIPRegister_Unregister(t *testing.T) {
 	}
 }
 
-func TestTrunk_SIPRegister_OutboundCallUsesTrunk(t *testing.T) {
-	inst := newTestInstance(t, "trunk-out")
+// originateOverRegisteredTrunk brings up a sip_register trunk with AOR
+// sip:alice@vb.test, originates one outbound leg with the given `from`, and
+// returns the INVITE the fake registrar received.
+//
+// The AOR host "vb.test" is deliberately not the engine's public host: the
+// harness builds its engine from a literal EngineConfig with BindIP
+// "127.0.0.1" and no PublicHost (call_test.go), so publicHost resolves to
+// "127.0.0.1". Any assertion below that finds "vb.test" therefore proves the
+// host came from the trunk and not from the engine.
+func originateOverRegisteredTrunk(t *testing.T, name, from string) *sip.Request {
+	t.Helper()
+	inst := newTestInstance(t, name)
 	reg := newRawSIPRegistrar(t, rawRegistrarOpts{grantExpires: 600})
 
 	createResp, body := createTrunkRequest(t, inst.baseURL(), map[string]interface{}{
@@ -450,12 +460,12 @@ func TestTrunk_SIPRegister_OutboundCallUsesTrunk(t *testing.T) {
 	id, _ := created["id"].(string)
 	waitForTrunkStatus(t, inst.baseURL(), id, "active", 3*time.Second)
 
-	// Originate a leg with from=alice@vb.test — should auto-attach
-	// the trunk's auth and Route header.
+	// Originating with a `from` that matches the trunk should auto-attach the
+	// trunk's auth, Route header, and From identity.
 	createLegResp := httpPost(t, inst.baseURL()+"/v1/legs", map[string]interface{}{
 		"type":   "sip",
 		"to":     fmt.Sprintf("sip:bob@127.0.0.1:%d", reg.port),
-		"from":   "alice",
+		"from":   from,
 		"codecs": []string{"PCMU"},
 	})
 	if createLegResp.StatusCode != http.StatusCreated && createLegResp.StatusCode != http.StatusAccepted {
@@ -464,8 +474,7 @@ func TestTrunk_SIPRegister_OutboundCallUsesTrunk(t *testing.T) {
 	createLegResp.Body.Close()
 
 	// The fake registrar should receive the INVITE; it returns 503 to keep
-	// the test quick, but we just need to verify the request hit and carried
-	// the Route header.
+	// the test quick, but we just need the request itself.
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		reg.mu.Lock()
@@ -481,10 +490,69 @@ func TestTrunk_SIPRegister_OutboundCallUsesTrunk(t *testing.T) {
 	if len(reg.receivedInvites) == 0 {
 		t.Fatal("fake registrar did not receive INVITE — trunk wiring not applied")
 	}
-	inv := reg.receivedInvites[0]
+	return reg.receivedInvites[0]
+}
+
+// assertInviteFromIdentity checks the From and P-Asserted-Identity of a
+// received INVITE. From() returns nil when the header failed to parse — which
+// is exactly what a malformed two-'@' From produces — so guard before
+// dereferencing to get a diagnosable failure instead of a panic.
+func assertInviteFromIdentity(t *testing.T, inv *sip.Request, wantUser, wantHost string) {
+	t.Helper()
+	f := inv.From()
+	if f == nil {
+		t.Fatalf("INVITE has no parseable From header; raw request:\n%s", inv.String())
+	}
+	if f.Address.User != wantUser {
+		t.Errorf("From user = %q, want %q", f.Address.User, wantUser)
+	}
+	if f.Address.Host != wantHost {
+		t.Errorf("From host = %q, want %q", f.Address.Host, wantHost)
+	}
+	pai := inv.GetHeader("P-Asserted-Identity")
+	if pai == nil {
+		t.Fatal("INVITE missing P-Asserted-Identity")
+	}
+	want := "sip:" + wantUser + "@" + wantHost
+	if pai.Value() != want {
+		t.Errorf("P-Asserted-Identity = %q, want %q", pai.Value(), want)
+	}
+}
+
+func TestTrunk_SIPRegister_OutboundCallUsesTrunk(t *testing.T) {
+	inv := originateOverRegisteredTrunk(t, "trunk-out", "alice")
 	if route := inv.GetHeader("Route"); route == nil {
 		t.Error("INVITE missing Route header (trunk routing not wired)")
 	}
+	// A bare `from` carries no host, so the trunk's AOR realm supplies one.
+	assertInviteFromIdentity(t, inv, "alice", "vb.test")
+}
+
+// TestTrunk_SIPRegister_OutboundCallFromFullURI covers `from` given as a full
+// SIP URI. Before the identity split, the whole URI landed in the user part and
+// the peer received From: <sip:sip:alice@vb.test@vb.test> — two '@' and an
+// embedded scheme.
+func TestTrunk_SIPRegister_OutboundCallFromFullURI(t *testing.T) {
+	inv := originateOverRegisteredTrunk(t, "trunk-out-uri", "sip:alice@vb.test")
+	if route := inv.GetHeader("Route"); route == nil {
+		t.Error("INVITE missing Route header (full-URI `from` broke trunk matching)")
+	}
+	assertInviteFromIdentity(t, inv, "alice", "vb.test")
+}
+
+// TestTrunk_SIPRegister_OutboundCallFromHostWins covers the precedence guard:
+// a caller-supplied host is not overwritten by the trunk's AOR realm.
+//
+// A case-differing host is the only input that reaches the guard's false
+// branch — trunk lookup canonicalizes the AOR (which lowercases the host)
+// while the identity split preserves the caller's spelling verbatim. SIP hosts
+// are case-insensitive, so this is about precedence, not about the wire.
+func TestTrunk_SIPRegister_OutboundCallFromHostWins(t *testing.T) {
+	inv := originateOverRegisteredTrunk(t, "trunk-out-case", "sip:alice@VB.TEST")
+	if route := inv.GetHeader("Route"); route == nil {
+		t.Error("INVITE missing Route header (case-differing host broke trunk matching)")
+	}
+	assertInviteFromIdentity(t, inv, "alice", "VB.TEST")
 }
 
 func TestTrunk_SIPRegister_RefreshFailedEmitsExpired(t *testing.T) {


### PR DESCRIPTION
An outbound INVITE always builds its From URI against the engine's own public host, so a call placed through a registered trunk claims an identity the registrar never issued.

Both builders hard-code it — `internal/sip/engine.go` and `internal/sip/engine_fork.go` each construct `sip.Uri{Scheme: "sip", User: opts.FromUser, Host: e.publicHost}` inline and derive P-Asserted-Identity from the same value. There is no request field, header or config that can override it.

That matters more now that trunks can register. `POST /v1/legs` already matches an outbound registration, attaches its digest credentials and sets `RouteURI` — but the From domain still says `publicHost`. Carriers and PBXs routinely match or reject on the From domain, so those auto-attached credentials are presenting an identity that does not belong to the account they authenticate. Setting the From domain to the registered realm is the standard behaviour elsewhere (Asterisk `from_domain`, FreeSWITCH `from-domain`).

It also makes a documented contract true. `internal/api/types.go` says of a trunk's `aor` that it "Becomes the From URI for inbound REGISTER and outbound calls placed from this AOR". The REGISTER half was already true; the outbound-call half was not.

## The change

- `InviteOptions.FromHost` overrides the From host, falling back to `publicHost` when empty. The two inline builds collapse into one `Engine.fromIdentity` helper, so From and P-Asserted-Identity cannot drift apart.
- `OutboundRegistration.FromHost()` exposes the AOR realm.
- `POST /v1/legs` now accepts a full URI in `from` (`sip:alice@pbx.example.com`), not just a user part, and splits it. When the caller gives no host and the call matches a registered trunk, the trunk's AOR realm fills it in.

**Caller wins.** An explicit host in `from` is never overridden by the trunk realm. A bare user part behaves as before except on a registered trunk, which is the case this fixes.

## Risk worth stating

A registered trunk that a peer previously accepted un-challenged may now be challenged, because the From domain changes. That is the intended behaviour — it is what claiming the registered identity means — but it is a behaviour change on live trunks, not a pure addition.

## Tests

Unit coverage for `fromIdentity` (no caller id, default host, explicit override, PAI tracking From, tag present), for `FromHost()` returning the AOR realm rather than the registrar host, and a table for the `from` URI split including `tel:` and a host-less `sip:alice@`. Integration coverage asserts the wire From and P-Asserted-Identity on a real registered-trunk INVITE.

Every guard was mutation-proven: the named production edit was applied, the test watched failing with a message naming the defect, then restored. The `from`-split table in particular needed a host-less row added — without it, dropping the `u.Host != ""` conjunct left every other row green.

`gofmt`, `go build ./...`, `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `go vet -tags integration ./tests/...` and `go test ./internal/...` are clean. `go test -race ./internal/...` is clean apart from the pre-existing `emiago/sipgo` v1.4.3 `connCloser` race in `internal/sip`, which reproduces identically on an untouched `master`.
