### PR TITLE
Bound VSI server-side WebSocket writes with a deadline

### DIFF
--- a/API.md
+++ b/API.md
@@ -2655,6 +2655,8 @@ The per-connection buffer size defaults to **256 events** and is configurable vi
 
 The default of 256 is sized for healthy clients on a normal event stream (one inbound call generates ~10 events). Increase only when you have a legitimate slow-consumer scenario you can't fix at the client.
 
+**Write deadline.** Buffering only covers a client that reads slowly. A client that stops reading altogether eventually fills the socket send buffer, and every server → client frame is bounded by a **5 second write deadline**: a frame that cannot be written within that window fails the write and the server closes the connection, logging the disconnect with `reason=write_timeout`. Previously such a write blocked forever, pinning the connection, its send loop and its event subscription for the lifetime of the process. Note the `events_dropped` notice is written before the event that triggered it, so a connection wedged badly enough may be closed while reporting drops — the socket was already stuck; the notice is the messenger. Clients should reconnect and resync via REST.
+
 **Example:**
 
 ```bash

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -5,10 +5,12 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/VoiceBlender/voiceblender/internal/mixer"
 	"github.com/VoiceBlender/voiceblender/internal/wsmedia"
+	"github.com/VoiceBlender/voiceblender/internal/wsutilx"
 	"github.com/go-chi/chi/v5"
 	"github.com/gobwas/ws"
 	"github.com/gobwas/ws/wsutil"
@@ -20,25 +22,99 @@ const (
 	wsPongTimeout  = 10 * time.Second
 )
 
+// vsiWriteTimeout bounds every server → client write on the VSI WebSocket.
+// The value is shared with internal/wsmedia rather than re-invented: both are
+// long-lived sockets carrying small JSON frames, so one number is easier to
+// reason about than two. It is a wsutilx.DurationVar — the same shape as
+// wsutilx.DefaultReadTimeout — so tests can shorten it without racing the
+// handler goroutines that read it. Nothing outside tests writes it.
+var vsiWriteTimeout wsutilx.DurationVar
+
+func init() { vsiWriteTimeout.Store(wsmedia.DefaultWriteTimeout) }
+
 // wsLockedWriter serializes all WebSocket frame writes to a net.Conn (server
 // side). Kept here for the VSI commands path (internal/api/agent.go,
 // internal/api/ws_events.go), which still hand-rolls WS framing for
 // command/result messages. The room-WS handler itself uses wsmedia.Transport.
+//
+// The mutex is deliberately held across the write: gobwas emits one frame as a
+// header write followed by a payload write, so releasing in between would let
+// another goroutine interleave its header into this frame. The hold is bounded
+// by the write deadline armed immediately before the write, and a write that
+// misses that deadline is fatal to the connection — see fail.
+//
+// If internal/wsutilx ever grows a shared locked writer it will be the client
+// side (masked frames, WriteClientText) and cannot serve this call site;
+// converging means adding a server-side constructor beside it and deleting
+// this type.
 type wsLockedWriter struct {
-	mu   sync.Mutex
-	conn net.Conn
+	mu      sync.Mutex
+	conn    net.Conn
+	timeout time.Duration
+
+	failOnce sync.Once
+	writeErr atomic.Pointer[error]
+}
+
+func newWSLockedWriter(conn net.Conn, timeout time.Duration) *wsLockedWriter {
+	return &wsLockedWriter{conn: conn, timeout: timeout}
 }
 
 func (lw *wsLockedWriter) writeText(data []byte) error {
 	lw.mu.Lock()
-	defer lw.mu.Unlock()
-	return wsutil.WriteServerText(lw.conn, data)
+	setWSWriteDeadline(lw.conn, lw.timeout)
+	err := wsutil.WriteServerText(lw.conn, data)
+	lw.mu.Unlock()
+	if err != nil {
+		// Outside the lock: fail closes the conn, which is a call that can
+		// block, and nothing else may wait on it while the mutex is held.
+		lw.fail(err)
+	}
+	return err
 }
 
 func (lw *wsLockedWriter) writeControl(op ws.OpCode, payload []byte) error {
 	lw.mu.Lock()
-	defer lw.mu.Unlock()
-	return wsutil.WriteServerMessage(lw.conn, op, payload)
+	setWSWriteDeadline(lw.conn, lw.timeout)
+	err := wsutil.WriteServerMessage(lw.conn, op, payload)
+	lw.mu.Unlock()
+	if err != nil {
+		lw.fail(err)
+	}
+	return err
+}
+
+// fail records the first write failure and closes the connection. Closing is
+// what unblocks the recv loop's blocking read, so the handler can return and
+// run its deferred unsubscribe instead of continuing to serve commands onto a
+// stream that may carry a half-written frame. Once semantics matter: after the
+// first failure every writer still blocked on this conn wakes with a
+// consequential error and calls fail too, and only the root cause is kept.
+func (lw *wsLockedWriter) fail(err error) {
+	lw.failOnce.Do(func() {
+		lw.writeErr.Store(&err)
+		_ = lw.conn.Close()
+	})
+}
+
+// Err returns the first write error recorded by fail, or nil if every write so
+// far has succeeded.
+func (lw *wsLockedWriter) Err() error {
+	if p := lw.writeErr.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// setWSWriteDeadline pushes conn's write deadline forward by timeout. A
+// non-positive timeout is a no-op (the caller manages deadlines). Mirrors the
+// unexported helper of the same shape in internal/wsmedia, which cannot be
+// reused across the package boundary.
+func setWSWriteDeadline(conn net.Conn, timeout time.Duration) {
+	if timeout <= 0 {
+		return
+	}
+	_ = conn.SetWriteDeadline(time.Now().Add(timeout))
 }
 
 // wsRoom upgrades an HTTP request to a WebSocket and wires it as a raw

--- a/internal/api/ws_commands_ctx_test.go
+++ b/internal/api/ws_commands_ctx_test.go
@@ -78,7 +78,7 @@ func TestWSRecordStartDoesNotStallRecvLoop(t *testing.T) {
 					cancel()
 				}
 
-				lw := &wsLockedWriter{conn: discardConn{}}
+				lw := newWSLockedWriter(discardConn{}, 2*time.Second)
 
 				done := make(chan struct{})
 				start := time.Now()
@@ -99,8 +99,11 @@ func TestWSRecordStartDoesNotStallRecvLoop(t *testing.T) {
 }
 
 // discardConn is a net.Conn that swallows writes, so wsHandleCommand can emit
-// its response without a real socket.
+// its response without a real socket. The embedded net.Conn is nil, so every
+// method the writer touches has to be overridden here or it panics at runtime
+// — which no compile-time gate catches.
 type discardConn struct{ net.Conn }
 
-func (discardConn) Write(b []byte) (int, error) { return len(b), nil }
-func (discardConn) Close() error                { return nil }
+func (discardConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (discardConn) Close() error                     { return nil }
+func (discardConn) SetWriteDeadline(time.Time) error { return nil }

--- a/internal/api/ws_events.go
+++ b/internal/api/ws_events.go
@@ -122,7 +122,7 @@ func (s *Server) vsi(w http.ResponseWriter, r *http.Request) {
 	})
 	defer unsub()
 
-	lw := &wsLockedWriter{conn: conn}
+	lw := newWSLockedWriter(conn, vsiWriteTimeout.Load())
 
 	connMsg, _ := json.Marshal(map[string]string{"type": "connected"})
 	if err := lw.writeText(connMsg); err != nil {
@@ -198,7 +198,7 @@ func (s *Server) vsi(w http.ResponseWriter, r *http.Request) {
 	// Recv loop with typed dispatch. Returns when the client sends a "stop"
 	// command, the WebSocket frame parse fails, or the read deadline
 	// elapses (zombie connection / network partition).
-	reason := s.vsiRecvLoop(r.Context(), conn, lw, &closed)
+	reason := vsiExitReason(s.vsiRecvLoop(r.Context(), conn, lw, &closed), lw.Err())
 
 	close(done)
 	s.Log.Info("vsi client disconnected",
@@ -219,6 +219,13 @@ func (s *Server) vsiRecvLoop(ctx context.Context, conn net.Conn, lw *wsLockedWri
 		Source: conn,
 		State:  ws.StateServerSide,
 		OnIntermediate: func(hdr ws.Header, r io.Reader) error {
+			// The handler's pong/close reply goes straight to conn, bypassing
+			// lw's mutex (a pre-existing interleave hazard, tracked
+			// separately), so it needs its own deadline or a peer that stops
+			// reading pins this loop forever. Both setters use now+timeout, so
+			// a concurrent one can only push an in-flight write's deadline
+			// out, never shorten it.
+			setWSWriteDeadline(conn, lw.timeout)
 			return controlHandler(hdr, r)
 		},
 	}
@@ -235,6 +242,9 @@ func (s *Server) vsiRecvLoop(ctx context.Context, conn net.Conn, lw *wsLockedWri
 		}
 
 		if hdr.OpCode.IsControl() {
+			// Same as OnIntermediate above: bound the reply this handler
+			// writes directly to conn.
+			setWSWriteDeadline(conn, lw.timeout)
 			if err := controlHandler(hdr, rd); err != nil {
 				return classifyReadError(err)
 			}
@@ -284,6 +294,20 @@ func classifyReadError(err error) string {
 		return "peer_close"
 	}
 	return "error"
+}
+
+// vsiExitReason lets a write-deadline expiry override the read classification.
+// When a write times out the writer closes the conn, so the recv loop's next
+// read fails with net.ErrClosed and classifyReadError reports "peer_close" for
+// what is really a server-side write failure. Only a timeout overrides: any
+// other recorded write error (EPIPE, ErrClosed) is collateral of the peer
+// going away, which the read reason already describes accurately.
+func vsiExitReason(readReason string, writeErr error) string {
+	var ne net.Error
+	if errors.As(writeErr, &ne) && ne.Timeout() {
+		return "write_timeout"
+	}
+	return readReason
 }
 
 func (s *Server) vsiSendResponse(lw *wsLockedWriter, requestID, typ string, data interface{}) {

--- a/internal/api/ws_write_deadline_test.go
+++ b/internal/api/ws_write_deadline_test.go
@@ -1,0 +1,351 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/VoiceBlender/voiceblender/internal/events"
+	"github.com/gobwas/ws"
+)
+
+// stuckWSConn is an in-process net.Conn whose Write blocks until the stored
+// write deadline trips (returning os.ErrDeadlineExceeded) or Close is called.
+// Read serves any pre-loaded bytes, then blocks until Close and returns io.EOF.
+// Modelled on internal/wsmedia/stuckconn_test.go — it deterministically
+// exercises the write-deadline path that real TCP only reaches once the kernel
+// send buffer fills.
+type stuckWSConn struct {
+	deadline atomic.Value // time.Time
+	closed   chan struct{}
+	once     sync.Once
+	// closes counts every Close call and is incremented OUTSIDE once, so a
+	// test can tell "closed twice" from "closed once". Putting it inside the
+	// once would make the fake dedupe on the writer's behalf and no assertion
+	// could ever see a missing sync.Once.
+	closes atomic.Int64
+
+	readMu  sync.Mutex
+	readBuf []byte
+}
+
+func newStuckWSConn(preload []byte) *stuckWSConn {
+	return &stuckWSConn{closed: make(chan struct{}), readBuf: preload}
+}
+
+func (s *stuckWSConn) Read(p []byte) (int, error) {
+	s.readMu.Lock()
+	if len(s.readBuf) > 0 {
+		n := copy(p, s.readBuf)
+		s.readBuf = s.readBuf[n:]
+		s.readMu.Unlock()
+		return n, nil
+	}
+	s.readMu.Unlock()
+	<-s.closed
+	return 0, io.EOF
+}
+
+func (s *stuckWSConn) Write(p []byte) (int, error) {
+	dl, _ := s.deadline.Load().(time.Time)
+	if dl.IsZero() {
+		<-s.closed
+		return 0, io.ErrClosedPipe
+	}
+	wait := time.Until(dl)
+	if wait <= 0 {
+		return 0, os.ErrDeadlineExceeded
+	}
+	select {
+	case <-s.closed:
+		return 0, io.ErrClosedPipe
+	case <-time.After(wait):
+		return 0, os.ErrDeadlineExceeded
+	}
+}
+
+func (s *stuckWSConn) Close() error {
+	s.closes.Add(1)
+	s.once.Do(func() { close(s.closed) })
+	return nil
+}
+
+func (s *stuckWSConn) isClosed() bool {
+	select {
+	case <-s.closed:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *stuckWSConn) closeCount() int64 { return s.closes.Load() }
+
+func (s *stuckWSConn) LocalAddr() net.Addr                { return nil }
+func (s *stuckWSConn) RemoteAddr() net.Addr               { return nil }
+func (s *stuckWSConn) SetDeadline(time.Time) error        { return nil }
+func (s *stuckWSConn) SetReadDeadline(time.Time) error    { return nil }
+func (s *stuckWSConn) SetWriteDeadline(t time.Time) error { s.deadline.Store(t); return nil }
+
+// A text frame written to a peer that never drains must fail on the deadline
+// instead of blocking forever with the writer mutex held. This is the core
+// claim: before the deadline the send loop pinned lw.mu, which pinned every
+// command response, which pinned the recv loop, which leaked the connection
+// and its event-bus subscription for the process lifetime.
+func TestWSLockedWriterTextWriteHonorsDeadline(t *testing.T) {
+	sc := newStuckWSConn(nil)
+	lw := newWSLockedWriter(sc, 50*time.Millisecond)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- lw.writeText([]byte(`{"type":"ping"}`)) }()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("writeText returned nil error against a peer that never drains")
+		}
+		if !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("want os.ErrDeadlineExceeded, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("writeText never returned: the write is not bounded by a deadline")
+	}
+}
+
+// writeControl has no production caller today, so nothing else in the suite
+// touches it: without this test its deadline could be omitted entirely and
+// every gate would stay green.
+func TestWSLockedWriterControlWriteHonorsDeadline(t *testing.T) {
+	sc := newStuckWSConn(nil)
+	lw := newWSLockedWriter(sc, 50*time.Millisecond)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- lw.writeControl(ws.OpPing, nil) }()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("writeControl returned nil error against a peer that never drains")
+		}
+		if !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("want os.ErrDeadlineExceeded, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("writeControl never returned: the write is not bounded by a deadline")
+	}
+}
+
+// A missed deadline must tear the connection down. vsiSendResponse discards
+// the write error, so without the close the recv loop would keep serving
+// commands onto a stream carrying a truncated frame.
+func TestWSLockedWriterClosesConnOnWriteFailure(t *testing.T) {
+	sc := newStuckWSConn(nil)
+	lw := newWSLockedWriter(sc, 50*time.Millisecond)
+
+	if err := lw.writeText([]byte(`{"type":"ping"}`)); err == nil {
+		t.Fatal("writeText returned nil error against a peer that never drains")
+	}
+	if !sc.isClosed() {
+		t.Fatal("write failure did not close the connection")
+	}
+	if got := lw.Err(); !errors.Is(got, os.ErrDeadlineExceeded) {
+		t.Fatalf("Err() = %v, want os.ErrDeadlineExceeded", got)
+	}
+}
+
+// Every writer blocked behind the first failure wakes with a consequential
+// error and calls fail too. Only the first close and the first recorded error
+// may win, so the reported cause is the root one and not the collateral.
+func TestWSLockedWriterFailsOnce(t *testing.T) {
+	sc := newStuckWSConn(nil)
+	lw := newWSLockedWriter(sc, 50*time.Millisecond)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = lw.writeText([]byte(`{"type":"ping"}`))
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent writers never returned")
+	}
+
+	if got := sc.closeCount(); got != 1 {
+		t.Fatalf("conn closed %d times, want exactly 1", got)
+	}
+	if got := lw.Err(); !errors.Is(got, os.ErrDeadlineExceeded) {
+		t.Fatalf("Err() = %v, want the first (root-cause) error", got)
+	}
+}
+
+// The pong reply the recv loop emits goes through the raw conn, not the locked
+// writer, so it needs its own deadline. Without one a client that pings and
+// then stops reading pins the recv loop forever — the permanent-leak chain
+// this branch exists to close.
+func TestVSIRecvLoopBoundsControlFrameReply(t *testing.T) {
+	s := newTestServer(t)
+
+	var buf bytes.Buffer
+	if err := ws.WriteFrame(&buf, ws.MaskFrameInPlace(ws.NewPingFrame(nil))); err != nil {
+		t.Fatalf("build client ping frame: %v", err)
+	}
+
+	sc := newStuckWSConn(buf.Bytes())
+	var closed atomic.Bool
+
+	done := make(chan string, 1)
+	go func() {
+		done <- s.vsiRecvLoop(context.Background(), sc, newWSLockedWriter(sc, 50*time.Millisecond), &closed)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("vsiRecvLoop never returned: the control-frame reply is not bounded by a deadline")
+	}
+}
+
+// syncBuffer is a concurrency-safe log sink: the handler logs from several
+// goroutines, so a bare bytes.Buffer would race under -race.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// Binds the production wiring in vsi(): the writer really is constructed with
+// the configured timeout, so a client that stops draining is disconnected
+// rather than pinning the handler and its event-bus subscription forever. The
+// unit tests above all build their own writer and would stay green if
+// ws_events.go passed a zero timeout. The log assertion binds the second half
+// of the wiring — that the disconnect is attributed to the write deadline and
+// not mis-reported as a peer close.
+func TestVSIStalledClientIsDisconnected(t *testing.T) {
+	prev := vsiWriteTimeout.Load()
+	vsiWriteTimeout.Store(200 * time.Millisecond)
+	t.Cleanup(func() { vsiWriteTimeout.Store(prev) })
+
+	s := newTestServer(t)
+	logs := &syncBuffer{}
+	s.Log = slog.New(slog.NewJSONHandler(logs, nil))
+	srv := httptest.NewServer(s.Router)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	wsURL := "ws://" + strings.TrimPrefix(srv.URL, "http://") + "/v1/vsi"
+	conn, _, _, err := ws.Dial(ctx, wsURL)
+	if err != nil {
+		t.Fatalf("dial vsi: %v", err)
+	}
+	defer conn.Close()
+	// Deliberately not reading: the kernel send buffer fills, the send loop's
+	// write blocks, and the write deadline is the only thing that can end it.
+
+	time.Sleep(100 * time.Millisecond) // let the handler subscribe
+
+	// One shared 64 KiB string referenced by every event, so this costs a
+	// transient marshal buffer per frame rather than 64 MiB of payload.
+	big := strings.Repeat("x", 64*1024)
+	for i := 0; i < 2000; i++ {
+		s.Bus.Publish(events.DTMFReceived, &events.DTMFReceivedData{
+			LegScope: events.LegScope{LegID: "leg-1"},
+			Digit:    big,
+		})
+	}
+
+	// Comfortably past the 200ms write deadline.
+	time.Sleep(time.Second)
+
+	// Now drain. Everything already queued arrives first; the read then ends
+	// in EOF/reset if the server hung up, or in our own deadline if it did not.
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	buf := make([]byte, 64*1024)
+	for {
+		if _, err := conn.Read(buf); err != nil {
+			var ne net.Error
+			if errors.As(err, &ne) && ne.Timeout() {
+				t.Fatal("server never disconnected the stalled client: the VSI write is unbounded in production")
+			}
+			break // server hung up — the deadline fired and closed the conn
+		}
+	}
+
+	// The disconnect log is emitted as the handler unwinds, which may trail the
+	// close the client just observed.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if strings.Contains(logs.String(), `"reason":"write_timeout"`) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("disconnect was not attributed to the write deadline:\n%s", logs.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestVSIExitReason(t *testing.T) {
+	cases := []struct {
+		name       string
+		readReason string
+		writeErr   error
+		want       string
+	}{
+		{name: "no write error passes the read reason through", readReason: "peer_close", want: "peer_close"},
+		{name: "stop is preserved", readReason: "stop", want: "stop"},
+		{
+			name:       "write deadline overrides the misleading peer_close",
+			readReason: "peer_close",
+			writeErr:   os.ErrDeadlineExceeded,
+			want:       "write_timeout",
+		},
+		{
+			// A broken pipe on the write side is collateral of the peer
+			// leaving; the read reason already says so accurately.
+			name:       "non-timeout write error does not override",
+			readReason: "peer_close",
+			writeErr:   io.ErrClosedPipe,
+			want:       "peer_close",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := vsiExitReason(tc.readReason, tc.writeErr); got != tc.want {
+				t.Fatalf("vsiExitReason(%q, %v) = %q, want %q", tc.readReason, tc.writeErr, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A VSI client that stops draining its receive window blocks the server forever, and takes every other writer on that socket down with it.

`wsLockedWriter` serializes writes behind a mutex — correctly, since a frame is a header write followed by a payload write and unsynchronized writers would interleave and corrupt the stream. But the write itself has no deadline. So once a peer stops reading and the send buffer fills, `wsutil.WriteServerText` blocks indefinitely **while holding the mutex**, and every subsequent event and command result for that connection queues behind it. The recv loop's pong and close replies do not take that lock — they write straight to the conn — so they stall on the same full buffer rather than on the mutex.

## The change

The writer takes a timeout and arms a write deadline before each frame, defaulting to `wsmedia.DefaultWriteTimeout` — the value already used elsewhere in the tree for the same job, rather than a new invented number. A write that trips the deadline fails the connection rather than retrying, because a peer that has not drained a frame within the budget is gone, and the socket cannot be left in an indeterminate state mid-frame.

Failing the connection happens **outside** the mutex: closing the conn is a call that can block, and holding the writer lock across it would reintroduce the stall this change removes.

## Relationship to #106

This is the server-side sibling of #106, which bounds the *client*-side provider sockets. The two are independent and can land in either order: this branch touches nothing #106 adds. It does use `wsutilx.DurationVar` for its timeout knob, but that type is already on master. The writer itself could not be shared in any case, because a server writes unmasked frames (`WriteServerText`) where `wsutilx.LockedWriter` writes masked client frames. If both land, the natural follow-up is a server-side constructor alongside the client one; that consolidation is deliberately not attempted here.

## What this does not fix

Control-frame replies — pong and close — are now deadline-bounded but still bypass the writer's mutex, so a pong can interleave into the header/payload pair of a text frame in flight.

The obvious fix, handing the locked writer to gobwas as the control handler's destination, is unsound: its protocol-error path issues two separate destination writes per frame, so taking the lock per write does not make the pair atomic. A correct fix needs a whole-frame-buffering writer, which is a larger change and belongs on its own branch. Flagging it explicitly so this is not read as having made every VSI write mutually exclusive — it has not.

## Tests

Coverage for the deadline being armed on text writes, on control writes and on the recv loop's control-frame reply; for an expired deadline closing the connection; for concurrent writers recording exactly one close and preserving the root-cause error; and for the production wiring disconnecting a stalled client. All mutation-proven — including that the mutated tree still compiles, since a mutation that fails to build proves nothing.

`gofmt`, `go build ./...`, `CGO_ENABLED=0 go build ./...`, `go vet ./...`, `go vet -tags integration ./tests/...` and `go test ./internal/...` are clean. `go test -race ./internal/...` is clean apart from the pre-existing `emiago/sipgo` v1.4.3 race in `internal/sip`.
