### PR TITLE
Let a DELETE drain in-flight leg playback before hanging up

### DIFF
--- a/API.md
+++ b/API.md
@@ -713,7 +713,9 @@ Undeafen a leg. Restores the participant's ability to hear other participants.
 
 | Field | Type | Description |
 |---|---|---|
-| `reason` | string (optional) | Disconnect reason. Honored only for **unanswered SIP inbound legs** (state `ringing` or `early_media`); on connected legs the body is ignored and the leg is hung up with the legacy `api_hangup` reason. The reason value flows through to `leg.disconnected`'s `cdr.reason` and selects the SIP final response sent to the caller. |
+| `reason` | string (optional) | Disconnect reason. Honored only for **unanswered SIP inbound legs** (state `ringing` or `early_media`); on connected legs this field is ignored and the leg is hung up with the legacy `api_hangup` reason. The reason value flows through to `leg.disconnected`'s `cdr.reason` and selects the SIP final response sent to the caller. |
+| `drain_playback` | bool (optional, default `false`) | Wait for playback and TTS already started **on this leg** to finish before sending BYE, so a farewell prompt is not cut off. See below. |
+| `drain_timeout_ms` | int (optional, default `5000`, max `30000`) | Upper bound on the `drain_playback` wait. Values at or above the maximum are clamped to it; `0` or omitted uses the default. |
 
 #### Reason → SIP final response (unanswered inbound only)
 
@@ -727,6 +729,23 @@ Undeafen a leg. Restores the participant's ability to hear other participants.
 | `server_error` | 500 Server Internal Error |
 
 Without a body, behavior is unchanged: BYE on connected legs (`cdr.reason: "api_hangup"`), or dialog cancel on unanswered inbound legs (`cdr.reason: "caller_cancel"`).
+
+#### Draining in-flight playback before hangup
+
+```json
+{ "drain_playback": true, "drain_timeout_ms": 8000 }
+```
+
+By default a DELETE cuts any prompt still playing on the leg. With `drain_playback` set, VoiceBlender waits for playback and TTS already started on that leg to finish before sending BYE — the "say goodbye, then hang up" pattern, without the app having to poll `playback.finished` itself.
+
+- **The 202 is unaffected.** The wait happens on the same background goroutine that already did the hangup, so `DELETE` still returns immediately. Only `leg.disconnected` (and any room recording finalisation that follows it) arrives later.
+- **It is bounded.** When `drain_timeout_ms` elapses the leg is hung up anyway and the cut utterance reports `reason: "stopped"`, exactly as it does today. The wait also ends early if the leg is torn down by something else in the meantime (RTP timeout, session expiry, remote BYE, max duration).
+- **A TTS utterance still being synthesized counts as outstanding** and is waited for — the utterance is registered on the leg before the provider is called.
+- **Scope.** Applies to legs in state `connected` or `early_media`. Ignored on held legs and on the reject path (supplying a `reason` for an unanswered inbound leg). Audio played to the **room** the leg is in is not waited for — only per-leg `POST /v1/legs/{id}/play` and `POST /v1/legs/{id}/tts`.
+- **The leg is unaddressable while draining.** It is claimed out of the leg manager before the wait starts, so `GET /v1/legs/{id}` and a second `DELETE` return 404 for the duration. `DELETE /v1/legs/{id}/play/{playbackID}` still works and is the abort handle: stopping the playback releases the drain immediately.
+- **`cdr.reason` can differ.** A real remote hangup arriving during the drain wins, and `leg.disconnected` then reports `remote_bye` rather than `api_hangup`.
+
+The same two fields exist on the VSI `delete_leg` command.
 
 **Response:** `202 Accepted`
 

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -5659,6 +5659,10 @@ components:
                     type: string
                 reason:
                     type: string
+                drain_playback:
+                    type: boolean
+                drain_timeout_ms:
+                    type: integer
             required:
                 - id
         deleteRegistrationPayload:

