### PR TITLE
Add a mid-stream STT finalize that keeps the session open

### DIFF
--- a/API.md
+++ b/API.md
@@ -1369,6 +1369,42 @@ Stop speech-to-text on a leg.
 
 ---
 
+### POST /v1/legs/{id}/stt/finalize
+
+Flush the STT buffer on a leg and force a final transcript for the audio spoken
+so far. **STT keeps running** — the provider session is not closed and no new
+`POST /v1/legs/{id}/stt` is needed afterwards. Use it when the caller already
+knows the speaker has finished (a barge-in, a push-to-talk release, an agent
+turn boundary) and does not want to wait for the provider's own endpointing.
+
+No request body.
+
+**Response:** `200 OK`
+
+```json
+{ "status": "stt_finalized" }
+```
+
+**Provider support:** `deepgram` only. VoiceBlender's ElevenLabs integration
+commits on its own voice-activity detection and its Azure integration has no
+mid-stream flush, so both answer `501`.
+
+**Notes:**
+- The flushed transcript arrives on the usual `stt.text` event with
+  `is_final: true`. A segment containing **no speech produces no event at
+  all** — a `200` here is an acknowledgement that the flush was requested, not
+  a promise that a transcript follows. Do not block waiting for one.
+- Applies to leg-scoped STT started with `POST /v1/legs/{id}/stt`. A leg being
+  transcribed as part of a room STT session is not tracked per leg and returns
+  `404`. There is no room-level finalize.
+
+**Errors:**
+- `404` — No STT in progress on this leg
+- `409` — The STT session is not connected, or the flush could not be written
+- `501` — The active STT provider does not support finalize
+
+---
+
 ### POST /v1/legs/{id}/agent/elevenlabs
 
 Attach an ElevenLabs ConvAI agent to a leg.
@@ -2621,6 +2657,7 @@ The commands below mirror the corresponding REST endpoints and use **resource-fi
 | `room_play_volume` | `{"id":"...","playback_id":"pb-...","volume":2}` | Adjust active room playback volume |
 | `leg_stt_start` | `{"id":"...","provider":"deepgram","language":"en"}` | Start speech-to-text on a leg |
 | `leg_stt_stop` | `{"id":"..."}` | Stop STT on a leg |
+| `leg_stt_finalize` | `{"id":"..."}` | Flush the STT buffer on a leg and emit a final transcript without stopping STT (Deepgram only) |
 | `room_stt_start` | `{"id":"...","provider":"elevenlabs"}` | Start STT on every participant of a room (auto-extends to legs that join later) |
 | `room_stt_stop` | `{"id":"..."}` | Stop room STT |
 | `leg_tts` | `{"id":"...","text":"Hello","voice":"Joanna","provider":"aws"}` | Synthesize and play TTS on a leg; returns `{tts_id, status}` |

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ DELETE /v1/legs/{id}/record        # Stop recording
 POST   /v1/legs/{id}/record/pause  # Pause recording (writes silence)
 POST   /v1/legs/{id}/record/resume # Resume recording
 POST   /v1/legs/{id}/stt           # Start speech-to-text
+POST   /v1/legs/{id}/stt/finalize  # Flush STT and emit a final transcript
 DELETE /v1/legs/{id}/stt           # Stop speech-to-text
 POST   /v1/legs/{id}/amd            # Start answering machine detection
 POST   /v1/legs/{id}/agent         # Attach AI agent

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -238,6 +238,10 @@ channels:
                 $ref: '#/components/messages/room_stt_stop'
             room_stt_stop.result:
                 $ref: '#/components/messages/room_stt_stopResult'
+            leg_stt_finalize:
+                $ref: '#/components/messages/leg_stt_finalize'
+            leg_stt_finalize.result:
+                $ref: '#/components/messages/leg_stt_finalizeResult'
             leg_tts:
                 $ref: '#/components/messages/leg_tts'
             leg_tts.result:
@@ -1201,6 +1205,19 @@ operations:
                 $ref: '#/channels/vsi'
             messages:
                 - $ref: '#/channels/vsi/messages/room_stt_stop.result'
+                - $ref: '#/channels/vsi/messages/error'
+    recv_leg_stt_finalize:
+        action: receive
+        channel:
+            $ref: '#/channels/vsi'
+        summary: Flush the speech-to-text buffer on a leg and emit a final transcript without stopping STT
+        messages:
+            - $ref: '#/channels/vsi/messages/leg_stt_finalize'
+        reply:
+            channel:
+                $ref: '#/channels/vsi'
+            messages:
+                - $ref: '#/channels/vsi/messages/leg_stt_finalize.result'
                 - $ref: '#/channels/vsi/messages/error'
     recv_leg_tts:
         action: receive
