### PR TITLE
Retry transient TTS synthesis failures with a bounded backoff

### DIFF
--- a/API.md
+++ b/API.md
@@ -1073,6 +1073,8 @@ Change the volume of an active leg playback. Takes effect immediately on the nex
 
 Synthesize speech and play it on a leg.
 
+Transient upstream failures (429, 500/502/503/504, transport timeouts) are retried up to 3 times with jittered backoff, bounded to 5 seconds in total, before `tts.error` is published. Auth failures, rejected input, and unclassifiable errors are not retried.
+
 **Request:**
 
 ```json
@@ -2012,6 +2014,8 @@ Change the volume of an active room playback. Takes effect immediately on the ne
 ### POST /v1/rooms/{id}/tts
 
 Synthesize speech and play it into a room.
+
+Transient upstream failures (429, 500/502/503/504, transport timeouts) are retried up to 3 times with jittered backoff, bounded to 5 seconds in total, before `tts.error` is published. Auth failures, rejected input, and unclassifiable errors are not retried.
 
 **Request:**
 
@@ -2972,7 +2976,7 @@ All event data uses typed structs with consistent field names. Events scoped to 
 | `playback.error` | Playback failed | `leg_id` or `room_id`, `playback_id`, `error` |
 | `tts.started` | TTS synthesis began playing | `leg_id` or `room_id`, `tts_id` |
 | `tts.finished` | TTS synthesis finished playing | `leg_id` or `room_id`, `tts_id`, `reason`, `played_ms` |
-| `tts.error` | TTS synthesis or playback failed | `leg_id` or `room_id`, `tts_id`, `error` |
+| `tts.error` | TTS synthesis or playback failed | `leg_id` or `room_id`, `tts_id`, `error`, `category` |
 > **Note:** `playback.finished` and `tts.finished` carry `reason` and `played_ms` so you can tell whether a prompt was heard in full or was cut short, and by how much.
 >
 > `reason` is `completed` when the audio played through to its end, and `stopped` when it did **not** reach the end — **for any reason**. That includes an app-initiated stop, a barge-in, and a leg hanging up: all three cancel the same playback, and they cannot be told apart from `reason` alone. To distinguish a hangup from a deliberate stop, look for a co-emitted `leg.disconnected` event. Tone playback never ends on its own, so it always reports `stopped`.

--- a/internal/api/openapi_meta.go
+++ b/internal/api/openapi_meta.go
@@ -112,6 +112,7 @@ func WebhookFieldDescriptions() map[string]string {
 		"tts.error.room_id":      "Room identifier",
 		"tts.error.tts_id":       "TTS playback identifier",
 		"tts.error.error":        "Error message",
+		"tts.error.category":     "Failure category: permanent_auth, permanent_input, rate_limited, service_unavailable, retryable, canceled or unknown for a synthesis failure, playback for a failure while streaming the audio. New values may be added; treat an unrecognised value as unknown",
 
 		// recording
 		"recording.started.leg_id":        "Leg identifier",

--- a/internal/api/tts.go
+++ b/internal/api/tts.go
@@ -313,6 +313,15 @@ func (s *Server) resolveTTSProvider(req TTSRequest) (tts.Provider, string) {
 		}
 		provider, name = s.TTS, "elevenlabs"
 	}
+	// Retry is inner and the cache is outer: a cache hit never enters the
+	// retry loop, so a cached utterance costs zero upstream calls.
+	//
+	// The nil check matters: without it every caller would get a non-nil
+	// wrapper, and the "no API key configured -> 503" guards in doLegTTS and
+	// doRoomTTS would stop firing when s.TTS itself is nil.
+	if provider != nil {
+		provider = tts.NewRetrying(provider, name, s.Log)
+	}
 	if s.TTSCache != nil {
 		provider = s.TTSCache.WrapProvider(provider, name)
 	}

--- a/internal/api/tts.go
+++ b/internal/api/tts.go
@@ -79,6 +79,7 @@ func (s *Server) doLegTTS(legID string, req TTSRequest) (*TTSStartResult, error)
 				LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 				TTSID:        ttsID,
 				Error:        err.Error(),
+				Category:     string(tts.Categorize(err)),
 			})
 			return
 		}
@@ -121,6 +122,7 @@ func (s *Server) doLegTTS(legID string, req TTSRequest) (*TTSStartResult, error)
 				LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 				TTSID:        ttsID,
 				Error:        playErr.Error(),
+				Category:     string(tts.CategoryPlayback),
 			})
 		} else {
 			s.Bus.Publish(events.TTSFinished, &events.TTSFinishedData{
@@ -214,6 +216,7 @@ func (s *Server) doRoomTTS(roomID string, req TTSRequest) (*TTSStartResult, erro
 				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 				TTSID:        ttsID,
 				Error:        err.Error(),
+				Category:     string(tts.Categorize(err)),
 			})
 			return
 		}
@@ -243,6 +246,7 @@ func (s *Server) doRoomTTS(roomID string, req TTSRequest) (*TTSStartResult, erro
 				LegRoomScope: events.LegRoomScope{RoomID: id, AppID: roomAppID},
 				TTSID:        ttsID,
 				Error:        playErr.Error(),
+				Category:     string(tts.CategoryPlayback),
 			})
 		} else {
 			s.Bus.Publish(events.TTSFinished, &events.TTSFinishedData{

--- a/internal/api/tts_retry_test.go
+++ b/internal/api/tts_retry_test.go
@@ -6,9 +6,12 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/VoiceBlender/voiceblender/internal/config"
+	"github.com/VoiceBlender/voiceblender/internal/events"
 	"github.com/VoiceBlender/voiceblender/internal/tts"
 )
 
@@ -69,5 +72,164 @@ func TestResolveTTSProvider_NilProviderStaysNil(t *testing.T) {
 
 	if p, _ := s.resolveTTSProvider(TTSRequest{APIKey: "k"}); p != nil {
 		t.Fatalf("provider = %v, want nil when no TTS provider is configured", p)
+	}
+}
+
+// ttsAudioLeg is an apiMockLeg with a usable audio writer. apiMockLeg
+// hardcodes AudioWriter() to nil, which makes doLegTTS answer 409 before it
+// ever reaches synthesis.
+type ttsAudioLeg struct {
+	*apiMockLeg
+}
+
+func (ttsAudioLeg) AudioWriter() io.Writer { return io.Discard }
+func (ttsAudioLeg) SampleRate() int        { return 16000 }
+
+// errReader fails its first Read with a non-EOF error, which streamRawPCM
+// surfaces as a playback error.
+type errReader struct{}
+
+func (errReader) Read(p []byte) (int, error) { return 0, errors.New("stream broke") }
+func (errReader) Close() error               { return nil }
+
+const ttsAuthFailure = `azure: status 401: body="invalid key"`
+
+// collectTTSError subscribes to the bus and returns a getter for the first
+// tts.error event matching want.
+func collectTTSError(t *testing.T, s *Server, match func(*events.TTSErrorData) bool) func() *events.TTSErrorData {
+	t.Helper()
+	var mu sync.Mutex
+	var got *events.TTSErrorData
+	s.Bus.Subscribe(func(e events.Event) {
+		if e.Type != events.TTSError {
+			return
+		}
+		d, ok := e.Data.(*events.TTSErrorData)
+		if !ok || !match(d) {
+			return
+		}
+		mu.Lock()
+		if got == nil {
+			got = d
+		}
+		mu.Unlock()
+	})
+	return func() *events.TTSErrorData {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			mu.Lock()
+			d := got
+			mu.Unlock()
+			if d != nil {
+				return d
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		return nil
+	}
+}
+
+func TestLegTTSErrorCarriesCategory(t *testing.T) {
+	s := newTestServer(t)
+	// A 401 categorizes as permanent_auth, so the decorator makes exactly one
+	// attempt and the test never sleeps on a backoff.
+	s.TTS = &ttsFake{errs: []error{errors.New(ttsAuthFailure)}}
+	s.LegMgr.Add(&ttsAudioLeg{&apiMockLeg{id: "tts-leg", createdAt: time.Now()}})
+
+	wait := collectTTSError(t, s, func(d *events.TTSErrorData) bool { return d.LegID == "tts-leg" })
+
+	if _, err := s.doLegTTS("tts-leg", TTSRequest{Text: "hi", Voice: "v", APIKey: "k"}); err != nil {
+		t.Fatalf("doLegTTS: %v", err)
+	}
+
+	d := wait()
+	if d == nil {
+		t.Fatal("no tts.error published for the leg")
+	}
+	if d.Category != string(tts.CategoryPermanentAuth) {
+		t.Fatalf("category = %q, want %q", d.Category, tts.CategoryPermanentAuth)
+	}
+}
+
+// TestRoomTTSErrorCarriesCategory is the neighbour-case guard: the leg test
+// above stays green whether or not the structurally identical room publish
+// site was updated.
+func TestRoomTTSErrorCarriesCategory(t *testing.T) {
+	s := newTestServer(t)
+	s.TTS = &ttsFake{errs: []error{errors.New(ttsAuthFailure)}}
+	s.LegMgr.Add(&apiMockLeg{id: "room-leg", createdAt: time.Now()})
+	if _, err := s.RoomMgr.Create("r1", "", 0); err != nil {
+		t.Fatalf("Create room: %v", err)
+	}
+	if err := s.RoomMgr.AddLeg("r1", "room-leg"); err != nil {
+		t.Fatalf("AddLeg: %v", err)
+	}
+
+	wait := collectTTSError(t, s, func(d *events.TTSErrorData) bool { return d.RoomID == "r1" })
+
+	if _, err := s.doRoomTTS("r1", TTSRequest{Text: "hi", Voice: "v", APIKey: "k"}); err != nil {
+		t.Fatalf("doRoomTTS: %v", err)
+	}
+
+	d := wait()
+	if d == nil {
+		t.Fatal("no tts.error published for the room")
+	}
+	if d.Category != string(tts.CategoryPermanentAuth) {
+		t.Fatalf("category = %q, want %q", d.Category, tts.CategoryPermanentAuth)
+	}
+}
+
+func TestLegTTSPlaybackErrorCategoryIsPlayback(t *testing.T) {
+	s := newTestServer(t)
+	s.TTS = &ttsFake{
+		results: []*tts.Result{{Audio: errReader{}, MimeType: "audio/pcm;rate=16000"}},
+		errs:    []error{nil},
+	}
+	s.LegMgr.Add(&ttsAudioLeg{&apiMockLeg{id: "play-leg", createdAt: time.Now()}})
+
+	wait := collectTTSError(t, s, func(d *events.TTSErrorData) bool { return d.LegID == "play-leg" })
+
+	if _, err := s.doLegTTS("play-leg", TTSRequest{Text: "hi", Voice: "v", APIKey: "k"}); err != nil {
+		t.Fatalf("doLegTTS: %v", err)
+	}
+
+	d := wait()
+	if d == nil {
+		t.Fatal("no tts.error published for the leg playback failure")
+	}
+	if d.Category != string(tts.CategoryPlayback) {
+		t.Fatalf("category = %q, want %q", d.Category, tts.CategoryPlayback)
+	}
+}
+
+// TestRoomTTSPlaybackErrorCategoryIsPlayback is the neighbour case for the
+// playback pair, for the same reason the room synth test exists.
+func TestRoomTTSPlaybackErrorCategoryIsPlayback(t *testing.T) {
+	s := newTestServer(t)
+	s.TTS = &ttsFake{
+		results: []*tts.Result{{Audio: errReader{}, MimeType: "audio/pcm;rate=16000"}},
+		errs:    []error{nil},
+	}
+	s.LegMgr.Add(&apiMockLeg{id: "play-room-leg", createdAt: time.Now()})
+	if _, err := s.RoomMgr.Create("r2", "", 0); err != nil {
+		t.Fatalf("Create room: %v", err)
+	}
+	if err := s.RoomMgr.AddLeg("r2", "play-room-leg"); err != nil {
+		t.Fatalf("AddLeg: %v", err)
+	}
+
+	wait := collectTTSError(t, s, func(d *events.TTSErrorData) bool { return d.RoomID == "r2" })
+
+	if _, err := s.doRoomTTS("r2", TTSRequest{Text: "hi", Voice: "v", APIKey: "k"}); err != nil {
+		t.Fatalf("doRoomTTS: %v", err)
+	}
+
+	d := wait()
+	if d == nil {
+		t.Fatal("no tts.error published for the room playback failure")
+	}
+	if d.Category != string(tts.CategoryPlayback) {
+		t.Fatalf("category = %q, want %q", d.Category, tts.CategoryPlayback)
 	}
 }

--- a/internal/api/tts_retry_test.go
+++ b/internal/api/tts_retry_test.go
@@ -1,0 +1,73 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/VoiceBlender/voiceblender/internal/config"
+	"github.com/VoiceBlender/voiceblender/internal/tts"
+)
+
+// ttsFake is a scripted tts.Provider. resolveTTSProvider hands it to a
+// decorator that calls it from a single goroutine, so a plain counter is
+// enough.
+type ttsFake struct {
+	calls   int
+	results []*tts.Result
+	errs    []error
+}
+
+func (f *ttsFake) Synthesize(ctx context.Context, text string, opts tts.Options) (*tts.Result, error) {
+	i := f.calls
+	f.calls++
+	if i >= len(f.errs) {
+		i = len(f.errs) - 1
+	}
+	var res *tts.Result
+	if i < len(f.results) {
+		res = f.results[i]
+	}
+	return res, f.errs[i]
+}
+
+// TestResolveTTSProvider_WrapsWithRetry proves the decorator is actually
+// installed on the production resolve path — the one thing no test inside
+// internal/tts can see. It costs one real backoff (~100ms).
+func TestResolveTTSProvider_WrapsWithRetry(t *testing.T) {
+	fake := &ttsFake{
+		results: []*tts.Result{nil, {Audio: io.NopCloser(strings.NewReader("pcm")), MimeType: "audio/pcm;rate=16000"}},
+		errs:    []error{errors.New("elevenlabs: status 503: down"), nil},
+	}
+	s := &Server{TTS: fake, Config: config.Config{}, Log: slog.Default()}
+
+	p, key := s.resolveTTSProvider(TTSRequest{APIKey: "k"})
+	if p == nil {
+		t.Fatal("resolveTTSProvider returned a nil provider for a request carrying an api_key")
+	}
+	if key != "k" {
+		t.Fatalf("api key = %q, want %q", key, "k")
+	}
+
+	if _, err := p.Synthesize(context.Background(), "hi", tts.Options{}); err != nil {
+		t.Fatalf("Synthesize: unexpected error %v", err)
+	}
+	if fake.calls != 2 {
+		t.Fatalf("provider calls = %d, want 2 — the 503 must have been retried", fake.calls)
+	}
+}
+
+// TestResolveTTSProvider_NilProviderStaysNil guards the "no API key
+// configured -> 503" contract: doLegTTS and doRoomTTS decide on a nil
+// provider, so the decorator must not manufacture a non-nil wrapper around
+// nothing.
+func TestResolveTTSProvider_NilProviderStaysNil(t *testing.T) {
+	s := &Server{Config: config.Config{}, Log: slog.Default()}
+
+	if p, _ := s.resolveTTSProvider(TTSRequest{APIKey: "k"}); p != nil {
+		t.Fatalf("provider = %v, want nil when no TTS provider is configured", p)
+	}
+}

--- a/internal/events/data.go
+++ b/internal/events/data.go
@@ -339,6 +339,10 @@ type TTSErrorData struct {
 	LegRoomScope
 	TTSID string `json:"tts_id"`
 	Error string `json:"error"`
+	// Category is the tts.Category the failure was classified as. Always
+	// set — no omitempty — so a path that forgets it emits a loud "" rather
+	// than a silently absent key. The value set is open.
+	Category string `json:"category"`
 }
 
 // --- Recording ---

--- a/internal/tts/retry.go
+++ b/internal/tts/retry.go
@@ -1,0 +1,120 @@
+package tts
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"regexp"
+	"strconv"
+)
+
+// Category classifies a synthesis failure so callers can tell a permanent
+// misconfiguration apart from a transient upstream blip. It is published on
+// the tts.error event, and the value set is open: consumers must treat an
+// unrecognised value as "unknown" rather than rejecting the event.
+type Category string
+
+const (
+	// CategoryPermanentAuth is a rejected or missing credential (401, 403).
+	CategoryPermanentAuth Category = "permanent_auth"
+	// CategoryPermanentInput is a request the upstream will never accept
+	// (400, 404, 422) — a bad voice name, malformed text, wrong model.
+	CategoryPermanentInput Category = "permanent_input"
+	// CategoryRateLimited is a 429.
+	CategoryRateLimited Category = "rate_limited"
+	// CategoryServiceUnavailable is an upstream 5xx.
+	CategoryServiceUnavailable Category = "service_unavailable"
+	// CategoryRetryable is a transient failure that is neither a 429 nor a
+	// 5xx: a request timeout (408), a deadline, a transport error.
+	CategoryRetryable Category = "retryable"
+	// CategoryCanceled means the caller went away — the leg or room context
+	// was cancelled. Terminal: there is nobody left to hear the audio.
+	CategoryCanceled Category = "canceled"
+	// CategoryUnknown is a failure with no status and no recognised transport
+	// shape: SDK errors from AWS Polly and Google, and the providers' own
+	// "no API key provided" guards.
+	CategoryUnknown Category = "unknown"
+	// CategoryPlayback is set by the API layer for failures raised after
+	// synthesis succeeded, while streaming the audio to the leg or room
+	// (internal/api/tts.go, the two playback-error publish sites). Categorize
+	// never returns it.
+	CategoryPlayback Category = "playback"
+)
+
+// retryable reports whether re-issuing the identical request could plausibly
+// succeed.
+//
+// CategoryUnknown is deliberately NOT retryable, diverging from the
+// ai-runtime categorizer this was ported from. Two reasons: aws-sdk-go-v2
+// already retries 3 times internally (config.LoadDefaultConfig installs the
+// standard retryer used by internal/tts/aws.go), so a second loop around it
+// would mean up to 9 upstream calls; and the unknown set is dominated by
+// misconfiguration — a missing API key, an unparseable credential, a failed
+// client construction — which no number of retries can fix.
+func (c Category) retryable() bool {
+	switch c {
+	case CategoryRetryable, CategoryRateLimited, CategoryServiceUnavailable:
+		return true
+	default:
+		return false
+	}
+}
+
+// ttsStatusRe extracts the HTTP status from the error strings the three HTTP
+// providers build: "elevenlabs: status %d: %s", "deepgram: status %d: %s" and
+// "azure: status %d: body=%q ...". Only the FIRST match is used, because the
+// azure shape embeds up to 2048 bytes of the response body after the real
+// status and that body can itself contain a "status NNN" token.
+var ttsStatusRe = regexp.MustCompile(`status (\d{3})`)
+
+// Categorize classifies a Synthesize error. It returns "" for a nil error.
+//
+// The order is load-bearing. context.Canceled and context.DeadlineExceeded are
+// checked before the transport arms because http.Client.Do returns a
+// *url.Error wrapping the context error on cancellation, and every provider
+// wraps that with %w — so checking *url.Error first would classify a hung-up
+// caller as a retryable transport blip and keep calling the upstream.
+func Categorize(err error) Category {
+	if err == nil {
+		return ""
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return CategoryCanceled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return CategoryRetryable
+	}
+
+	if m := ttsStatusRe.FindStringSubmatch(err.Error()); m != nil {
+		if code, convErr := strconv.Atoi(m[1]); convErr == nil {
+			switch code {
+			case 401, 403:
+				return CategoryPermanentAuth
+			case 400, 404, 422:
+				return CategoryPermanentInput
+			case 408:
+				return CategoryRetryable
+			case 429:
+				return CategoryRateLimited
+			case 500, 502, 503, 504:
+				return CategoryServiceUnavailable
+			default:
+				return CategoryUnknown
+			}
+		}
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return CategoryRetryable
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return CategoryRetryable
+	}
+
+	return CategoryUnknown
+}

--- a/internal/tts/retry.go
+++ b/internal/tts/retry.go
@@ -3,10 +3,13 @@ package tts
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"regexp"
 	"strconv"
+	"time"
 )
 
 // Category classifies a synthesis failure so callers can tell a permanent
@@ -117,4 +120,130 @@ func Categorize(err error) Category {
 	}
 
 	return CategoryUnknown
+}
+
+// Retry policy. Deliberately constants rather than configuration: the numbers
+// are bounded by ttsRetryMaxElapsed, so there is nothing an operator would
+// need to tune without also changing the code that consumes them.
+const (
+	ttsRetryMaxAttempts = 3
+	// ttsRetryBaseInterval is the pre-jitter delay before the second attempt.
+	ttsRetryBaseInterval = 100 * time.Millisecond
+	ttsRetryMultiplier   = 4
+	// ttsRetryMaxInterval is the PRE-JITTER ceiling on a single delay; jitter
+	// is applied afterwards, so the effective maximum is 25% higher.
+	ttsRetryMaxInterval = 1600 * time.Millisecond
+	// ttsRetryJitterFraction spreads each delay over ±25% so concurrent legs
+	// failing on the same upstream blip do not retry in lockstep.
+	ttsRetryJitterFraction = 0.25
+	// ttsRetryMaxElapsed bounds the whole loop, not one delay: once the next
+	// delay would push past it, the last error is returned instead.
+	ttsRetryMaxElapsed = 5 * time.Second
+)
+
+// retryDelay returns the jittered backoff before the attempt following the
+// given zero-based attempt index.
+//
+// The exponent is applied by repeated multiplication with an early clamp
+// rather than math.Pow, so a large attempt index can neither overflow int64
+// nor produce an absurd duration.
+func retryDelay(attempt int, base, maxInterval time.Duration) time.Duration {
+	d := base
+	for i := 0; i < attempt; i++ {
+		if d > maxInterval/ttsRetryMultiplier {
+			d = maxInterval
+			break
+		}
+		d *= ttsRetryMultiplier
+	}
+	jitter := (rand.Float64()*2 - 1) * ttsRetryJitterFraction
+	return time.Duration(float64(d) * (1 + jitter))
+}
+
+// retryingProvider re-issues a failed Synthesize when the failure looks
+// transient. It is immutable after construction and spawns no goroutines, so
+// it adds no synchronization and nothing to leak.
+//
+// Retrying a whole Synthesize is safe for every provider in this package:
+//
+//   - All three HTTP providers check resp.StatusCode BEFORE handing resp.Body
+//     back as Result.Audio (elevenlabs.go:71 vs :77-80, azure.go:77 vs
+//     :101-104, deepgram.go:67 vs :73-76), so a non-nil error guarantees that
+//     zero audio bytes ever reached the caller.
+//   - Each provider builds a fresh request from an in-memory body on every
+//     call (elevenlabs.go:57 bytes.NewReader, azure.go:53 strings.NewReader,
+//     deepgram.go:53 bytes.NewReader), so there is no consumed reader to
+//     rewind between attempts.
+type retryingProvider struct {
+	inner       Provider
+	name        string
+	log         *slog.Logger
+	maxAttempts int
+	base        time.Duration
+	maxInterval time.Duration
+	maxElapsed  time.Duration
+}
+
+// NewRetrying wraps inner so transient synthesis failures are retried under
+// the package retry policy. name is the provider name, used only for logging.
+func NewRetrying(inner Provider, name string, log *slog.Logger) Provider {
+	return &retryingProvider{
+		inner:       inner,
+		name:        name,
+		log:         log,
+		maxAttempts: ttsRetryMaxAttempts,
+		base:        ttsRetryBaseInterval,
+		maxInterval: ttsRetryMaxInterval,
+		maxElapsed:  ttsRetryMaxElapsed,
+	}
+}
+
+// Synthesize calls the wrapped provider, retrying transient failures.
+//
+// On success the inner *Result is returned unchanged, so the audio stream is
+// never copied or re-wrapped. On failure the last attempt's error is returned
+// by identity — not reformatted — so errors.Is, errors.As and any status
+// substring a caller matches on all survive the decorator.
+func (r *retryingProvider) Synthesize(ctx context.Context, text string, opts Options) (*Result, error) {
+	deadline := time.Now().Add(r.maxElapsed)
+	var lastErr error
+
+	for attempt := 0; ; attempt++ {
+		res, err := r.inner.Synthesize(ctx, text, opts)
+		if err == nil {
+			return res, nil
+		}
+		lastErr = err
+
+		cat := Categorize(err)
+		if !cat.retryable() || attempt >= r.maxAttempts-1 {
+			break
+		}
+
+		d := retryDelay(attempt, r.base, r.maxInterval)
+		if time.Now().Add(d).After(deadline) {
+			break
+		}
+
+		r.log.Warn("tts synthesis retry",
+			"provider", r.name,
+			"attempt", attempt+1,
+			"category", string(cat),
+			"delay", d,
+			"error", err,
+		)
+
+		t := time.NewTimer(d)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			// The context error is the actual reason the loop stopped, and
+			// it categorizes as "canceled" — more useful to the caller than
+			// the upstream failure that triggered the backoff.
+			return nil, ctx.Err()
+		case <-t.C:
+		}
+	}
+
+	return nil, lastErr
 }

--- a/internal/tts/retry_test.go
+++ b/internal/tts/retry_test.go
@@ -1,0 +1,98 @@
+package tts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"testing"
+)
+
+// fakeTimeout is a net.Error reporting a timeout, standing in for the
+// transport errors http.Client.Do surfaces on a stalled connection.
+type fakeTimeout struct{}
+
+func (fakeTimeout) Error() string { return "i/o timeout" }
+func (fakeTimeout) Timeout() bool { return true }
+func (fakeTimeout) Temporary() bool {
+	return true
+}
+
+var _ net.Error = fakeTimeout{}
+
+func TestCategorize(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want Category
+	}{
+		{"nil", nil, ""},
+		{"rate limited", errors.New("elevenlabs: status 429: rate limited"), CategoryRateLimited},
+		{"service unavailable", errors.New("deepgram: status 503: down"), CategoryServiceUnavailable},
+		{
+			// The azure error embeds the response body after the real status.
+			// A categorizer taking the LAST match would read 503 out of the
+			// body and retry a rejected credential.
+			"azure auth with a status token inside the body",
+			fmt.Errorf("azure: status 401: body=%q ms-error-code=%q ms-error-message=%q",
+				`{"detail":"status 503 upstream"}`, "", ""),
+			CategoryPermanentAuth,
+		},
+		{"bad request", errors.New("elevenlabs: status 400: bad"), CategoryPermanentInput},
+		{"unprocessable", errors.New("elevenlabs: status 422: unprocessable"), CategoryPermanentInput},
+		{"not found", errors.New("elevenlabs: status 404: voice not found"), CategoryPermanentInput},
+		{"request timeout", errors.New("deepgram: status 408: too slow"), CategoryRetryable},
+		{"unmapped status", errors.New("elevenlabs: status 418: teapot"), CategoryUnknown},
+		{
+			"cancelled through url.Error",
+			fmt.Errorf("elevenlabs request: %w", &url.Error{
+				Op: "Post", URL: "http://x", Err: context.Canceled,
+			}),
+			CategoryCanceled,
+		},
+		{"deadline exceeded", fmt.Errorf("azure request: %w", context.DeadlineExceeded), CategoryRetryable},
+		{
+			"transport timeout",
+			fmt.Errorf("deepgram request: %w", &url.Error{Op: "Post", URL: "http://x", Err: fakeTimeout{}}),
+			CategoryRetryable,
+		},
+		{
+			"transport refused",
+			fmt.Errorf("elevenlabs request: %w", &url.Error{
+				Op: "Post", URL: "http://x", Err: errors.New("connection refused"),
+			}),
+			CategoryRetryable,
+		},
+		{"polly sdk error", fmt.Errorf("polly: synthesize: %w", errors.New("AccessDenied")), CategoryUnknown},
+		{"missing api key", errors.New("elevenlabs: no API key provided"), CategoryUnknown},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Categorize(tc.err); got != tc.want {
+				t.Fatalf("Categorize(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCategoryRetryable pins the retryable set, including the deliberate
+// divergence from ai-runtime: unknown is NOT retryable.
+func TestCategoryRetryable(t *testing.T) {
+	retryable := []Category{CategoryRetryable, CategoryRateLimited, CategoryServiceUnavailable}
+	terminal := []Category{
+		CategoryPermanentAuth, CategoryPermanentInput, CategoryCanceled,
+		CategoryUnknown, CategoryPlayback, Category(""),
+	}
+	for _, c := range retryable {
+		if !c.retryable() {
+			t.Errorf("%q.retryable() = false, want true", c)
+		}
+	}
+	for _, c := range terminal {
+		if c.retryable() {
+			t.Errorf("%q.retryable() = true, want false", c)
+		}
+	}
+}

--- a/internal/tts/retry_test.go
+++ b/internal/tts/retry_test.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"net"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 )
 
 // fakeTimeout is a net.Error reporting a timeout, standing in for the
@@ -94,5 +98,232 @@ func TestCategoryRetryable(t *testing.T) {
 		if c.retryable() {
 			t.Errorf("%q.retryable() = true, want false", c)
 		}
+	}
+}
+
+// fakeProvider returns a scripted sequence of results, then repeats the last
+// entry. It is only ever driven from a single goroutine — the decorator
+// spawns none — so a plain counter is enough.
+type fakeProvider struct {
+	calls   int
+	results []*Result
+	errs    []error
+}
+
+func (f *fakeProvider) Synthesize(ctx context.Context, text string, opts Options) (*Result, error) {
+	i := f.calls
+	f.calls++
+	if i >= len(f.errs) {
+		i = len(f.errs) - 1
+	}
+	var res *Result
+	if i < len(f.results) {
+		res = f.results[i]
+	}
+	return res, f.errs[i]
+}
+
+// fastRetrying builds a decorator with the production attempt cap but
+// millisecond delays, so the real timer and select code path runs without
+// costing the suite half a second.
+func fastRetrying(inner Provider) *retryingProvider {
+	return &retryingProvider{
+		inner:       inner,
+		name:        "t",
+		log:         slog.Default(),
+		maxAttempts: ttsRetryMaxAttempts,
+		base:        time.Millisecond,
+		maxInterval: 2 * time.Millisecond,
+		maxElapsed:  ttsRetryMaxElapsed,
+	}
+}
+
+func TestRetrying_RetriesTransientThenSucceeds(t *testing.T) {
+	want := &Result{Audio: io.NopCloser(strings.NewReader("pcm")), MimeType: "audio/pcm;rate=16000"}
+	fake := &fakeProvider{
+		results: []*Result{nil, nil, want},
+		errs: []error{
+			errors.New("elevenlabs: status 503: unavailable"),
+			errors.New("elevenlabs: status 503: unavailable"),
+			nil,
+		},
+	}
+	r := fastRetrying(fake)
+
+	got, err := r.Synthesize(context.Background(), "hi", Options{})
+	if err != nil {
+		t.Fatalf("Synthesize: unexpected error %v", err)
+	}
+	if fake.calls != 3 {
+		t.Fatalf("inner calls = %d, want 3", fake.calls)
+	}
+	if got != want {
+		t.Fatalf("Result = %p, want the inner Result %p returned by identity", got, want)
+	}
+}
+
+var errFake401 = errors.New(`azure: status 401: body="invalid key"`)
+
+func TestRetrying_PermanentAuthNotRetried(t *testing.T) {
+	fake := &fakeProvider{errs: []error{errFake401}}
+	r := fastRetrying(fake)
+
+	_, err := r.Synthesize(context.Background(), "hi", Options{})
+	if fake.calls != 1 {
+		t.Fatalf("inner calls = %d, want 1 — a 401 must not be retried", fake.calls)
+	}
+	// errors.Is, not a substring match: a decorator that reformatted the
+	// error with %v would still carry "401" in its message, so a substring
+	// assertion could not tell wrapping from passthrough.
+	if !errors.Is(err, errFake401) {
+		t.Fatalf("error = %v, want the inner error returned by identity", err)
+	}
+}
+
+func TestRetrying_ExhaustsAndReturnsLastError(t *testing.T) {
+	// Retryable-shaped sentinels: an unclassifiable error is terminal, so
+	// plain errors.New would stop the loop after one attempt and prove
+	// nothing about the cap.
+	err1 := errors.New("elevenlabs: status 503: down #1")
+	err2 := errors.New("elevenlabs: status 503: down #2")
+	err3 := errors.New("elevenlabs: status 503: down #3")
+	err4 := errors.New("elevenlabs: status 503: down #4")
+	fake := &fakeProvider{errs: []error{err1, err2, err3, err4}}
+	r := fastRetrying(fake)
+
+	_, err := r.Synthesize(context.Background(), "hi", Options{})
+	if fake.calls != ttsRetryMaxAttempts {
+		t.Fatalf("inner calls = %d, want %d", fake.calls, ttsRetryMaxAttempts)
+	}
+	if !errors.Is(err, err3) {
+		t.Fatalf("error = %v, want the last attempt's error (%v)", err, err3)
+	}
+}
+
+func TestRetrying_ContextCancelAbortsBackoff(t *testing.T) {
+	fake := &fakeProvider{errs: []error{errors.New("elevenlabs: status 503: down")}}
+	r := &retryingProvider{
+		inner:       fake,
+		name:        "t",
+		log:         slog.Default(),
+		maxAttempts: ttsRetryMaxAttempts,
+		base:        2 * time.Second,
+		maxInterval: 2 * time.Second,
+		maxElapsed:  time.Minute,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := r.Synthesize(ctx, "hi", Options{})
+	elapsed := time.Since(start)
+
+	// The elapsed bound is the assertion that fails fast: a backoff that
+	// slept unconditionally would take seconds to trip the other two.
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("Synthesize took %v, want the backoff to abort on ctx cancel", elapsed)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if fake.calls != 1 {
+		t.Fatalf("inner calls = %d, want 1 — no attempt after cancellation", fake.calls)
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	// Attempt 10 is in the table on purpose: with ttsRetryMaxAttempts = 3 the
+	// runtime only ever asks for attempts 0 and 1, where the ceiling never
+	// binds, so a band assertion over the live attempts alone would stay
+	// green with the clamp deleted.
+	for _, attempt := range []int{0, 1, 3, 10} {
+		want := ttsRetryBaseInterval
+		for i := 0; i < attempt; i++ {
+			want *= ttsRetryMultiplier
+			if want > ttsRetryMaxInterval {
+				want = ttsRetryMaxInterval
+				break
+			}
+		}
+		// The ±25% band is written out rather than derived from
+		// ttsRetryJitterFraction: a band computed from the constant widens
+		// with it, so changing the constant could not fail this test.
+		lo := want * 3 / 4
+		hi := want * 5 / 4
+
+		seen := make(map[time.Duration]struct{})
+		for i := 0; i < 200; i++ {
+			d := retryDelay(attempt, ttsRetryBaseInterval, ttsRetryMaxInterval)
+			if d < lo || d > hi {
+				t.Fatalf("retryDelay(%d) = %v, want within [%v, %v]", attempt, d, lo, hi)
+			}
+			seen[d] = struct{}{}
+		}
+		if len(seen) < 2 {
+			t.Fatalf("retryDelay(%d) produced %d distinct value(s) over 200 samples, want jitter", attempt, len(seen))
+		}
+	}
+}
+
+func TestRetrying_MaxElapsedStopsRetrying(t *testing.T) {
+	sentinel := errors.New("elevenlabs: status 503: down")
+	fake := &fakeProvider{errs: []error{sentinel}}
+	r := &retryingProvider{
+		inner:       fake,
+		name:        "t",
+		log:         slog.Default(),
+		maxAttempts: ttsRetryMaxAttempts,
+		base:        time.Second,
+		maxInterval: time.Second,
+		maxElapsed:  time.Nanosecond,
+	}
+
+	start := time.Now()
+	_, err := r.Synthesize(context.Background(), "hi", Options{})
+	elapsed := time.Since(start)
+
+	if fake.calls != 1 {
+		t.Fatalf("inner calls = %d, want 1 — the elapsed ceiling must stop the loop", fake.calls)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want %v", err, sentinel)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Fatalf("Synthesize took %v, want it to break out rather than sleep", elapsed)
+	}
+}
+
+// TestNewRetryingUsesPolicyConstants guards the constructor: every other test
+// builds the struct literal directly, so a wiring typo in NewRetrying would
+// disable retry in production with the whole package still green.
+func TestNewRetryingUsesPolicyConstants(t *testing.T) {
+	fake := &fakeProvider{errs: []error{nil}}
+	p := NewRetrying(fake, "t", slog.Default())
+
+	r, ok := p.(*retryingProvider)
+	if !ok {
+		t.Fatalf("NewRetrying returned %T, want *retryingProvider", p)
+	}
+	if r.inner != Provider(fake) {
+		t.Errorf("inner = %v, want the wrapped provider", r.inner)
+	}
+	if r.name != "t" {
+		t.Errorf("name = %q, want %q", r.name, "t")
+	}
+	if r.maxAttempts != ttsRetryMaxAttempts {
+		t.Errorf("maxAttempts = %d, want %d", r.maxAttempts, ttsRetryMaxAttempts)
+	}
+	if r.base != ttsRetryBaseInterval {
+		t.Errorf("base = %v, want %v", r.base, ttsRetryBaseInterval)
+	}
+	if r.maxInterval != ttsRetryMaxInterval {
+		t.Errorf("maxInterval = %v, want %v", r.maxInterval, ttsRetryMaxInterval)
+	}
+	if r.maxElapsed != ttsRetryMaxElapsed {
+		t.Errorf("maxElapsed = %v, want %v", r.maxElapsed, ttsRetryMaxElapsed)
 	}
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4535,6 +4535,9 @@ x-webhooks:
                                     error:
                                         type: string
                                         description: Error message
+                                    category:
+                                        type: string
+                                        description: 'Failure category: permanent_auth, permanent_input, rate_limited, service_unavailable, retryable, canceled or unknown for a synthesis failure, playback for a failure while streaming the audio. New values may be added; treat an unrecognised value as unknown'
     recording.started:
         post:
             summary: Recording began


### PR DESCRIPTION
A TTS synthesis failure is final on the first attempt. Every provider makes one request and returns its error, and the synth goroutine in `internal/api/tts.go` turns that straight into a `tts.error` event.

So a 429 from the provider's rate limiter, or a 503 while it rolls a deployment, drops the prompt on a live call. These are exactly the failures that succeed on a retry a few hundred milliseconds later, and they are the common ones — a caller hears silence where the application expected speech.

## The change

A `retrying` decorator wrapping the provider. Failures are categorized by shape, and only transient categories are retried:

- retried: rate-limited, service-unavailable, and transport/timeout errors
- one-shot: 4xx that will fail identically on a retry (auth, bad request, unprocessable), and anything uncategorized

Uncategorized is deliberately **not** retried. An unknown failure is as likely to be a permanent misconfiguration as a blip, and retrying it triples the latency before the caller hears the failure.

**This means the retry currently covers three of the five providers**, and that limit is worth being explicit about. Categorization keys off the `status %d` error strings that the raw-HTTP providers build — elevenlabs, deepgram and azure — plus context errors, `net.Error` timeouts and `*url.Error`. AWS Polly and Google go through their SDKs and surface neither shape, so their failures categorize as unknown and are not retried. They are no worse off than today, but they do not get the fix. Extending it means matching on those SDKs' own error types, which I would rather do as a separate change than guess at here.

Backoff is hand-rolled, so no new dependency: exponential with jitter, capped on attempts, per-interval and total elapsed. Every sleep selects on the context, so a hung-up call abandons the retry immediately rather than holding the goroutine to the end of the schedule.

The decorator wraps **inside** the provider cache, so a cache hit does no synthesis and no retry.

`tts.error` gains a `category` field, so an operator can tell "the provider is rate-limiting us" from "our API key is wrong" without reading log text. `openapi.yaml` and `asyncapi.yaml` are regenerated via `cmd/openapi-gen` / `cmd/asyncapi-gen`, not hand-edited.

## Tests

Coverage for the categorizer per status class, for retry-vs-one-shot per category, for the backoff bounds and jitter band, for context cancellation mid-backoff, for exhaustion returning the last error with its status text preserved, and for the cache-hit path performing zero synthesis. All four `tts.error` publish sites are asserted to carry the category.

Every guard is mutation-proven. Two of the mutations originally specified turned out to be green lies and were replaced: the attempt cap was enforced in two places, so loosening one changed nothing, and the jitter-band assertion was computed from the same constant it was checking, so widening the constant widened the assertion with it.

`gofmt`, `go build ./...`, `CGO_ENABLED=0 go build ./...`, `go vet ./...` and `go test ./internal/...` are clean. `go test -race ./internal/...` is clean apart from the pre-existing `emiago/sipgo` v1.4.3 race in `internal/sip`, which reproduces on an untouched `master`.