--- a/internal/api/leg_drain_test.go
+++ b/internal/api/leg_drain_test.go
@@ -1,0 +1,225 @@
+package api
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+	"github.com/VoiceBlender/voiceblender/internal/leg"
+	"github.com/VoiceBlender/voiceblender/internal/playback"
+)
+
+// seedLegPlayer registers a player for legID without ever starting it: the
+// drain's predicate is legPlayers membership, not audio actually flowing, so
+// these tests stay sub-second and never depend on the media path.
+func seedLegPlayer(t *testing.T, s *Server, legID, playbackID string) {
+	t.Helper()
+	clearLegPlayers(t, legID)
+	legPlayers.Lock()
+	if legPlayers.m[legID] == nil {
+		legPlayers.m[legID] = make(map[string]*playback.Player)
+	}
+	legPlayers.m[legID][playbackID] = playback.NewPlayer(s.Log)
+	legPlayers.Unlock()
+}
+
+// watchLegDisconnected returns a predicate reporting whether leg.disconnected
+// has been published for legID.
+func watchLegDisconnected(s *Server, legID string) func() bool {
+	var mu sync.Mutex
+	seen := false
+	s.Bus.Subscribe(func(e events.Event) {
+		if e.Type != events.LegDisconnected {
+			return
+		}
+		d, ok := e.Data.(*events.LegDisconnectedData)
+		if !ok || d.LegID != legID {
+			return
+		}
+		mu.Lock()
+		seen = true
+		mu.Unlock()
+	})
+	return func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return seen
+	}
+}
+
+func waitFor(t *testing.T, d time.Duration, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for %s", d, what)
+}
+
+// TestDoDeleteLeg_DrainWaitsForOutstandingPlayback is the feature: with
+// drain_playback set, neither the BYE nor leg.disconnected happens while an
+// utterance is still outstanding, and both happen once it deregisters.
+func TestDoDeleteLeg_DrainWaitsForOutstandingPlayback(t *testing.T) {
+	s := newTestServer(t)
+	const legID = "leg-drain-waits"
+
+	disconnected := watchLegDisconnected(s, legID)
+	l := &apiMockLeg{id: legID, createdAt: time.Now()}
+	s.LegMgr.Add(l)
+	seedLegPlayer(t, s, legID, "pb-outstanding")
+
+	if err := s.doDeleteLeg(legID, "", true, 2000); err != nil {
+		t.Fatalf("doDeleteLeg: %v", err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	if disconnected() {
+		t.Error("leg.disconnected published while playback was still outstanding")
+	}
+	if n := l.hangups.Load(); n != 0 {
+		t.Errorf("Hangup called %d time(s) during the drain, want 0", n)
+	}
+
+	deregisterLegPlayer(legID, "pb-outstanding")
+	waitFor(t, time.Second, disconnected, "leg.disconnected once the playback deregistered")
+}
+
+// TestDoDeleteLeg_DrainExpiryReleasesTeardown pins the bound: a player that
+// never deregisters, on a leg whose context is never cancelled, still gets torn
+// down once the budget elapses.
+func TestDoDeleteLeg_DrainExpiryReleasesTeardown(t *testing.T) {
+	s := newTestServer(t)
+	const legID = "leg-drain-expiry"
+
+	disconnected := watchLegDisconnected(s, legID)
+	l := &apiMockLeg{id: legID, createdAt: time.Now()}
+	s.LegMgr.Add(l)
+	seedLegPlayer(t, s, legID, "pb-stuck")
+
+	if err := s.doDeleteLeg(legID, "", true, 200); err != nil {
+		t.Fatalf("doDeleteLeg: %v", err)
+	}
+
+	waitFor(t, 2*time.Second, disconnected, "leg.disconnected after the drain budget expired")
+}
+
+// TestDoDeleteLeg_NoDrainWithoutOptIn is the behaviour-preservation guard: a
+// DELETE that does not ask for a drain must tear down immediately even with an
+// utterance outstanding, exactly as it does today.
+func TestDoDeleteLeg_NoDrainWithoutOptIn(t *testing.T) {
+	s := newTestServer(t)
+	const legID = "leg-no-drain"
+
+	disconnected := watchLegDisconnected(s, legID)
+	l := &apiMockLeg{id: legID, createdAt: time.Now()}
+	s.LegMgr.Add(l)
+	seedLegPlayer(t, s, legID, "pb-ignored")
+
+	if err := s.doDeleteLeg(legID, "", false, 0); err != nil {
+		t.Fatalf("doDeleteLeg: %v", err)
+	}
+
+	waitFor(t, time.Second, disconnected, "leg.disconnected without a drain opt-in")
+}
+
+// TestDrainLegPlayback_AbortsOnLegContextCancel proves the wait ends as soon as
+// the leg context is cancelled — which is what happens when a competing
+// teardown path reaches Hangup first — rather than burning the whole budget.
+func TestDrainLegPlayback_AbortsOnLegContextCancel(t *testing.T) {
+	s := newTestServer(t)
+	const legID = "leg-drain-cancel"
+	seedLegPlayer(t, s, legID, "pb-stuck")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan bool, 1)
+	go func() {
+		// The budget is far outside the assertion window, so the timer arm
+		// cannot stand in for the missing context arm.
+		done <- drainLegPlayback(ctx, legID, 30*time.Second)
+	}()
+
+	time.AfterFunc(50*time.Millisecond, cancel)
+	select {
+	case drained := <-done:
+		if drained {
+			t.Error("drainLegPlayback reported a drain after its context was cancelled")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("drainLegPlayback did not return after the leg context was cancelled")
+	}
+}
+
+// TestDrainLegPlayback_FastPathsWhenIdle guards the common case: a leg with
+// nothing outstanding must not wait at all.
+func TestDrainLegPlayback_FastPathsWhenIdle(t *testing.T) {
+	// A zero budget isolates the fast path from the first poll tick: without a
+	// fast path the timer fires before the 10ms tick, and an idle leg would be
+	// reported as having failed to drain.
+	if !drainLegPlayback(context.Background(), "leg-never-played", 0) {
+		t.Error("drainLegPlayback reported no drain for an idle leg on a zero budget")
+	}
+
+	start := time.Now()
+	if !drainLegPlayback(context.Background(), "leg-never-played", time.Minute) {
+		t.Error("drainLegPlayback reported no drain for a leg with no playback")
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("idle leg took %s to drain, want an immediate return", elapsed)
+	}
+}
+
+// TestDrainBudget_DefaultAndClamp checks normalisation at every boundary.
+//
+// The expectations are bare literals on purpose: referencing
+// defaultDrainTimeout/maxDrainTimeout would make the table move with the
+// constants and stop detecting a change to them.
+func TestDrainBudget_DefaultAndClamp(t *testing.T) {
+	tests := []struct {
+		name string
+		ms   int
+		want time.Duration
+	}{
+		{"omitted", 0, 5 * time.Second},
+		{"negative", -1, 5 * time.Second},
+		{"explicit", 250, 250 * time.Millisecond},
+		{"just under the ceiling", 29999, 29999 * time.Millisecond},
+		{"exactly the ceiling", 30000, 30 * time.Second},
+		{"over the ceiling", 30001, 30 * time.Second},
+		// Clamping must happen on the millisecond count: converting first
+		// overflows int64 into a duration of 0 (or a negative one), which
+		// would fire the timer instantly and silently disable the drain.
+		{"overflowing", 1 << 62, 30 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := drainBudget(tt.ms); got != tt.want {
+				t.Errorf("drainBudget(%d) = %s, want %s", tt.ms, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDrainablePlaybackState(t *testing.T) {
+	tests := []struct {
+		state leg.LegState
+		want  bool
+	}{
+		{leg.StateConnected, true},
+		{leg.StateEarlyMedia, true},
+		{leg.StateHeld, false},
+		{leg.StateRinging, false},
+		{leg.StateHungUp, false},
+	}
+	for _, tt := range tests {
+		if got := drainablePlaybackState(tt.state); got != tt.want {
+			t.Errorf("drainablePlaybackState(%q) = %v, want %v", tt.state, got, tt.want)
+		}
+	}
+}

--- a/internal/api/legs.go
+++ b/internal/api/legs.go
@@ -652,7 +652,48 @@ func rejectionMapping(reason string) (code int, phrase string, ok bool) {
 	return 0, "", false
 }
 
-func (s *Server) doDeleteLeg(id string, reason string) error {
+const (
+	// defaultDrainTimeout applies when drain_playback is set without an
+	// explicit drain_timeout_ms.
+	defaultDrainTimeout = 5 * time.Second
+	// maxDrainTimeout caps how long a client can keep a leg alive after
+	// asking for its teardown.
+	maxDrainTimeout = 30 * time.Second
+)
+
+// drainBudget normalises a client-supplied drain_timeout_ms.
+//
+// The clamp is applied to the millisecond count BEFORE converting to a
+// Duration: multiplying first would let a large integer overflow int64 into a
+// negative duration, which fires the timer immediately and silently disables
+// the drain for a client who asked for a long one.
+func drainBudget(ms int) time.Duration {
+	if ms <= 0 {
+		return defaultDrainTimeout
+	}
+	if ms >= maxDrainTimeoutMillis {
+		return maxDrainTimeout
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// The two budgets expressed the way the wire field is, so the clamp, the
+// default and the published schema constraints cannot drift apart.
+const (
+	defaultDrainTimeoutMillis = int(defaultDrainTimeout / time.Millisecond)
+	maxDrainTimeoutMillis     = int(maxDrainTimeout / time.Millisecond)
+)
+
+// drainablePlaybackState reports whether a leg in this state can have direct
+// playback worth waiting for. Early media qualifies: doStartLegPlay's only
+// precondition is a non-nil AudioWriter, which SIPLeg provides before answer,
+// so pre-answer announcements are real. Held does not: the audio is not heard,
+// so waiting for it would only stall the teardown.
+func drainablePlaybackState(st leg.LegState) bool {
+	return st == leg.StateConnected || st == leg.StateEarlyMedia
+}
+
+func (s *Server) doDeleteLeg(id string, reason string, drain bool, drainTimeoutMs int) error {
 	// Validate reason early so a malformed request never claims the leg.
 	var (
 		rejectCode   int
@@ -705,6 +746,20 @@ func (s *Server) doDeleteLeg(id string, reason string) error {
 	}
 
 	go func() {
+		// Bounded wait for outstanding playback/TTS, INSIDE the detached
+		// goroutine — deleteLeg writes its 202 outside it, so the endpoint
+		// still returns immediately and only the timing of leg.disconnected
+		// moves. Do not hoist this above the `go func()`.
+		//
+		// The result is deliberately discarded: an expired budget is not an
+		// error, teardown proceeds either way and the truncated player reports
+		// reason "stopped" exactly as it does today. The wait also ends early
+		// if the leg context is cancelled, which happens once any competing
+		// teardown path (RTP timeout, session expiry, remote BYE, max duration,
+		// caller cancel) reaches Hangup.
+		if drain && drainablePlaybackState(l.State()) {
+			_ = drainLegPlayback(l.Context(), l.ID(), drainBudget(drainTimeoutMs))
+		}
 		if err := l.Hangup(context.Background()); err != nil {
 			s.Log.Warn("hangup error", "leg_id", l.ID(), "error", err)
 		}
@@ -723,7 +778,7 @@ func (s *Server) deleteLeg(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := s.doDeleteLeg(id, req.Reason); err != nil {
+	if err := s.doDeleteLeg(id, req.Reason, req.DrainPlayback, req.DrainTimeoutMs); err != nil {
 		handleAPIError(w, err)
 		return
 	}

--- a/internal/api/openapi_meta.go
+++ b/internal/api/openapi_meta.go
@@ -385,7 +385,14 @@ func RoutesMetadata() []RouteMeta {
 				"VoiceBlender sends a final non-2xx response instead of BYE/cancel: `busy`→486, `declined`/`rejected`→" +
 				"603, `unavailable`→480, `not_found`→404, `forbidden`→403, `server_error`→500. The reason value is " +
 				"passed through to `leg.disconnected`'s `cdr.reason`.\n\n" +
-				"For connected legs the request body is ignored.",
+				"On connected legs the `reason` field is ignored. `drain_playback` and `drain_timeout_ms` are the " +
+				"opposite: they apply to legs in state `connected` or `early_media` that are being hung up, and are " +
+				"ignored on the reject path. With `drain_playback` set, VoiceBlender waits — in the background, so " +
+				"the 202 is unaffected — for playback and TTS already started on that leg to finish before sending " +
+				"BYE, up to `drain_timeout_ms`. When the bound expires the leg is hung up anyway and the cut " +
+				"utterance reports `reason: \"stopped\"`. While the drain runs the leg is already out of the " +
+				"manager, so `GET /v1/legs/{id}` and a second `DELETE` return 404; `DELETE " +
+				"/v1/legs/{id}/play/{playbackID}` still works and releases the drain immediately.",
 			Tags:         []string{"Legs"},
 			RequestType:  DeleteLegRequest{},
 			OptionalBody: true,

--- a/internal/api/playback.go
+++ b/internal/api/playback.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/VoiceBlender/voiceblender/internal/events"
 	"github.com/VoiceBlender/voiceblender/internal/leg"
@@ -54,6 +55,55 @@ func deregisterLegPlayer(legID, playbackID string) {
 	delete(legPlayers.m[legID], playbackID)
 	if len(legPlayers.m[legID]) == 0 {
 		delete(legPlayers.m, legID)
+	}
+}
+
+// drainPollInterval is how often drainLegPlayback re-checks legPlayers. Half a
+// 20ms ptime frame, so the extra latency it adds is inaudible. legPlayers is a
+// plain mutex-guarded map with no change signal, so a poll is the only option
+// short of adding one.
+const drainPollInterval = 10 * time.Millisecond
+
+// legHasPlayback reports whether legID has any playback or TTS outstanding.
+func legHasPlayback(legID string) bool {
+	legPlayers.Lock()
+	defer legPlayers.Unlock()
+	return len(legPlayers.m[legID]) > 0
+}
+
+// drainLegPlayback waits until legID has no playback or TTS outstanding,
+// returning true if it drained and false if the timeout or ctx won first.
+//
+// The predicate is legPlayers MEMBERSHIP, not Player.IsPlaying(). Membership is
+// established synchronously, before POST /play and POST /tts return 200, while
+// a player only reports itself as playing once the goroutine launched
+// afterwards actually starts writing. Gating on IsPlaying() would therefore
+// race a DELETE issued immediately after a 200, and for TTS it would be false
+// for the whole provider.Synthesize window — precisely the farewell-prompt case
+// this exists to serve. Membership is cleared on every terminal branch (see
+// deregisterLegPlayer's callers), so it cannot stick.
+//
+// Only per-leg audio counts. Audio played to the room the leg sits in lives in
+// roomPlayers and is not waited for — it is not this leg's property.
+func drainLegPlayback(ctx context.Context, legID string, timeout time.Duration) bool {
+	if !legHasPlayback(legID) {
+		return true
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(drainPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-timer.C:
+			return false
+		case <-ticker.C:
+			if !legHasPlayback(legID) {
+				return true
+			}
+		}
 	}
 }
 

--- a/internal/api/playback.go
+++ b/internal/api/playback.go
@@ -44,6 +44,19 @@ var (
 	}{m: make(map[string]map[string]*playback.Player)}
 )
 
+// deregisterLegPlayer removes a player from legPlayers, pruning the per-leg
+// map when it empties. Every path that registers a leg player MUST reach this
+// on every terminal branch — an entry left behind is a permanent leak for a
+// leg that is already gone.
+func deregisterLegPlayer(legID, playbackID string) {
+	legPlayers.Lock()
+	defer legPlayers.Unlock()
+	delete(legPlayers.m[legID], playbackID)
+	if len(legPlayers.m[legID]) == 0 {
+		delete(legPlayers.m, legID)
+	}
+}
+
 // PlaybackStartResult is the success payload for starting a playback on a
 // leg or room. The same shape is returned by leg_tts and room_tts (with
 // "tts_id" semantics).
@@ -115,6 +128,10 @@ func (s *Server) doStartLegPlay(legID string, req PlaybackRequest) (*PlaybackSta
 		if req.Tone != "" {
 			spec, ok := playback.LookupTone(req.Tone)
 			if !ok {
+				// Deregister before returning: this branch never reaches the
+				// deregistration below, and a stale entry would make the leg
+				// look like it has audio outstanding forever.
+				deregisterLegPlayer(legID, playbackID)
 				s.Bus.Publish(events.PlaybackError, &events.PlaybackErrorData{
 					LegRoomScope: events.LegRoomScope{LegID: legID, AppID: appID},
 					PlaybackID:   playbackID,
@@ -127,12 +144,7 @@ func (s *Server) doStartLegPlay(legID string, req PlaybackRequest) (*PlaybackSta
 		} else {
 			err = player.PlayAtRate(l.Context(), writer, req.URL, req.MimeType, playRate, req.Repeat)
 		}
-		legPlayers.Lock()
-		delete(legPlayers.m[legID], playbackID)
-		if len(legPlayers.m[legID]) == 0 {
-			delete(legPlayers.m, legID)
-		}
-		legPlayers.Unlock()
+		deregisterLegPlayer(legID, playbackID)
 		if err != nil && err != context.Canceled {
 			s.Bus.Publish(events.PlaybackError, &events.PlaybackErrorData{
 				LegRoomScope: events.LegRoomScope{LegID: legID, AppID: appID},

--- a/internal/api/playback_registry_test.go
+++ b/internal/api/playback_registry_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+// clearLegPlayers registers a cleanup that drops every player registered for
+// legID. legPlayers is a package-level global, so a test that seeds it must
+// clean up or it leaks into every other test in the package.
+func clearLegPlayers(t *testing.T, legID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		legPlayers.Lock()
+		delete(legPlayers.m, legID)
+		legPlayers.Unlock()
+	})
+}
+
+func legPlayerCount(legID string) int {
+	legPlayers.Lock()
+	defer legPlayers.Unlock()
+	return len(legPlayers.m[legID])
+}
+
+// TestStartLegPlay_UnknownToneDeregistersPlayer pins the invariant that every
+// terminal branch of the playback goroutine clears its legPlayers entry. The
+// unknown-tone branch returns early, before the normal deregistration, so
+// without an explicit deregister the entry survives forever — a permanent leak
+// for a leg that is already gone, and a stall for anything that waits on the
+// leg having no audio outstanding.
+func TestStartLegPlay_UnknownToneDeregistersPlayer(t *testing.T) {
+	s := newTestServer(t)
+	const legID = "leg-bad-tone"
+	clearLegPlayers(t, legID)
+
+	l := &apiMockLeg{id: legID, createdAt: time.Now(), audioWriter: io.Discard}
+	s.LegMgr.Add(l)
+
+	res, err := s.doStartLegPlay(legID, PlaybackRequest{Tone: "definitely-not-a-tone"})
+	if err != nil {
+		t.Fatalf("doStartLegPlay: %v", err)
+	}
+	if res.PlaybackID == "" {
+		t.Fatal("no playback id returned")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if legPlayerCount(legID) == 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("unknown tone left %d player(s) registered for %s", legPlayerCount(legID), legID)
+}

--- a/internal/api/rooms_test.go
+++ b/internal/api/rooms_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 // apiMockLeg implements leg.Leg for addLegToRoom tests.
+//
+// Every optional field is zero-value compatible with the original mock:
+// an unset state reports connected, an unset ctx reports a background
+// context, and an unset audioWriter reports no writer.
 type apiMockLeg struct {
 	id             string
 	muted          bool
@@ -21,19 +25,40 @@ type apiMockLeg struct {
 	role           string
 	createdAt      time.Time
 	disconnectDone atomic.Bool
+
+	state       leg.LegState // "" → StateConnected
+	ctx         context.Context
+	audioWriter io.Writer
+	hangups     atomic.Int32
 }
 
 func (m *apiMockLeg) ID() string                             { return m.id }
 func (m *apiMockLeg) Type() leg.LegType                      { return leg.TypeSIPInbound }
-func (m *apiMockLeg) State() leg.LegState                    { return leg.StateConnected }
 func (m *apiMockLeg) SampleRate() int                        { return 8000 }
 func (m *apiMockLeg) AudioReader() io.Reader                 { return nil }
-func (m *apiMockLeg) AudioWriter() io.Writer                 { return nil }
+func (m *apiMockLeg) AudioWriter() io.Writer                 { return m.audioWriter }
 func (m *apiMockLeg) OnDTMF(func(rune))                      {}
 func (m *apiMockLeg) SendDTMF(context.Context, string) error { return nil }
-func (m *apiMockLeg) Hangup(context.Context) error           { return nil }
 func (m *apiMockLeg) Answer(context.Context) error           { return nil }
-func (m *apiMockLeg) Context() context.Context               { return context.Background() }
+
+func (m *apiMockLeg) State() leg.LegState {
+	if m.state == "" {
+		return leg.StateConnected
+	}
+	return m.state
+}
+
+func (m *apiMockLeg) Context() context.Context {
+	if m.ctx == nil {
+		return context.Background()
+	}
+	return m.ctx
+}
+
+func (m *apiMockLeg) Hangup(context.Context) error {
+	m.hangups.Add(1)
+	return nil
+}
 func (m *apiMockLeg) RoomID() string                         { return m.roomID }
 func (m *apiMockLeg) SetRoomID(id string)                    { m.roomID = id }
 func (m *apiMockLeg) AppID() string                          { return "" }

--- a/internal/api/spec_drain_fields_test.go
+++ b/internal/api/spec_drain_fields_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// schemaProperties resolves components.schemas.<name>.properties in a spec
+// document, failing the test if any hop is missing.
+func schemaProperties(t *testing.T, file, schema string) *yaml.Node {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), file))
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	if len(doc.Content) == 0 {
+		t.Fatalf("%s is empty", file)
+	}
+	n := doc.Content[0]
+	for _, key := range []string{"components", "schemas", schema, "properties"} {
+		n = mappingValue(n, key)
+		if n == nil {
+			t.Fatalf("%s: no %s under components.schemas.%s", file, key, schema)
+		}
+	}
+	return n
+}
+
+// TestOpenAPISpec_CarriesDrainFields asserts the checked-in openapi.yaml was
+// regenerated after the DeleteLegRequest change. There is no regenerate-and-diff
+// gate in the repo, so without this a forgotten `go generate` ships silently.
+//
+// The assertions are scoped to the DeleteLegRequest schema node rather than
+// grepping the file: both field names also appear in the deleteLeg operation
+// description, so a substring search over the whole document would pass even
+// with the properties missing.
+func TestOpenAPISpec_CarriesDrainFields(t *testing.T) {
+	props := schemaProperties(t, "openapi.yaml", "DeleteLegRequest")
+
+	drain := mappingValue(props, "drain_playback")
+	if drain == nil {
+		t.Fatal("openapi.yaml: DeleteLegRequest has no drain_playback; run go generate ./internal/api/")
+	}
+	if v := mappingValue(drain, "type"); v == nil || v.Value != "boolean" {
+		t.Errorf("drain_playback type = %v, want boolean", v)
+	}
+
+	budget := mappingValue(props, "drain_timeout_ms")
+	if budget == nil {
+		t.Fatal("openapi.yaml: DeleteLegRequest has no drain_timeout_ms; run go generate ./internal/api/")
+	}
+	// The enrichment constraints are the only evidence the FieldEnrichment was
+	// wired through; the bare property would be emitted from the struct alone.
+	for _, tc := range []struct{ key, want string }{
+		{"type", "integer"},
+		{"default", "5000"},
+		{"minimum", "0"},
+		{"maximum", "30000"},
+	} {
+		got := mappingValue(budget, tc.key)
+		if got == nil || got.Value != tc.want {
+			t.Errorf("drain_timeout_ms %s = %v, want %s", tc.key, got, tc.want)
+		}
+	}
+}
+
+// TestAsyncAPISpec_CarriesDrainFields is the VSI mirror. Nothing else in the
+// tree asserts asyncapi.yaml at all, so this is the only thing standing between
+// a delete_leg payload change and a stale published spec.
+func TestAsyncAPISpec_CarriesDrainFields(t *testing.T) {
+	props := schemaProperties(t, "asyncapi.yaml", "deleteLegPayload")
+
+	// cmd/asyncapi-gen does not consume SchemaEnrichments, so these land as
+	// bare typed properties beside the equally bare `reason`. Expected output,
+	// not drift — assert the types only.
+	for _, tc := range []struct{ name, want string }{
+		{"drain_playback", "boolean"},
+		{"drain_timeout_ms", "integer"},
+	} {
+		p := mappingValue(props, tc.name)
+		if p == nil {
+			t.Errorf("asyncapi.yaml: deleteLegPayload has no %s; run go generate ./internal/api/", tc.name)
+			continue
+		}
+		if v := mappingValue(p, "type"); v == nil || v.Value != tc.want {
+			t.Errorf("%s type = %v, want %s", tc.name, v, tc.want)
+		}
+	}
+}

--- a/internal/api/tts.go
+++ b/internal/api/tts.go
@@ -69,12 +69,7 @@ func (s *Server) doLegTTS(legID string, req TTSRequest) (*TTSStartResult, error)
 			APIKey:   apiKey,
 		})
 		if err != nil {
-			legPlayers.Lock()
-			delete(legPlayers.m[id], ttsID)
-			if len(legPlayers.m[id]) == 0 {
-				delete(legPlayers.m, id)
-			}
-			legPlayers.Unlock()
+			deregisterLegPlayer(id, ttsID)
 			s.Bus.Publish(events.TTSError, &events.TTSErrorData{
 				LegRoomScope: events.LegRoomScope{LegID: id, AppID: appID},
 				TTSID:        ttsID,
@@ -109,12 +104,7 @@ func (s *Server) doLegTTS(legID string, req TTSRequest) (*TTSStartResult, error)
 		}
 		playErr := player.PlayReaderAtRate(l.Context(), writer, result.Audio, result.MimeType, ttsRate)
 
-		legPlayers.Lock()
-		delete(legPlayers.m[id], ttsID)
-		if len(legPlayers.m[id]) == 0 {
-			delete(legPlayers.m, id)
-		}
-		legPlayers.Unlock()
+		deregisterLegPlayer(id, ttsID)
 
 		if playErr != nil && playErr != context.Canceled {
 			s.Bus.Publish(events.TTSError, &events.TTSErrorData{

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -122,11 +122,16 @@ var earlyMediaLegRequestFields = map[string]FieldEnrichment{
 }
 
 // DeleteLegRequest is the optional request body for DELETE /v1/legs/{id}.
-// Honored only for unanswered SIP inbound legs (state ringing or
-// early_media). For connected legs the body is ignored and the leg is hung
-// up via SIP BYE with the legacy `api_hangup` reason.
+//
+// `reason` is honored only for unanswered SIP inbound legs (state ringing or
+// early_media); on connected legs it is ignored and the leg is hung up via SIP
+// BYE with the legacy `api_hangup` reason. `drain_playback` and
+// `drain_timeout_ms` are the other way round: they apply to connected and
+// early-media legs that are being hung up, not rejected.
 type DeleteLegRequest struct {
-	Reason string `json:"reason,omitempty"`
+	Reason         string `json:"reason,omitempty"`
+	DrainPlayback  bool   `json:"drain_playback,omitempty"`
+	DrainTimeoutMs int    `json:"drain_timeout_ms,omitempty"`
 }
 
 // DeleteReasonEnum lists the reason values accepted on DELETE /v1/legs/{id}.
@@ -135,7 +140,14 @@ type DeleteLegRequest struct {
 var DeleteReasonEnum = []string{"busy", "declined", "rejected", "unavailable", "not_found", "forbidden", "server_error"}
 
 var deleteLegRequestFields = map[string]FieldEnrichment{
-	"reason": {Description: "Disconnect reason. Only honored for unanswered SIP inbound legs (state `ringing` or `early_media`); on connected legs the body is ignored and the leg is hung up with the legacy `api_hangup` reason. The value flows through to `leg.disconnected`'s `cdr.reason` and selects the SIP final response: `busy`→486, `declined`/`rejected`→603, `unavailable`→480, `not_found`→404, `forbidden`→403, `server_error`→500.", Enum: DeleteReasonEnum},
+	"reason":         {Description: "Disconnect reason. Only honored for unanswered SIP inbound legs (state `ringing` or `early_media`); on connected legs this field is ignored and the leg is hung up with the legacy `api_hangup` reason. The value flows through to `leg.disconnected`'s `cdr.reason` and selects the SIP final response: `busy`→486, `declined`/`rejected`→603, `unavailable`→480, `not_found`→404, `forbidden`→403, `server_error`→500.", Enum: DeleteReasonEnum},
+	"drain_playback": {Description: "Wait for playback and TTS already started on this leg to finish before sending BYE, so a farewell prompt is not cut off. Best-effort and bounded by `drain_timeout_ms`; when the bound expires the leg is hung up anyway and the cut utterance reports `reason: \"stopped\"`. The HTTP 202 is unaffected — the wait happens in the background, only `leg.disconnected` arrives later. A TTS utterance still being synthesized counts as outstanding and is waited for. Applies to legs in state `connected` or `early_media` only; ignored on the reject path (a `reason` on an unanswered inbound leg) and on held legs. Audio played to the room the leg is in is not waited for. While the drain runs the leg is already out of the manager, so `GET /v1/legs/{id}` and a second `DELETE` return 404; `DELETE /v1/legs/{id}/play/{playbackID}` still works and releases the drain immediately.", Default: false},
+	"drain_timeout_ms": {
+		Description: "Upper bound in milliseconds on the `drain_playback` wait. Values at or above the maximum are clamped to it; 0 or omitted uses the default.",
+		Default:     defaultDrainTimeoutMillis,
+		Minimum:     intPtr(0),
+		Maximum:     intPtr(maxDrainTimeoutMillis),
+	},
 }
 
 // TransferRequest is the body for POST /v1/legs/{id}/transfer.

--- a/internal/api/ws_commands.go
+++ b/internal/api/ws_commands.go
@@ -82,8 +82,10 @@ type answerLegPayload struct {
 
 // deleteLegPayload carries the inputs for delete_leg.
 type deleteLegPayload struct {
-	ID     string `json:"id"`
-	Reason string `json:"reason,omitempty"`
+	ID             string `json:"id"`
+	Reason         string `json:"reason,omitempty"`
+	DrainPlayback  bool   `json:"drain_playback,omitempty"`
+	DrainTimeoutMs int    `json:"drain_timeout_ms,omitempty"`
 }
 
 // transferLegPayload combines a leg id with the transfer request.
@@ -302,7 +304,7 @@ func (s *Server) wsHandleCommand(ctx context.Context, lw *wsLockedWriter, msg vs
 		if !s.wsParsePayload(lw, msg, &p) {
 			return
 		}
-		if err := s.doDeleteLeg(p.ID, p.Reason); err != nil {
+		if err := s.doDeleteLeg(p.ID, p.Reason, p.DrainPlayback, p.DrainTimeoutMs); err != nil {
 			s.wsCommandError(lw, msg, err)
 			return
 		}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -373,7 +373,7 @@ paths:
 
                 With `{"reason": "<value>"}` and an unanswered SIP inbound leg (state `ringing` or `early_media`), VoiceBlender sends a final non-2xx response instead of BYE/cancel: `busy`→486, `declined`/`rejected`→603, `unavailable`→480, `not_found`→404, `forbidden`→403, `server_error`→500. The reason value is passed through to `leg.disconnected`'s `cdr.reason`.
 
-                For connected legs the request body is ignored.
+                On connected legs the `reason` field is ignored. `drain_playback` and `drain_timeout_ms` are the opposite: they apply to legs in state `connected` or `early_media` that are being hung up, and are ignored on the reject path. With `drain_playback` set, VoiceBlender waits — in the background, so the 202 is unaffected — for playback and TTS already started on that leg to finish before sending BYE, up to `drain_timeout_ms`. When the bound expires the leg is hung up anyway and the cut utterance reports `reason: "stopped"`. While the drain runs the leg is already out of the manager, so `GET /v1/legs/{id}` and a second `DELETE` return 404; `DELETE /v1/legs/{id}/play/{playbackID}` still works and releases the drain immediately.
             tags:
                 - Legs
             requestBody:
@@ -3285,7 +3285,7 @@ components:
             properties:
                 reason:
                     type: string
-                    description: 'Disconnect reason. Only honored for unanswered SIP inbound legs (state `ringing` or `early_media`); on connected legs the body is ignored and the leg is hung up with the legacy `api_hangup` reason. The value flows through to `leg.disconnected`''s `cdr.reason` and selects the SIP final response: `busy`→486, `declined`/`rejected`→603, `unavailable`→480, `not_found`→404, `forbidden`→403, `server_error`→500.'
+                    description: 'Disconnect reason. Only honored for unanswered SIP inbound legs (state `ringing` or `early_media`); on connected legs this field is ignored and the leg is hung up with the legacy `api_hangup` reason. The value flows through to `leg.disconnected`''s `cdr.reason` and selects the SIP final response: `busy`→486, `declined`/`rejected`→603, `unavailable`→480, `not_found`→404, `forbidden`→403, `server_error`→500.'
                     enum:
                         - busy
                         - declined
@@ -3294,6 +3294,16 @@ components:
                         - not_found
                         - forbidden
                         - server_error
+                drain_playback:
+                    type: boolean
+                    description: 'Wait for playback and TTS already started on this leg to finish before sending BYE, so a farewell prompt is not cut off. Best-effort and bounded by `drain_timeout_ms`; when the bound expires the leg is hung up anyway and the cut utterance reports `reason: "stopped"`. The HTTP 202 is unaffected — the wait happens in the background, only `leg.disconnected` arrives later. A TTS utterance still being synthesized counts as outstanding and is waited for. Applies to legs in state `connected` or `early_media` only; ignored on the reject path (a `reason` on an unanswered inbound leg) and on held legs. Audio played to the room the leg is in is not waited for. While the drain runs the leg is already out of the manager, so `GET /v1/legs/{id}` and a second `DELETE` return 404; `DELETE /v1/legs/{id}/play/{playbackID}` still works and releases the drain immediately.'
+                    default: false
+                drain_timeout_ms:
+                    type: integer
+                    description: Upper bound in milliseconds on the `drain_playback` wait. Values at or above the maximum are clamped to it; 0 or omitted uses the default.
+                    default: 5000
+                    minimum: 0
+                    maximum: 30000
         EarlyMediaLegRequest:
             type: object
             properties:

--- a/tests/integration/leg_drain_test.go
+++ b/tests/integration/leg_drain_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// servePrompt serves a 1-second 8kHz WAV over HTTP for the duration of the test.
+func servePrompt(t *testing.T) string {
+	t.Helper()
+	wav := wavOneSecond8k()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "audio/wav")
+		w.Write(wav)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL + "/prompt.wav"
+}
+
+// startPrompt starts the 1s prompt on legID and returns its playback id.
+func startPrompt(t *testing.T, baseURL, legID, promptURL string) string {
+	t.Helper()
+	resp := httpPost(t, fmt.Sprintf("%s/v1/legs/%s/play", baseURL, legID), map[string]interface{}{
+		"url":       promptURL,
+		"mime_type": "audio/wav",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("play: unexpected status %d", resp.StatusCode)
+	}
+	var pb struct {
+		PlaybackID string `json:"playback_id"`
+	}
+	decodeJSON(t, resp, &pb)
+	return pb.PlaybackID
+}
+
+// TestDeleteLegDrain_PromptFinishes is the end-to-end case on a real SIP call:
+// a farewell prompt survives a DELETE issued while it is still playing, because
+// the request asked for a bounded drain.
+func TestDeleteLegDrain_PromptFinishes(t *testing.T) {
+	instA := newTestInstance(t, "drain-on-a")
+	instB := newTestInstance(t, "drain-on-b")
+	outID, _ := establishCall(t, instA, instB)
+
+	promptURL := servePrompt(t)
+	conn := dialVSI(t, instA)
+	defer conn.Close()
+
+	playbackID := startPrompt(t, instA.baseURL(), outID, promptURL)
+
+	// Well inside the 1s prompt, so without the drain the cut is unmistakable.
+	time.Sleep(100 * time.Millisecond)
+
+	delResp := httpDeleteWithBody(t, fmt.Sprintf("%s/v1/legs/%s", instA.baseURL(), outID), map[string]interface{}{
+		"drain_playback":   true,
+		"drain_timeout_ms": 5000,
+	})
+	if delResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("delete: unexpected status %d", delResp.StatusCode)
+	}
+	delResp.Body.Close()
+
+	fin := awaitPlaybackFinished(t, conn, playbackID, 15*time.Second)
+	if fin.Reason != "completed" {
+		t.Errorf("reason = %q, want %q — the drain did not hold off the hangup", fin.Reason, "completed")
+	}
+	if fin.PlayedMs < 950 {
+		t.Errorf("played_ms = %d, want >= 950 for a 1s prompt allowed to finish", fin.PlayedMs)
+	}
+	t.Logf("drained delete: reason=%q played_ms=%d", fin.Reason, fin.PlayedMs)
+}
+
+// TestDeleteLegNoDrain_PromptTruncated is the paired control: the identical
+// flow with the drain fields omitted must still cut the prompt. Without it, a
+// passing drained case could just be a harness that never truncates anything.
+func TestDeleteLegNoDrain_PromptTruncated(t *testing.T) {
+	instA := newTestInstance(t, "drain-off-a")
+	instB := newTestInstance(t, "drain-off-b")
+	outID, _ := establishCall(t, instA, instB)
+
+	promptURL := servePrompt(t)
+	conn := dialVSI(t, instA)
+	defer conn.Close()
+
+	playbackID := startPrompt(t, instA.baseURL(), outID, promptURL)
+	time.Sleep(100 * time.Millisecond)
+
+	delResp := httpDelete(t, fmt.Sprintf("%s/v1/legs/%s", instA.baseURL(), outID))
+	if delResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("delete: unexpected status %d", delResp.StatusCode)
+	}
+	delResp.Body.Close()
+
+	fin := awaitPlaybackFinished(t, conn, playbackID, 15*time.Second)
+	if fin.Reason != "stopped" {
+		t.Errorf("reason = %q, want %q for a DELETE with no drain opt-in", fin.Reason, "stopped")
+	}
+	if fin.PlayedMs >= 500 {
+		t.Errorf("played_ms = %d, want < 500 for a prompt cut ~100ms in", fin.PlayedMs)
+	}
+	t.Logf("undrained delete: reason=%q played_ms=%d", fin.Reason, fin.PlayedMs)
+}


### PR DESCRIPTION
`DELETE /v1/legs/{id}` cuts audio off mid-word.

The connected path spawns the teardown immediately and does not wait. `Hangup` cancels the leg's context, and that context is what both direct playback and TTS synthesis stream on — so a DELETE issued while a prompt is playing truncates it. An application that wants to say "goodbye" and then hang up has to subscribe to the event stream and issue the DELETE when `playback.finished` or `tts.finished` arrives — a full round trip through the webhook or VSI socket. Short of that it either hangs up too early and clips the prompt, or guesses a sleep long enough to cover it.

## The change

Two optional fields on the DELETE body:

- `drain_playback` — wait for in-flight playback on this leg to finish before hanging up
- `drain_timeout_ms` — the bound on that wait

**Opt-in by design.** Omit them and the endpoint behaves exactly as it does today. The HTTP 202 returns immediately either way — the wait happens inside the teardown goroutine that already existed, not on the request path — so what a non-opt-in drain would change is the timing of the BYE and of `leg.disconnected`, and delaying those by seconds on every DELETE would break clients that rely on the current behaviour. The wait is also clamped, at 30 s, so a leg whose playback never completes cannot hold the teardown open indefinitely.

## A pre-existing leak fixed on the way

Auditing the design's premise — that the player registry is cleared on every terminal path — showed it was false. `doStartLegPlay`'s goroutine returns early when the tone name is unknown, and that branch never reached the deregistration below it, so the entry survived for the life of the process. Any leg that ever hit it would look like it had audio outstanding forever, which would have made this feature wait for playback that had already finished.

That is fixed as its own commit, ahead of the drain, since it is a bug in its own right.

## Tests

Unit coverage for the drain path (waits while playback is registered, proceeds once it clears), the timeout bound, the default no-drain behaviour, and the leak fix. All mutation-proven.

## What is not proven

The integration tests under `tests/integration/` are **compiled but never executed** here — they need two live SIP instances, and `build.yml` does not build the `integration` tag. They assert the end-to-end shape (`reason == "completed"` with `played_ms >= 950` after a DELETE 100 ms into a 1 s prompt, against a paired control asserting `stopped` and `played_ms < 500`), but that behaviour is inferred from the unit-level proof rather than observed.

The unit tests seed the player registry directly rather than driving real audio, so the TTS-still-synthesising case — where playback has not started yet — is argued from the registration order in the code, not covered by an executing test. Worth a reviewer's eye.

`gofmt`, `go build ./...`, `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `go vet -tags integration ./tests/...` and `go test ./internal/...` are clean. `go test -race ./internal/...` is clean apart from the pre-existing `emiago/sipgo` v1.4.3 race in `internal/sip`.