@@ -3675,6 +3692,36 @@ components:
                         $ref: '#/components/schemas/STTStopResult'
                 required:
                     - type
+        leg_stt_finalize:
+            name: leg_stt_finalize
+            title: Flush the speech-to-text buffer on a leg and emit a final transcript without stopping STT
+            summary: Flush the speech-to-text buffer on a leg and emit a final transcript without stopping STT
+            payload:
+                type: object
+                properties:
+                    type:
+                        const: leg_stt_finalize
+                    request_id:
+                        type: string
+                        description: Echoed back on the matching .result/error frame; clients use it to correlate.
+                    payload:
+                        $ref: '#/components/schemas/idPayload'
+                required:
+                    - type
+        leg_stt_finalizeResult:
+            name: leg_stt_finalizeResult
+            title: Flush the speech-to-text buffer on a leg and emit a final transcript without stopping STT — success response
+            payload:
+                type: object
+                properties:
+                    type:
+                        const: leg_stt_finalize.result
+                    request_id:
+                        type: string
+                    data:
+                        $ref: '#/components/schemas/STTFinalizeResult'
+                required:
+                    - type
         leg_tts:
             name: leg_tts
             title: Synthesize speech and play it on a leg
@@ -5303,6 +5350,13 @@ components:
                 - registrar_uri
                 - aor
                 - requested_expires_seconds
+        STTFinalizeResult:
+            type: object
+            properties:
+                status:
+                    type: string
+            required:
+                - status
         STTStartLegResult:
             type: object
             properties:

