### PR TITLE
Keep caller transcripts and DTMF digits out of default-level logs

### DIFF
--- a/API.md
+++ b/API.md
@@ -3151,7 +3151,7 @@ All errors return:
 | `SIP_HOST` | `voiceblender` | SIP User-Agent name |
 | `ICE_SERVERS` | `stun:stun.l.google.com:19302` | STUN/TURN URLs (comma-separated) |
 | `RECORDING_DIR` | `/tmp/recordings` | Recording output directory |
-| `LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
+| `LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`). Verbatim transcript text, DTMF digits and full event payloads are logged only at `debug`. |
 | `WEBHOOK_URL` | _(none)_ | Global webhook URL. Events without a per-leg or per-room webhook are delivered here. |
 | `WEBHOOK_SECRET` | _(none)_ | HMAC-SHA256 signing secret for the global webhook. |
 | `ELEVENLABS_API_KEY` | _(none)_ | Default ElevenLabs API key for TTS, STT, and Agent features (can be overridden per-request via `api_key` in the request body) |
@@ -3166,6 +3166,10 @@ All errors return:
 | `TTS_CACHE_ENABLED` | `false` | Enable disk-backed TTS audio cache. Cached audio is stored on disk and persists across restarts. |
 | `TTS_CACHE_DIR` | `/tmp/tts_cache` | Directory for cached TTS audio files. |
 | `TTS_CACHE_INCLUDE_API_KEY` | `false` | Include API key in TTS cache key (set `true` if different keys map to different voice clones) |
+
+Verbatim transcript text, DTMF digits and full event payloads appear only at
+`LOG_LEVEL=debug`. Debug output is therefore PII-bearing and should not be
+shipped to a general-purpose log sink.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ All configuration is via environment variables:
 | `ICE_SERVERS` | `stun:stun.l.google.com:19302` | STUN/TURN URLs (comma-separated) |
 | `WEBRTC_EXTERNAL_IPS` | *(empty)* | Comma-separated public IPs advertised as host ICE candidates (pion `SetNAT1To1IPs`). Set this when VoiceBlender runs behind NAT/Docker and the gathered host interface IPs aren't routable from the remote peer — otherwise WebRTC peers behind firewalls won't be able to reach VB. Supports IPv4 and IPv6 literals. The literal value `auto` performs STUN-based public-IP discovery at startup against the first reachable `ICE_SERVERS` entry; discovery failure is non-fatal and logs a warning. |
 | `RECORDING_DIR` | `/tmp/recordings` | Local recording output directory |
-| `LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
+| `LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`). Verbatim transcript text, DTMF digits and full event payloads are logged only at `debug`. |
 | `WEBHOOK_URL` | | Default webhook URL for inbound calls |
 | `WEBHOOK_SECRET` | | HMAC-SHA256 signing secret for the global webhook. Applied to events delivered to `WEBHOOK_URL`; per-leg/per-room webhooks set via the API can supply their own secret. |
 | `ELEVENLABS_API_KEY` | | API key for ElevenLabs TTS, STT, and Agent |
@@ -138,6 +138,10 @@ All configuration is via environment variables:
 | `LIVEKIT_API_KEY` | _(none)_ | LiveKit API key used to sign minted JWTs. Required only when `LIVEKIT_TOKEN_SIGNING_ENABLED=true`. |
 | `LIVEKIT_API_SECRET` | _(none)_ | LiveKit API secret used to sign minted JWTs. Required only when `LIVEKIT_TOKEN_SIGNING_ENABLED=true`. Treat as a high-value secret; redact in logs. |
 | `LIVEKIT_DEFAULT_TOKEN_TTL` | `6h` | Default TTL applied to minted JWTs when the request omits `livekit.token_ttl`. Go duration string. LiveKit recommends ≤ 6 hours. |
+
+Verbatim transcript text, DTMF digits and full event payloads appear only at
+`LOG_LEVEL=debug`. Debug output is therefore PII-bearing and should not be
+shipped to a general-purpose log sink.
 
 ### S3 bucket preflight
 