--- a/internal/api/openapi_meta.go
+++ b/internal/api/openapi_meta.go
@@ -773,6 +773,20 @@ func RoutesMetadata() []RouteMeta {
 			},
 		},
 		{
+			Method: "POST", Path: "/legs/{id}/stt/finalize", OperationID: "finalizeSTTLeg",
+			Summary: "Flush the STT buffer on a leg without stopping STT",
+			Description: "Forces the provider to emit a final transcript for the audio buffered so far while the session keeps running, so a caller that knows the speaker has finished does not have to wait for the provider's own endpointing. " +
+				"Only Deepgram supports this; the Azure and ElevenLabs integrations answer 501. " +
+				"The flushed transcript arrives on the usual stt.text event with is_final true — a segment containing no speech produces no event at all, so do not block on one.",
+			Tags: []string{"Legs"},
+			Responses: map[int]ResponseMeta{
+				200: {Description: "Final transcript requested"},
+				404: {Description: "No STT in progress"},
+				409: {Description: "STT session not connected or the flush failed"},
+				501: {Description: "The active STT provider does not support finalize"},
+			},
+		},
+		{
 			Method: "POST", Path: "/legs/{id}/agent/elevenlabs", OperationID: "agentLegElevenLabs",
 			Summary:     "Attach an ElevenLabs ConvAI agent to a leg",
 			Description: "Bridges audio bidirectionally with an ElevenLabs conversational AI agent. Standalone legs use direct audio; legs in a room use mixer taps.",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -174,6 +174,7 @@ func (s *Server) routes() {
 		r.Post("/legs/{id}/record/pause", s.pauseRecordLeg)
 		r.Post("/legs/{id}/record/resume", s.resumeRecordLeg)
 		r.Post("/legs/{id}/stt", s.sttLeg)
+		r.Post("/legs/{id}/stt/finalize", s.finalizeSTTLeg)
 		r.Delete("/legs/{id}/stt", s.stopSTTLeg)
 		r.Post("/legs/{id}/agent/elevenlabs", s.agentLegElevenLabs)
 		r.Post("/legs/{id}/agent/vapi", s.agentLegVAPI)

--- a/internal/api/stt.go
+++ b/internal/api/stt.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"sync"
@@ -182,6 +183,42 @@ func (s *Server) doStopSTTLeg(legID string) (*STTStopResult, error) {
 func (s *Server) stopSTTLeg(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	res, err := s.doStopSTTLeg(id)
+	if err != nil {
+		handleAPIError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
+// STTFinalizeResult is the success payload for flushing STT on a leg.
+type STTFinalizeResult struct {
+	Status string `json:"status"`
+}
+
+// doFinalizeSTTLeg flushes the provider's audio buffer and leaves the session
+// running — unlike doStopSTTLeg it must NOT drop the transcriber from the map.
+// Only Deepgram implements the capability; the other providers answer 501
+// rather than pretending the flush happened.
+func (s *Server) doFinalizeSTTLeg(ctx context.Context, legID string) (*STTFinalizeResult, error) {
+	legTranscribers.Lock()
+	transcriber, ok := legTranscribers.m[legID]
+	legTranscribers.Unlock()
+	if !ok {
+		return nil, newAPIError(http.StatusNotFound, "no STT in progress")
+	}
+	f, ok := transcriber.(stt.Finalizer)
+	if !ok {
+		return nil, newAPIError(http.StatusNotImplemented, "STT provider does not support finalize")
+	}
+	if err := f.Finalize(ctx); err != nil {
+		return nil, newAPIError(http.StatusConflict, "finalize failed: %v", err)
+	}
+	return &STTFinalizeResult{Status: "stt_finalized"}, nil
+}
+
+func (s *Server) finalizeSTTLeg(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	res, err := s.doFinalizeSTTLeg(r.Context(), id)
 	if err != nil {
 		handleAPIError(w, err)
 		return

--- a/internal/api/stt_finalize_test.go
+++ b/internal/api/stt_finalize_test.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/VoiceBlender/voiceblender/internal/stt"
+)
+
+// fakeSTTProvider satisfies stt.Provider and nothing more, standing in for the
+// Azure and ElevenLabs integrations, which have no mid-stream flush.
+type fakeSTTProvider struct {
+	mu    sync.Mutex
+	stops int
+}
+
+func (f *fakeSTTProvider) Start(context.Context, io.Reader, string, stt.Options, stt.TranscriptCallback) error {
+	return nil
+}
+
+func (f *fakeSTTProvider) Stop() {
+	f.mu.Lock()
+	f.stops++
+	f.mu.Unlock()
+}
+
+func (f *fakeSTTProvider) Running() bool { return true }
+
+func (f *fakeSTTProvider) stopCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.stops
+}
+
+// fakeSTTFinalizer additionally satisfies stt.Finalizer, standing in for
+// Deepgram.
+type fakeSTTFinalizer struct {
+	fakeSTTProvider
+	err error
+
+	mu        sync.Mutex
+	finalizes int
+}
+
+func (f *fakeSTTFinalizer) Finalize(context.Context) error {
+	f.mu.Lock()
+	f.finalizes++
+	f.mu.Unlock()
+	return f.err
+}
+
+func (f *fakeSTTFinalizer) finalizeCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.finalizes
+}
+
+// registerTranscriber injects into the process-wide legTranscribers map and
+// guarantees removal: a leaked entry makes unrelated tests in this package see
+// "STT already running on this leg".
+func registerTranscriber(t *testing.T, legID string, p stt.Provider) {
+	t.Helper()
+	legTranscribers.Lock()
+	legTranscribers.m[legID] = p
+	legTranscribers.Unlock()
+	t.Cleanup(func() {
+		legTranscribers.Lock()
+		delete(legTranscribers.m, legID)
+		legTranscribers.Unlock()
+	})
+}
+
+func transcriberRegistered(legID string) bool {
+	legTranscribers.Lock()
+	defer legTranscribers.Unlock()
+	_, ok := legTranscribers.m[legID]
+	return ok
+}
+
+// "nothing to flush" must stay distinguishable from "cannot flush".
+func TestFinalizeSTTLeg_NoSession404(t *testing.T) {
+	s := newTestServer(t)
+
+	w := doRequest(s, http.MethodPost, "/v1/legs/leg-absent/stt/finalize", "")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (body %s)", w.Code, w.Body.String())
+	}
+}
+
+// A provider without the capability must say so, not silently succeed and not
+// masquerade as a missing session.
+func TestFinalizeSTTLeg_UnsupportedProvider501(t *testing.T) {
+	s := newTestServer(t)
+	registerTranscriber(t, "leg-azure", &fakeSTTProvider{})
+
+	w := doRequest(s, http.MethodPost, "/v1/legs/leg-azure/stt/finalize", "")
+	if w.Code != http.StatusNotImplemented {
+		t.Errorf("status = %d, want 501 (body %s)", w.Code, w.Body.String())
+	}
+}
+
+// The happy path reaches the provider and — the whole difference from stop —
+// leaves the session registered and running.
+func TestFinalizeSTTLeg_Success200(t *testing.T) {
+	s := newTestServer(t)
+	f := &fakeSTTFinalizer{}
+	registerTranscriber(t, "leg-dg", f)
+
+	w := doRequest(s, http.MethodPost, "/v1/legs/leg-dg/stt/finalize", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"stt_finalized"`) {
+		t.Errorf("body = %s, want it to carry the stt_finalized status", w.Body.String())
+	}
+	if got := f.finalizeCount(); got != 1 {
+		t.Errorf("Finalize called %d times, want 1", got)
+	}
+	if got := f.stopCount(); got != 0 {
+		t.Errorf("Stop called %d times, want 0: finalize must not end the session", got)
+	}
+	if !transcriberRegistered("leg-dg") {
+		t.Error("transcriber was dropped from legTranscribers: finalize must leave STT running")
+	}
+}
+
+// A provider-side failure — the teardown race where the writer is still
+// published but the socket has already closed — is a conflict, not a success
+// and not a panic.
+func TestFinalizeSTTLeg_WriteFailure409(t *testing.T) {
+	s := newTestServer(t)
+	registerTranscriber(t, "leg-dead", &fakeSTTFinalizer{err: errors.New("conn closed")})
+
+	w := doRequest(s, http.MethodPost, "/v1/legs/leg-dead/stt/finalize", "")
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409 (body %s)", w.Code, w.Body.String())
+	}
+}
+
+// The VSI parity gates only assert that a `case "leg_stt_finalize":` label
+// exists, so nothing else catches a dispatch body that calls the stop helper
+// instead. Both return (*T, error) and fit the surrounding shape, so the
+// copy-paste compiles and type-checks.
+func TestWSLegSTTFinalizeDispatchesToFinalize(t *testing.T) {
+	s := newTestServer(t)
+	f := &fakeSTTFinalizer{}
+	registerTranscriber(t, "leg-vsi", f)
+
+	payload, err := json.Marshal(map[string]string{"id": "leg-vsi"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	lw := &wsLockedWriter{conn: discardConn{}}
+	s.wsHandleCommand(context.Background(), lw, vsiInMsg{Type: "leg_stt_finalize", Payload: payload})
+
+	if got := f.finalizeCount(); got != 1 {
+		t.Errorf("Finalize called %d times, want 1", got)
+	}
+	if got := f.stopCount(); got != 0 {
+		t.Errorf("Stop called %d times, want 0: leg_stt_finalize must not end the session", got)
+	}
+	if !transcriberRegistered("leg-vsi") {
+		t.Error("transcriber was dropped from legTranscribers: leg_stt_finalize must leave STT running")
+	}
+}

--- a/internal/api/vsi_meta.go
+++ b/internal/api/vsi_meta.go
@@ -165,6 +165,7 @@ func VSICommandsMetadata() []VSICommandMeta {
 		{Name: "room_stt_start", Summary: "Start speech-to-text on every participant of a room (auto-extends to legs that join later)", PayloadType: sttStartPayload{}, ResultType: STTStartRoomResult{}, ErrorCodes: []int{400, 404, 409, 503}},
 		{Name: "leg_stt_stop", Summary: "Stop speech-to-text on a leg", PayloadType: idPayload{}, ResultType: STTStopResult{}, ErrorCodes: []int{404}},
 		{Name: "room_stt_stop", Summary: "Stop speech-to-text on a room", PayloadType: idPayload{}, ResultType: STTStopResult{}, ErrorCodes: []int{404}},
+		{Name: "leg_stt_finalize", Summary: "Flush the speech-to-text buffer on a leg and emit a final transcript without stopping STT", PayloadType: idPayload{}, ResultType: STTFinalizeResult{}, ErrorCodes: []int{404, 409, 501}},
 
 		// ── TTS ─────────────────────────────────────────────────────────
 		{Name: "leg_tts", Summary: "Synthesize speech and play it on a leg", PayloadType: ttsStartPayload{}, ResultType: TTSStartResult{}, ErrorCodes: []int{400, 404, 409, 503}},

--- a/internal/api/vsi_meta_test.go
+++ b/internal/api/vsi_meta_test.go
@@ -20,7 +20,7 @@ func TestVSIMetadata_AllNewCommandsRegistered(t *testing.T) {
 		"leg_play_start", "leg_play_stop", "leg_play_volume",
 		"room_play_start", "room_play_stop", "room_play_volume",
 		// STT
-		"leg_stt_start", "leg_stt_stop", "room_stt_start", "room_stt_stop",
+		"leg_stt_start", "leg_stt_stop", "leg_stt_finalize", "room_stt_start", "room_stt_stop",
 		// TTS
 		"leg_tts", "room_tts",
 		// Agent
@@ -119,6 +119,7 @@ var routeToVSICommand = map[string]string{
 	"Post /legs/{id}/record/pause":                    "leg_record_pause",
 	"Post /legs/{id}/record/resume":                   "leg_record_resume",
 	"Post /legs/{id}/stt":                             "leg_stt_start",
+	"Post /legs/{id}/stt/finalize":                    "leg_stt_finalize",
 	"Delete /legs/{id}/stt":                           "leg_stt_stop",
 	"Post /legs/{id}/agent/elevenlabs":                "leg_agent_elevenlabs",
 	"Post /legs/{id}/agent/vapi":                      "leg_agent_vapi",

--- a/internal/api/ws_commands.go
+++ b/internal/api/ws_commands.go
@@ -935,6 +935,19 @@ func (s *Server) wsHandleCommand(ctx context.Context, lw *wsLockedWriter, msg vs
 		}
 		s.wsCommandResult(lw, msg, res)
 
+	// ── STT finalize ────────────────────────────────────────────────
+	case "leg_stt_finalize":
+		var p idPayload
+		if !s.wsParsePayload(lw, msg, &p) {
+			return
+		}
+		res, err := s.doFinalizeSTTLeg(ctx, p.ID)
+		if err != nil {
+			s.wsCommandError(lw, msg, err)
+			return
+		}
+		s.wsCommandResult(lw, msg, res)
+
 	// ── Agent start (per-provider) ──────────────────────────────────
 	case "leg_agent_elevenlabs":
 		var p agentElevenLabsPayload

--- a/internal/stt/deepgram.go
+++ b/internal/stt/deepgram.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/VoiceBlender/voiceblender/internal/wsutilx"
 	"github.com/gobwas/ws"
@@ -17,7 +19,16 @@ import (
 const (
 	deepgramWSURL = "wss://api.deepgram.com/v1/listen"
 	dgFrameBytes  = 640 // 320 samples × 2 bytes (16-bit PCM at 16kHz, 20ms)
+	// dgWriteTimeout caps how long a single frame write — and therefore the
+	// writer lock hold — may block on a peer that has stopped draining. A
+	// 640-byte audio frame or a 20-byte control frame never legitimately
+	// takes this long.
+	dgWriteTimeout = 5 * time.Second
 )
+
+// dgFinalizeFrame is the Deepgram control message that flushes the server-side
+// buffer and emits a final transcript while leaving the session open.
+var dgFinalizeFrame = []byte(`{"type":"Finalize"}`)
 
 // DeepgramTranscriber streams audio to Deepgram real-time STT over WebSocket.
 type DeepgramTranscriber struct {
@@ -25,6 +36,10 @@ type DeepgramTranscriber struct {
 	running bool
 	cancel  context.CancelFunc
 	log     *slog.Logger
+	// lw is the live socket writer, guarded by mu. Non-nil only between a
+	// successful dial and Start returning, so Finalize can reach the socket
+	// that otherwise lives entirely inside Start.
+	lw *dgLockedWriter
 }
 
 func NewDeepgram(log *slog.Logger) *DeepgramTranscriber {
@@ -75,6 +90,13 @@ func (t *DeepgramTranscriber) Start(ctx context.Context, reader io.Reader, apiKe
 	defer conn.Close()
 
 	lw := &dgLockedWriter{conn: conn}
+	// Publish the writer so Finalize can reach this socket, and release it on
+	// the way out. Registered after `defer conn.Close()` so LIFO clears the
+	// field first; a Finalize that already copied the writer out can still
+	// race the close, which is why its write error is surfaced rather than
+	// treated as impossible.
+	t.setWriter(lw)
+	defer t.clearWriter()
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -105,6 +127,41 @@ func (t *DeepgramTranscriber) Running() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.running
+}
+
+func (t *DeepgramTranscriber) setWriter(lw *dgLockedWriter) {
+	t.mu.Lock()
+	t.lw = lw
+	t.mu.Unlock()
+}
+
+func (t *DeepgramTranscriber) clearWriter() {
+	t.mu.Lock()
+	t.lw = nil
+	t.mu.Unlock()
+}
+
+// Finalize asks Deepgram to emit a final transcript for the audio buffered so
+// far and keeps the socket OPEN — unlike the CloseStream frame sendLoop writes
+// at teardown, which flushes AND ends the session. Fire-and-forget: it writes
+// the frame and returns; the flushed final arrives through the existing
+// recvLoop callback. A silent segment yields no transcript at all, because
+// empty transcripts are dropped before the callback.
+//
+// ctx bounds the write: a cancelled ctx returns without touching the socket,
+// and the write itself is deadline-capped so a caller running on a shared
+// recv loop cannot be pinned by a peer that stopped draining.
+func (t *DeepgramTranscriber) Finalize(ctx context.Context) error {
+	t.mu.Lock()
+	lw := t.lw
+	t.mu.Unlock()
+	if lw == nil {
+		return errors.New("deepgram stt session not connected")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return lw.WriteText(dgFinalizeFrame)
 }
 
 func (t *DeepgramTranscriber) sendLoop(ctx context.Context, reader io.Reader, lw *dgLockedWriter) {
@@ -251,25 +308,42 @@ func (t *DeepgramTranscriber) recvLoop(ctx context.Context, conn net.Conn, lw *d
 }
 
 // dgLockedWriter serializes all WebSocket frame writes to a net.Conn.
+//
+// The mutex is deliberately held across the gobwas write call: a frame is a
+// header write followed by a payload write, so unsynchronized writers would
+// interleave and corrupt the stream. Every hold is bounded by a write
+// deadline set immediately beforehand, which is what makes it safe to acquire
+// this lock from a caller that must not stall — Finalize runs on the VSI
+// connection's recv loop, and a hold that could last forever there would
+// wedge every later command from that client.
 type dgLockedWriter struct {
 	mu   sync.Mutex
 	conn net.Conn
 }
 
+// setWriteDeadline bounds the next write. Errors are ignored: a conn that
+// rejects the deadline is already broken and the write will say so.
+func (lw *dgLockedWriter) setWriteDeadline() {
+	_ = lw.conn.SetWriteDeadline(time.Now().Add(dgWriteTimeout))
+}
+
 func (lw *dgLockedWriter) WriteBinary(data []byte) error {
 	lw.mu.Lock()
 	defer lw.mu.Unlock()
+	lw.setWriteDeadline()
 	return wsutil.WriteClientBinary(lw.conn, data)
 }
 
 func (lw *dgLockedWriter) WriteText(data []byte) error {
 	lw.mu.Lock()
 	defer lw.mu.Unlock()
+	lw.setWriteDeadline()
 	return wsutil.WriteClientText(lw.conn, data)
 }
 
 func (lw *dgLockedWriter) WriteControl(op ws.OpCode, payload []byte) error {
 	lw.mu.Lock()
 	defer lw.mu.Unlock()
+	lw.setWriteDeadline()
 	return wsutil.WriteClientMessage(lw.conn, op, payload)
 }

--- a/internal/stt/deepgram_finalize_test.go
+++ b/internal/stt/deepgram_finalize_test.go
@@ -1,0 +1,222 @@
+package stt
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsutil"
+)
+
+// Only Deepgram flushes mid-stream today; the interface exists so the other
+// providers are not forced to pretend they can.
+var _ Finalizer = (*DeepgramTranscriber)(nil)
+
+// dgEchoServer spins a WebSocket server that forwards every frame it receives
+// to textCh (OpText) or binaryCh (OpBinary), and returns a live client conn
+// dialed against it. Both are torn down by t.Cleanup.
+func dgEchoServer(t *testing.T) (client net.Conn, textCh, binaryCh chan []byte) {
+	t.Helper()
+	textCh = make(chan []byte, 8)
+	binaryCh = make(chan []byte, 8)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, _, _, err := ws.UpgradeHTTP(r, w)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			data, op, err := wsutil.ReadClientData(conn)
+			if err != nil {
+				return
+			}
+			switch op {
+			case ws.OpText:
+				textCh <- data
+			case ws.OpBinary:
+				binaryCh <- data
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, _, _, err := ws.Dialer{}.Dial(context.Background(), wsURL)
+	if err != nil {
+		t.Fatalf("dial test websocket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn, textCh, binaryCh
+}
+
+func dgRecv(t *testing.T, ch chan []byte, what string) []byte {
+	t.Helper()
+	select {
+	case b := <-ch:
+		return b
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for %s frame", what)
+		return nil
+	}
+}
+
+// The whole point of the feature: the exact Deepgram control frame goes out as
+// TEXT, and the session survives it — audio written afterwards still lands.
+func TestDeepgramFinalize_SendsExactFrameAndKeepsSocketOpen(t *testing.T) {
+	conn, textCh, binaryCh := dgEchoServer(t)
+
+	tr := &DeepgramTranscriber{log: slog.Default()}
+	tr.setWriter(&dgLockedWriter{conn: conn})
+
+	if err := tr.Finalize(context.Background()); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	// Hardcoded on purpose: mutating the production frame must not move this.
+	want := []byte(`{"type":"Finalize"}`)
+	if got := dgRecv(t, textCh, "finalize"); !bytes.Equal(got, want) {
+		t.Errorf("finalize frame = %q, want %q", got, want)
+	}
+
+	// The socket is still usable: a later audio frame reaches the server.
+	audio := []byte{0x01, 0x02, 0x03, 0x04}
+	lw := &dgLockedWriter{conn: conn}
+	if err := lw.WriteBinary(audio); err != nil {
+		t.Fatalf("WriteBinary after finalize: %v", err)
+	}
+	if got := dgRecv(t, binaryCh, "audio"); !bytes.Equal(got, audio) {
+		t.Errorf("audio frame = %q, want %q", got, audio)
+	}
+}
+
+func TestDeepgramFinalize_RefusesWithoutLiveWrite(t *testing.T) {
+	t.Run("never_started", func(t *testing.T) {
+		tr := &DeepgramTranscriber{log: slog.Default()}
+		if err := tr.Finalize(context.Background()); err == nil {
+			t.Error("Finalize on a transcriber that never started returned nil, want error")
+		}
+	})
+
+	// A caller whose connection is already gone must not put a frame on the
+	// provider socket just to throw the answer away.
+	t.Run("caller_context_cancelled", func(t *testing.T) {
+		conn, textCh, _ := dgEchoServer(t)
+		tr := &DeepgramTranscriber{log: slog.Default()}
+		tr.setWriter(&dgLockedWriter{conn: conn})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := tr.Finalize(ctx); err == nil {
+			t.Error("Finalize with a cancelled context returned nil, want error")
+		}
+		select {
+		case got := <-textCh:
+			t.Errorf("Finalize wrote %q despite a cancelled context", got)
+		case <-time.After(200 * time.Millisecond):
+		}
+	})
+}
+
+// The writer must genuinely be released when the session ends, or a late
+// Finalize writes to a dead conn. The socket is deliberately left OPEN so the
+// only thing that can produce the error is the cleared field.
+func TestDeepgramFinalize_AfterSessionEndsErrors(t *testing.T) {
+	conn, textCh, _ := dgEchoServer(t)
+
+	tr := &DeepgramTranscriber{log: slog.Default()}
+	tr.setWriter(&dgLockedWriter{conn: conn})
+	if err := tr.Finalize(context.Background()); err != nil {
+		t.Fatalf("Finalize while connected: %v", err)
+	}
+	dgRecv(t, textCh, "finalize")
+
+	tr.clearWriter()
+	if err := tr.Finalize(context.Background()); err == nil {
+		t.Fatal("Finalize after the session ended returned nil, want error")
+	}
+}
+
+// dgDeadlineConn records write deadlines and swallows writes, so the bound on
+// a writer hold can be asserted without a peer that stops draining.
+type dgDeadlineConn struct {
+	net.Conn
+	mu       sync.Mutex
+	deadline time.Time
+}
+
+func (c *dgDeadlineConn) Write(b []byte) (int, error) { return len(b), nil }
+func (c *dgDeadlineConn) Close() error                { return nil }
+
+func (c *dgDeadlineConn) SetWriteDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.deadline = t
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *dgDeadlineConn) writeDeadline() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.deadline
+}
+
+// Finalize is called from the VSI connection's recv loop, so it may acquire
+// the writer lock. That is only safe while every hold is bounded — an
+// unbounded hold anywhere on this writer stalls the loop and every later
+// command from that client.
+func TestDeepgramWriter_BoundsEveryHold(t *testing.T) {
+	cases := []struct {
+		name  string
+		write func(lw *dgLockedWriter) error
+	}{
+		{"text", func(lw *dgLockedWriter) error { return lw.WriteText([]byte("x")) }},
+		{"binary", func(lw *dgLockedWriter) error { return lw.WriteBinary([]byte("x")) }},
+		{"control", func(lw *dgLockedWriter) error { return lw.WriteControl(ws.OpPong, nil) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &dgDeadlineConn{}
+			before := time.Now()
+			if err := tc.write(&dgLockedWriter{conn: conn}); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			got := conn.writeDeadline()
+			if got.IsZero() {
+				t.Fatal("no write deadline set: this hold is unbounded")
+			}
+			if !got.After(before) {
+				t.Errorf("write deadline %v is not in the future (now %v)", got, before)
+			}
+			if got.After(before.Add(30 * time.Second)) {
+				t.Errorf("write deadline %v is too far out to bound anything", got)
+			}
+		})
+	}
+}
+
+// The capability stays honestly scoped: internal/stt holds exactly three
+// providers (azure.go, deepgram.go, elevenlabs.go) and only one can flush.
+func TestSTTFinalizerConformance(t *testing.T) {
+	log := slog.Default()
+
+	if _, ok := Provider(NewDeepgram(log)).(Finalizer); !ok {
+		t.Error("*DeepgramTranscriber does not implement Finalizer")
+	}
+	if _, ok := Provider(NewAzure("region", log)).(Finalizer); ok {
+		t.Error("*AzureTranscriber implements Finalizer; VoiceBlender's Azure " +
+			"integration has no mid-stream flush, so it must not claim one")
+	}
+	if _, ok := Provider(NewElevenLabs(log)).(Finalizer); ok {
+		t.Error("*ElevenLabsTranscriber implements Finalizer; VoiceBlender's " +
+			"ElevenLabs integration has no mid-stream flush, so it must not claim one")
+	}
+}

--- a/internal/stt/provider.go
+++ b/internal/stt/provider.go
@@ -13,6 +13,14 @@ type Provider interface {
 	Running() bool
 }
 
+// Finalizer is implemented by providers that can flush the server-side audio
+// buffer mid-stream, forcing a final transcript for what has been spoken so
+// far WITHOUT closing the session. Optional: only Deepgram supports it today,
+// so callers must type-assert rather than assume every Provider has it.
+type Finalizer interface {
+	Finalize(ctx context.Context) error
+}
+
 // Options configures the transcription session.
 type Options struct {
 	Language string // ISO-639-1 language code (default "en")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1233,6 +1233,40 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Error'
+    /legs/{id}/stt/finalize:
+        parameters:
+            - $ref: '#/components/parameters/LegId'
+        post:
+            operationId: finalizeSTTLeg
+            summary: Flush the STT buffer on a leg without stopping STT
+            description: Forces the provider to emit a final transcript for the audio buffered so far while the session keeps running, so a caller that knows the speaker has finished does not have to wait for the provider's own endpointing. Only Deepgram supports this; the Azure and ElevenLabs integrations answer 501. The flushed transcript arrives on the usual stt.text event with is_final true — a segment containing no speech produces no event at all, so do not block on one.
+            tags:
+                - Legs
+            responses:
+                '200':
+                    description: Final transcript requested
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/StatusResponse'
+                '404':
+                    description: No STT in progress
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '409':
+                    description: STT session not connected or the flush failed
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '501':
+                    description: The active STT provider does not support finalize
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
     /legs/{id}/agent/elevenlabs:
         parameters:
             - $ref: '#/components/parameters/LegId'


### PR DESCRIPTION
There is no way to get a final transcript without ending the stream.

Today the only thing that flushes Deepgram's server-side buffer is teardown: `sendLoop` writes a `CloseStream` frame on each of its two exit paths — context cancellation and the audio reader closing — and that frame flushes **and** ends the session. So an application that wants a committed transcript at a turn boundary — the caller has stopped speaking, act on what they said — has to drop the socket and reconnect for the next utterance, paying the setup cost and losing the provider's rolling context every turn.

## The change

`POST /v1/legs/{id}/stt/finalize` and the matching VSI command. It writes Deepgram's `Finalize` control frame and **keeps the socket open**. The flushed final arrives through the existing `recvLoop` callback and the same `stt.text` event as any other transcript — nothing new to subscribe to.

Fire-and-forget: the call writes the frame and returns rather than waiting for the final, because the transcript is delivered asynchronously and blocking the HTTP request on a vendor round-trip would only add a way to time out.

## Not every provider can do this

`Finalize` is an **optional** interface that callers type-assert, not a method on `Provider`. Only Deepgram implements it. The Azure integration has no mid-stream flush at all, and the ElevenLabs one commits on the provider's own voice-activity detection (`commit_strategy=vad`) with no client-driven commit wired up — so a no-op on the base interface would make the endpoint silently do nothing on two of three providers. A request against a provider that cannot finalize gets a clear error instead.

## Limits worth knowing

- **The vendor's semantics cannot be proven from this repo.** The tests prove VoiceBlender emits exactly the right bytes as a text frame on the right socket, that the socket survives the write, and that a finalize against a disconnected session errors rather than panicking. They cannot prove Deepgram answers with a final — that needs a live API key and is out of scope here.
- A silent segment yields no transcript at all, because empty transcripts are already dropped before the callback. Finalize does not change that.
- The writer is published for the lifetime of the session and released on exit; a finalize racing teardown surfaces the write error rather than treating it as impossible.
- The write is deadline-bounded, so a finalize issued from a shared recv loop cannot be pinned by a peer that has stopped draining. The deadline is asserted to be *set*; its expiry behaviour is not exercised, since that needs a peer that accepts a connection and then stops reading until the TCP buffer fills.

## Tests

Coverage for the frame content and opcode, the socket staying open across a finalize, the disconnected-session error, writer publish/release, and the deadline being applied. All mutation-proven.

One honest gap: neither the publish nor the release call *inside `Start`* is exercised, because the Deepgram URL is a package constant with no seam to point a test server at, so no test can enter `Start` at all. Making it injectable is a wider change than this item warrants. The release helper itself **is** covered — a test clears the writer directly while leaving the socket open, so mutating away the field assignment kills it.

`gofmt`, `go build ./...`, `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `go vet -tags integration ./tests/...` and `go test ./internal/...` are clean. `go test -race ./internal/...` is clean apart from the pre-existing `emiago/sipgo` v1.4.3 race in `internal/sip`.