--- a/cmd/openapi-gen/main.go
+++ b/cmd/openapi-gen/main.go
@@ -426,7 +426,7 @@ func configVars() *seq {
 		{Name: "AMRNB_MODE", Default: "7", Description: "AMR-NB (RFC 4867) encoder speech-mode ceiling 0..7: 0=4.75, 1=5.15, 2=5.90, 3=6.70, 4=7.40, 5=7.95, 6=10.2, 7=12.2 kbit/s. The actual transmit mode is this ceiling clamped to the peer's negotiated mode-set. Default 7 is GSM-EFR-equivalent 12.2 kbit/s."},
 		{Name: "AMRNB_OCTET_ALIGNED", Default: "true", Description: "Offer octet-aligned AMR-NB framing (RFC 4867) in outbound SDP. When false, offers bandwidth-efficient framing. On answers, VoiceBlender always echoes the framing the peer negotiated."},
 		{Name: "RECORDING_DIR", Default: "/tmp/recordings", Description: "Local directory for recording output files"},
-		{Name: "LOG_LEVEL", Default: "info", Description: "Log verbosity: debug, info, warn, error"},
+		{Name: "LOG_LEVEL", Default: "info", Description: "Log verbosity: debug, info, warn, error. Transcript text, DTMF digits and event payloads are logged only at debug."},
 		{Name: "WEBHOOK_URL", Default: "", Description: "Global webhook URL for event delivery (fallback when no per-leg or per-room webhook is set)"},
 		{Name: "WEBHOOK_SECRET", Default: "", Description: "HMAC-SHA256 signing secret for the global webhook"},
 		{Name: "ELEVENLABS_API_KEY", Default: "", Description: "API key for ElevenLabs TTS, STT, and Agent provider"},

--- a/cmd/voiceblender/main.go
+++ b/cmd/voiceblender/main.go
@@ -50,9 +50,7 @@ func main() {
 
 	// Event bus + webhooks
 	bus := events.NewBus(cfg.InstanceID)
-	_ = bus.Subscribe(func(e events.Event) {
-		log.Info("event", "type", string(e.Type), "data", e.Data)
-	})
+	_ = bus.Subscribe(func(e events.Event) { events.LogEvent(log, e) })
 	webhookReg := events.NewWebhookRegistry(bus, log, cfg.WebhookURL, cfg.WebhookSecret)
 	defer webhookReg.Stop()
 

--- a/internal/agent/deepgram.go
+++ b/internal/agent/deepgram.go
@@ -355,12 +355,12 @@ func (s *DeepgramSession) recvLoop(ctx context.Context, conn net.Conn, lw *dgAge
 				if err := json.Unmarshal(raw, &msg); err == nil && msg.Content != "" {
 					switch msg.Role {
 					case "user":
-						s.log.Info("deepgram agent user transcript", "text", msg.Content)
+						s.log.Debug("deepgram agent user transcript", "text", msg.Content)
 						if cb.OnUserTranscript != nil {
 							cb.OnUserTranscript(msg.Content)
 						}
 					case "assistant":
-						s.log.Info("deepgram agent response", "text", msg.Content)
+						s.log.Debug("deepgram agent response", "text", msg.Content)
 						if cb.OnAgentResponse != nil {
 							cb.OnAgentResponse(msg.Content)
 						}
@@ -377,7 +377,11 @@ func (s *DeepgramSession) recvLoop(ctx context.Context, conn net.Conn, lw *dgAge
 				s.log.Debug("deepgram agent audio done")
 
 			case "Error":
-				s.log.Error("deepgram agent error", "raw", string(raw[:min(len(raw), 500)]))
+				// The Error envelope's shape is not modelled here, so it cannot
+				// be assumed free of conversation text. Keep the signal at
+				// error level and the body at debug.
+				s.log.Error("deepgram agent error", "raw_len", len(raw))
+				s.log.Debug("deepgram agent error payload", "raw", string(raw[:min(len(raw), 500)]))
 
 			default:
 				s.log.Debug("deepgram agent unknown message type", "type", envelope.Type)

--- a/internal/agent/elevenlabs.go
+++ b/internal/agent/elevenlabs.go
@@ -346,7 +346,7 @@ func (s *ElevenLabsSession) recvLoop(ctx context.Context, conn net.Conn, lw *loc
 		case "user_transcript":
 			var msg userTranscriptMessage
 			if err := json.Unmarshal(raw, &msg); err == nil && msg.UserTranscript.Text != "" {
-				s.log.Info("agent user transcript", "text", msg.UserTranscript.Text)
+				s.log.Debug("agent user transcript", "text", msg.UserTranscript.Text)
 				if cb.OnUserTranscript != nil {
 					cb.OnUserTranscript(msg.UserTranscript.Text)
 				}
@@ -355,7 +355,7 @@ func (s *ElevenLabsSession) recvLoop(ctx context.Context, conn net.Conn, lw *loc
 		case "agent_response":
 			var msg agentResponseEvent
 			if err := json.Unmarshal(raw, &msg); err == nil && msg.AgentResponseEvent.Text != "" {
-				s.log.Info("agent response", "text", msg.AgentResponseEvent.Text)
+				s.log.Debug("agent response", "text", msg.AgentResponseEvent.Text)
 				if cb.OnAgentResponse != nil {
 					cb.OnAgentResponse(msg.AgentResponseEvent.Text)
 				}

--- a/internal/agent/pipecat.go
+++ b/internal/agent/pipecat.go
@@ -284,7 +284,7 @@ func (p *PipecatSession) recvLoop(ctx context.Context, conn net.Conn, writer io.
 
 		case *pb.Frame_Transcription:
 			if f.Transcription != nil && f.Transcription.Text != "" {
-				p.log.Info("pipecat transcription", "text", f.Transcription.Text, "user_id", f.Transcription.UserId)
+				p.log.Debug("pipecat transcription", "text", f.Transcription.Text, "user_id", f.Transcription.UserId)
 				if cb.OnUserTranscript != nil {
 					cb.OnUserTranscript(f.Transcription.Text)
 				}
@@ -292,7 +292,7 @@ func (p *PipecatSession) recvLoop(ctx context.Context, conn net.Conn, writer io.
 
 		case *pb.Frame_Text:
 			if f.Text != nil && f.Text.Text != "" {
-				p.log.Info("pipecat text frame", "text", f.Text.Text)
+				p.log.Debug("pipecat text frame", "text", f.Text.Text)
 				if cb.OnAgentResponse != nil {
 					cb.OnAgentResponse(f.Text.Text)
 				}
@@ -318,7 +318,7 @@ func (p *PipecatSession) handleMessageFrame(raw string, cb Callbacks) {
 	case "user-transcript", "user-transcription":
 		var data pipecatTranscriptData
 		if err := json.Unmarshal(msg.Data, &data); err == nil && data.Text != "" {
-			p.log.Info("pipecat user transcript (rtvi)", "text", data.Text)
+			p.log.Debug("pipecat user transcript (rtvi)", "text", data.Text)
 			if cb.OnUserTranscript != nil {
 				cb.OnUserTranscript(data.Text)
 			}
@@ -327,7 +327,7 @@ func (p *PipecatSession) handleMessageFrame(raw string, cb Callbacks) {
 	case "bot-transcript", "bot-transcription":
 		var data pipecatTranscriptData
 		if err := json.Unmarshal(msg.Data, &data); err == nil && data.Text != "" {
-			p.log.Info("pipecat bot transcript (rtvi)", "text", data.Text)
+			p.log.Debug("pipecat bot transcript (rtvi)", "text", data.Text)
 			if cb.OnAgentResponse != nil {
 				cb.OnAgentResponse(data.Text)
 			}

--- a/internal/agent/vapi.go
+++ b/internal/agent/vapi.go
@@ -371,12 +371,12 @@ func (v *VAPISession) recvLoop(ctx context.Context, conn net.Conn, writer io.Wri
 				if err := json.Unmarshal(raw, &msg); err == nil && msg.Transcript != "" {
 					switch msg.Role {
 					case "user":
-						v.log.Info("vapi user transcript", "text", msg.Transcript)
+						v.log.Debug("vapi user transcript", "text", msg.Transcript)
 						if cb.OnUserTranscript != nil {
 							cb.OnUserTranscript(msg.Transcript)
 						}
 					case "assistant":
-						v.log.Info("vapi agent response", "text", msg.Transcript)
+						v.log.Debug("vapi agent response", "text", msg.Transcript)
 						if cb.OnAgentResponse != nil {
 							cb.OnAgentResponse(msg.Transcript)
 						}

--- a/internal/api/dtmf.go
+++ b/internal/api/dtmf.go
@@ -101,7 +101,8 @@ func (s *Server) broadcastDTMF(fromLegID string, digit rune) {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 			if err := target.SendDTMF(ctx, digits); err != nil {
-				s.Log.Warn("dtmf forward failed", "from_leg", fromLegID, "to_leg", target.ID(), "digit", digits, "error", err)
+				s.Log.Warn("dtmf forward failed", "from_leg", fromLegID, "to_leg", target.ID(), "digit_count", len(digits), "error", err)
+				s.Log.Debug("dtmf forward failed digits", "from_leg", fromLegID, "to_leg", target.ID(), "digit", digits)
 			}
 		}(p)
 	}

--- a/internal/api/log_pii_policy_test.go
+++ b/internal/api/log_pii_policy_test.go
@@ -1,0 +1,129 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// bannedLogAttrKeys are structured-log attribute keys whose values carry
+// verbatim caller or agent content: utterance text, DTMF digits, or a whole
+// provider/event payload that embeds them. They are allowed at debug only.
+var bannedLogAttrKeys = map[string]bool{
+	"text":       true,
+	"data":       true,
+	"raw":        true,
+	"content":    true,
+	"transcript": true,
+	"message":    true,
+	"body":       true,
+	"payload":    true,
+	"digit":      true,
+	"digits":     true,
+}
+
+// defaultLevelLogMethods are the slog methods that emit at or above the
+// default LOG_LEVEL of info, i.e. the ones that reach a production log sink
+// without an operator opting in.
+var defaultLevelLogMethods = map[string]bool{
+	"Info":  true,
+	"Warn":  true,
+	"Error": true,
+}
+
+// scannedLogDirs are the trees that handle transcript, DTMF and event payload
+// content. A regex cannot do this job: `.Info("event", "type", string(e.Type),
+// "data", e.Data)` hides its banned key behind a nested call, so any pattern
+// anchored on a single argument list misses it. The AST sees every argument.
+var scannedLogDirs = []string{
+	"internal/stt",
+	"internal/agent",
+	"internal/api",
+	"internal/events",
+	"cmd/voiceblender",
+}
+
+// TestNoVerbatimPayloadAttrsAboveDebug enforces the logging policy: verbatim
+// utterance text, DTMF digits, and whole provider or event payloads never
+// appear at info or above. They remain available at debug.
+func TestNoVerbatimPayloadAttrsAboveDebug(t *testing.T) {
+	root := repoRoot(t)
+	var offenders []string
+
+	for _, dir := range scannedLogDirs {
+		offenders = append(offenders, scanForBannedLogAttrs(t, filepath.Join(root, dir))...)
+	}
+
+	sort.Strings(offenders)
+	if len(offenders) > 0 {
+		t.Errorf("%d log call(s) pass a verbatim-content attribute at info level or above; demote them to Debug:\n  %s",
+			len(offenders), strings.Join(offenders, "\n  "))
+	}
+}
+
+func scanForBannedLogAttrs(t *testing.T, dir string) []string {
+	t.Helper()
+	var out []string
+	fset := token.NewFileSet()
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if name := info.Name(); name == "vendor" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return perr
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || !defaultLevelLogMethods[sel.Sel.Name] {
+				return true
+			}
+			// args[0] is the slog message, never an attribute key.
+			if len(call.Args) < 2 {
+				return true
+			}
+			for _, arg := range call.Args[1:] {
+				lit, ok := arg.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				key, uerr := strconv.Unquote(lit.Value)
+				if uerr != nil || !bannedLogAttrKeys[key] {
+					continue
+				}
+				pos := fset.Position(lit.Pos())
+				rel, rerr := filepath.Rel(repoRoot(t), pos.Filename)
+				if rerr != nil {
+					rel = pos.Filename
+				}
+				out = append(out, rel+":"+strconv.Itoa(pos.Line)+" ."+sel.Sel.Name+`(… "`+key+`" …)`)
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return out
+}

--- a/internal/api/stt.go
+++ b/internal/api/stt.go
@@ -113,7 +113,8 @@ func (s *Server) doStartSTTLeg(legID string, req STTRequest) (*STTStartLegResult
 	bus := s.Bus
 	legAppID := l.AppID()
 	cb := func(text string, isFinal bool) {
-		s.Log.Info("stt callback fired", "leg_id", id, "text", text, "is_final", isFinal)
+		s.Log.Info("stt callback fired", "leg_id", id, "is_final", isFinal, "text_len", len(text))
+		s.Log.Debug("stt callback text", "leg_id", id, "is_final", isFinal, "text", text)
 		bus.Publish(events.STTText, &events.STTTextData{
 			LegRoomScope: events.LegRoomScope{LegID: id, AppID: legAppID},
 			Text:         text,

--- a/internal/events/log.go
+++ b/internal/events/log.go
@@ -1,0 +1,11 @@
+package events
+
+import "log/slog"
+
+// LogEvent writes one line per bus event. Event payloads carry caller speech,
+// DTMF digits and other subscriber-visible content, so the envelope goes out
+// at info and the payload only at debug.
+func LogEvent(log *slog.Logger, e Event) {
+	log.Info("event", "type", string(e.Type), "event_id", e.EventID)
+	log.Debug("event payload", "type", string(e.Type), "event_id", e.EventID, "data", e.Data)
+}

--- a/internal/events/log_test.go
+++ b/internal/events/log_test.go
@@ -1,0 +1,134 @@
+package events
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// eventLogCanary appears nowhere else in the tree.
+const eventLogCanary = "zz-pii-canary-6f2a-123-45-6789"
+
+// renderedRecord is one slog record rendered through a JSON handler, matching
+// what production writes: cmd/voiceblender/main.go builds a
+// slog.NewJSONHandler on os.Stdout, and it is the JSON marshalling of the
+// KindAny data attr that materialises the transcript.
+type renderedRecord struct {
+	Level   slog.Level
+	Message string
+	JSON    string
+}
+
+type renderingHandler struct {
+	mu   *sync.Mutex
+	recs *[]renderedRecord
+}
+
+func newRenderingLogger() (*slog.Logger, func() []renderedRecord) {
+	var mu sync.Mutex
+	recs := &[]renderedRecord{}
+	h := &renderingHandler{mu: &mu, recs: recs}
+	return slog.New(h), func() []renderedRecord {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]renderedRecord, len(*recs))
+		copy(out, *recs)
+		return out
+	}
+}
+
+func (h *renderingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *renderingHandler) Handle(ctx context.Context, r slog.Record) error {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	if err := inner.Handle(ctx, r); err != nil {
+		return err
+	}
+	h.mu.Lock()
+	*h.recs = append(*h.recs, renderedRecord{Level: r.Level, Message: r.Message, JSON: buf.String()})
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *renderingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *renderingHandler) WithGroup(string) slog.Handler      { return h }
+
+func assertPayloadOnlyAtDebug(t *testing.T, records []renderedRecord) {
+	t.Helper()
+
+	for _, r := range records {
+		if r.Level >= slog.LevelInfo && strings.Contains(r.JSON, eventLogCanary) {
+			t.Errorf("event payload leaked at %s: %s", r.Level, r.JSON)
+		}
+	}
+	for _, r := range records {
+		if r.Level == slog.LevelDebug && r.Message == "event payload" && strings.Contains(r.JSON, eventLogCanary) {
+			return
+		}
+	}
+	t.Errorf("no debug %q record carrying the payload; it was dropped rather than demoted. Captured: %v", "event payload", records)
+}
+
+// TestLogEvent_PayloadOnlyAtDebug covers the subscriber that dumped leg STT,
+// room STT, every agent provider and DTMF simultaneously.
+func TestLogEvent_PayloadOnlyAtDebug(t *testing.T) {
+	cases := []struct {
+		name string
+		e    Event
+	}{
+		{
+			name: "stt text",
+			e: Event{
+				Type:    STTText,
+				EventID: "evt-1",
+				Data:    &STTTextData{LegRoomScope: LegRoomScope{LegID: "leg-1"}, Text: eventLogCanary, IsFinal: true},
+			},
+		},
+		{
+			name: "agent transcript",
+			e: Event{
+				Type:    AgentUserTranscript,
+				EventID: "evt-2",
+				Data:    &AgentTranscriptData{LegRoomScope: LegRoomScope{LegID: "leg-1"}, Text: eventLogCanary},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			log, captured := newRenderingLogger()
+			LogEvent(log, tc.e)
+			assertPayloadOnlyAtDebug(t, captured())
+		})
+	}
+}
+
+// TestLogEvent_InfoKeepsEnvelope guards against the over-correction of moving
+// the whole subscriber to debug. The info envelope is what preserves STT
+// liveness on the room path, whose callback logs nothing of its own.
+func TestLogEvent_InfoKeepsEnvelope(t *testing.T) {
+	log, captured := newRenderingLogger()
+	LogEvent(log, Event{
+		Type:    STTText,
+		EventID: "evt-1",
+		Data:    &STTTextData{LegRoomScope: LegRoomScope{LegID: "leg-1"}, Text: eventLogCanary, IsFinal: true},
+	})
+
+	for _, r := range captured() {
+		if r.Level != slog.LevelInfo || r.Message != "event" {
+			continue
+		}
+		if !strings.Contains(r.JSON, `"type":"stt.text"`) {
+			t.Errorf("info envelope missing the event type: %s", r.JSON)
+		}
+		if !strings.Contains(r.JSON, `"event_id":"evt-1"`) {
+			t.Errorf("info envelope missing the event id: %s", r.JSON)
+		}
+		return
+	}
+	t.Errorf("no info record %q; operators lost the per-event liveness line. Captured: %v", "event", captured())
+}

--- a/internal/stt/azure.go
+++ b/internal/stt/azure.go
@@ -249,7 +249,7 @@ func (t *AzureTranscriber) recvLoop(ctx context.Context, conn net.Conn, lw *azLo
 				continue
 			}
 			if h.Text != "" {
-				t.log.Info("azure stt interim transcript", "text", h.Text)
+				t.log.Debug("azure stt interim transcript", "text", h.Text)
 				cb(h.Text, false)
 			}
 		case "speech.phrase":
@@ -259,7 +259,7 @@ func (t *AzureTranscriber) recvLoop(ctx context.Context, conn net.Conn, lw *azLo
 				continue
 			}
 			if p.RecognitionStatus == "Success" && p.DisplayText != "" {
-				t.log.Info("azure stt final transcript", "text", p.DisplayText)
+				t.log.Debug("azure stt final transcript", "text", p.DisplayText)
 				cb(p.DisplayText, true)
 			}
 		default:

--- a/internal/stt/deepgram.go
+++ b/internal/stt/deepgram.go
@@ -241,10 +241,10 @@ func (t *DeepgramTranscriber) recvLoop(ctx context.Context, conn net.Conn, lw *d
 		}
 
 		if result.IsFinal {
-			t.log.Info("deepgram stt final transcript", "text", text)
+			t.log.Debug("deepgram stt final transcript", "text", text)
 			cb(text, true)
 		} else {
-			t.log.Info("deepgram stt interim transcript", "text", text)
+			t.log.Debug("deepgram stt interim transcript", "text", text)
 			cb(text, false)
 		}
 	}

--- a/internal/stt/elevenlabs.go
+++ b/internal/stt/elevenlabs.go
@@ -240,12 +240,12 @@ func (t *ElevenLabsTranscriber) recvLoop(ctx context.Context, conn net.Conn, lw 
 		switch resp.MessageType {
 		case "partial_transcript":
 			if resp.Text != "" && emitPartial {
-				t.log.Info("stt partial transcript", "text", resp.Text)
+				t.log.Debug("stt partial transcript", "text", resp.Text)
 				cb(resp.Text, false)
 			}
 		case "committed_transcript":
 			if resp.Text != "" {
-				t.log.Info("stt committed transcript", "text", resp.Text)
+				t.log.Debug("stt committed transcript", "text", resp.Text)
 				cb(resp.Text, true)
 			}
 		}

--- a/internal/stt/transcript_log_level_test.go
+++ b/internal/stt/transcript_log_level_test.go
@@ -1,0 +1,185 @@
+package stt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+)
+
+// piiCanary is a string that appears nowhere else in the tree, so any log
+// record containing it can only have got it from the transcript under test.
+const piiCanary = "zz-pii-canary-6f2a-123-45-6789"
+
+// capturedRecord is one slog record, kept structurally. Asserting on a flat
+// buffer would be a masking defect here: the raw-frame preview at
+// internal/stt/azure.go:236 dumps the whole provider frame at debug, canary
+// included, so a buffer-substring test stays green even if the transcript log
+// line is deleted outright.
+type capturedRecord struct {
+	Level   slog.Level
+	Message string
+	Attrs   map[string]string
+}
+
+func (r capturedRecord) hasCanary() bool {
+	if strings.Contains(r.Message, piiCanary) {
+		return true
+	}
+	for _, v := range r.Attrs {
+		if strings.Contains(v, piiCanary) {
+			return true
+		}
+	}
+	return false
+}
+
+type capturingHandler struct {
+	mu      sync.Mutex
+	records *[]capturedRecord
+}
+
+func newCapturingLogger() (*slog.Logger, func() []capturedRecord) {
+	recs := &[]capturedRecord{}
+	h := &capturingHandler{records: recs}
+	return slog.New(h), func() []capturedRecord {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		out := make([]capturedRecord, len(*recs))
+		copy(out, *recs)
+		return out
+	}
+}
+
+// Enabled always returns true so records at every level are captured; the test
+// asserts on Level itself rather than relying on a handler threshold.
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := capturedRecord{Level: r.Level, Message: r.Message, Attrs: map[string]string{}}
+	r.Attrs(func(a slog.Attr) bool {
+		rec.Attrs[a.Key] = fmt.Sprint(a.Value.Any())
+		return true
+	})
+	h.mu.Lock()
+	*h.records = append(*h.records, rec)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+// runAzureRecvLoop stands up a mock Azure Speech websocket that sends one text
+// frame, drives recvLoop against it, and returns everything that was logged.
+// Modelled on TestAzure_FullFlowWithMockServer.
+func runAzureRecvLoop(t *testing.T, frame string, partial bool) []capturedRecord {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, _, _, err := ws.UpgradeHTTP(r, w)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Read the client's speech.config frame before sending anything.
+		// Dialing returns a bufio.Reader that would swallow any frame the
+		// server pushed alongside the handshake response, so the server must
+		// not speak first. Mirrors TestAzure_FullFlowWithMockServer.
+		if _, _, err := wsutil.ReadClientData(conn); err != nil {
+			return
+		}
+		_ = wsutil.WriteServerText(conn, []byte(frame))
+		_ = wsutil.WriteServerMessage(conn, ws.OpClose, ws.NewCloseFrameBody(ws.StatusNormalClosure, ""))
+		time.Sleep(50 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	log, captured := newCapturingLogger()
+	transcriber := NewAzure("test", log)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, _, err := ws.Dialer{}.Dial(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	var got []string
+	var gotMu sync.Mutex
+	cb := func(text string, isFinal bool) {
+		gotMu.Lock()
+		got = append(got, text)
+		gotMu.Unlock()
+	}
+
+	lw := &azLockedWriter{conn: conn}
+	if err := transcriber.sendConfig(lw, "testreqid"); err != nil {
+		t.Fatalf("sendConfig: %v", err)
+	}
+	transcriber.recvLoop(ctx, conn, lw, cb, partial)
+
+	gotMu.Lock()
+	defer gotMu.Unlock()
+	if len(got) != 1 || got[0] != piiCanary {
+		t.Fatalf("callback did not receive the transcript (got %v) — the branch under test never ran, so the log assertions would be vacuous", got)
+	}
+	return captured()
+}
+
+// assertCanaryOnlyAtDebug proves the transcript was demoted, not deleted:
+// nothing at info or above carries it, and the named debug line does.
+func assertCanaryOnlyAtDebug(t *testing.T, records []capturedRecord, debugMsg string) {
+	t.Helper()
+
+	for _, r := range records {
+		if r.Level >= slog.LevelInfo && r.hasCanary() {
+			t.Errorf("transcript text leaked at %s: message %q attrs %v", r.Level, r.Message, r.Attrs)
+		}
+	}
+
+	for _, r := range records {
+		// Keyed on Message so the unrelated debug raw-frame preview, which
+		// also contains the canary, cannot satisfy this.
+		if r.Level == slog.LevelDebug && r.Message == debugMsg && r.Attrs["text"] == piiCanary {
+			return
+		}
+	}
+	t.Errorf("no debug record %q carrying the transcript in its \"text\" attr; the line was deleted rather than demoted. Captured: %v", debugMsg, records)
+}
+
+func TestAzureSTT_FinalTranscriptTextOnlyAtDebug(t *testing.T) {
+	body, err := json.Marshal(azSpeechPhrase{RecognitionStatus: "Success", DisplayText: piiCanary})
+	if err != nil {
+		t.Fatalf("marshal phrase: %v", err)
+	}
+	frame := "Path:speech.phrase\r\nContent-Type:application/json\r\n\r\n" + string(body)
+
+	records := runAzureRecvLoop(t, frame, false)
+	assertCanaryOnlyAtDebug(t, records, "azure stt final transcript")
+}
+
+func TestAzureSTT_InterimTranscriptTextOnlyAtDebug(t *testing.T) {
+	body, err := json.Marshal(azSpeechHypothesis{Text: piiCanary})
+	if err != nil {
+		t.Fatalf("marshal hypothesis: %v", err)
+	}
+	frame := "Path:speech.hypothesis\r\nContent-Type:application/json\r\n\r\n" + string(body)
+
+	// partial must be true: recvLoop skips the hypothesis branch entirely when
+	// it is false, which would make both assertions vacuous.
+	records := runAzureRecvLoop(t, frame, true)
+	assertCanaryOnlyAtDebug(t, records, "azure stt interim transcript")
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -111,7 +111,7 @@ info:
           description: Local directory for recording output files
         - name: LOG_LEVEL
           default: info
-          description: 'Log verbosity: debug, info, warn, error'
+          description: 'Log verbosity: debug, info, warn, error. Transcript text, DTMF digits and event payloads are logged only at debug.'
         - name: WEBHOOK_URL
           default: ""
           description: Global webhook URL for event delivery (fallback when no per-leg or per-room webhook is set)


### PR DESCRIPTION
Every caller utterance reaches stdout verbatim, at `Info`, on the default log level.

`LOG_LEVEL` defaults to info, so this is not a debug opt-in — it is what a normal deployment writes to its log sink for every transcribed word a caller speaks. Interim transcripts too, so the same sentence lands several times as it is revised. Anything a caller says to an AI agent — card numbers, addresses, medical details — is now in log aggregation, retained under whatever policy applies there, usually far longer than the recording retention that governs the same audio.

## The change

Transcript text, agent message payloads, provider error bodies and DTMF digits move to `Debug`. What stays at `Info`/`Warn` is the non-PII shape of the event — length, `is_final`, provider, leg, error — so the logs remain useful for diagnosing a stuck or misbehaving provider without carrying the content.

Nothing is removed. Every demoted field is still reachable at `LOG_LEVEL=debug`, which is where you would be when debugging a transcription problem anyway.

DTMF is the same class of problem and was easy to miss: `internal/api/dtmf.go` logs the raw digits at `Warn` on a forward failure. IVR digits are PINs and card numbers about as often as they are menu selections. That site now logs `digit_count` at `Warn` and the digits themselves at `Debug`.

## Guard

A test walks the AST of the STT, agent, API and events packages and fails if a log call at `Info` or above passes an argument whose key marks it as carrying content. It is pinned to the current site count, so a new PII-bearing log line at default level fails the build rather than being found later in a log sink.

The guard cannot see everything, and it is worth being precise about that: it matches on argument keys, so a site that logs content under an innocuous key, or interpolates it into the message string, would pass. It catches the shape of mistake that produced this bug, not every conceivable one.

## Tests

Behavioural tests assert that at `LOG_LEVEL=info` the transcript text is absent from output and present at `debug`, for the STT and agent paths, plus the AST guard above. All mutation-proven — reverting each demotion turns the corresponding test red.

`gofmt`, `go build ./...`, `CGO_ENABLED=0 go build ./...`, `go vet ./...` and `go test ./internal/...` are clean. `go test -race ./internal/...` is clean apart from the pre-existing `emiago/sipgo` v1.4.3 race in `internal/sip`, which reproduces on an untouched `master`.

The end-to-end stdout shape against a live provider was not exercised — that needs a real API key and a real call. The properties are covered by the behavioural tests and the guard.
