### PR TITLE
 Transferred legs now publish leg.hold/leg.unhold like

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -261,6 +261,7 @@ go test -tags integration -v -timeout 60s -run TestGCSRecording ./tests/integrat
 | `TestWebRTC_AppIDFilter` | A WebRTC leg tagged with `app_id` on the offer reaches an `app_id`-filtered VSI subscriber, while an untagged WebRTC leg on the same server is dropped by the filter |
 | `TestWebRTC_AppIDInLegEvents` | `app_id` set on `POST /v1/webrtc/offer` is carried on the leg's `leg.connected` event |
 | `TestTransfer_Blind_Outbound` | A↔B, REFER on B's leg dials C, completion event fires, original hung up |
+| `TestTransfer_Blind_RemoteByeEndsTransferredLeg` | After the transfer completes, C hangs up: B must publish `leg.disconnected` with `remote_bye` for the leg it originated and drop it from the manager (the referrer that would otherwise watch it is already gone) |
 | `TestTransfer_Inbound_AutoDeclineOnTimeout` | Auto-dial off: an undecided inbound REFER is parked, surfaced as `leg.transfer_requested` (declined vestigial), then auto-declined 603 after `SIP_REFER_CONSULT_TIMEOUT_MS`; referrer sees `transfer_failed` |
 | `TestTransfer_Inbound_AppAcceptsAndCompletes` | App-driven happy path: `transfer/accept` then `transfer/complete{success:true}`; referrer observes 202→NOTIFY 100→NOTIFY 200 as `transfer_completed` |
 | `TestTransfer_Inbound_AppDeclines` | App calls `transfer/decline`; referrer sees `transfer_failed` |

--- a/internal/api/legs.go
+++ b/internal/api/legs.go
@@ -631,6 +631,42 @@ func (s *Server) cleanupLeg(l leg.Leg) {
 	s.LegMgr.Remove(l.ID())
 }
 
+// watchLegDialogEnd blocks until a connected leg ends, then tears it down and
+// publishes leg.disconnected — unless it was already torn down locally. It
+// returns when the dialog ends (the remote BYE), when maxDuration elapses
+// (skipped when <= 0), or when the leg's own context is cancelled.
+//
+// The leg context is in the select because a local teardown — an API hangup, a
+// room delete, an RTP timeout — hangs the leg up and cancels its context, but
+// our BYE to a vanished peer may never get the 200 that ends the sipgo dialog,
+// so waiting on the dialog alone would block for the process lifetime. Every
+// path that cancels a leg's context sets StateHungUp first, so the state guard
+// below can only suppress the disconnect that teardown already published; it
+// never publishes a spurious one.
+func (s *Server) watchLegDialogEnd(l leg.Leg, dialogCtx context.Context, maxDuration time.Duration) {
+	// A nil channel blocks forever, which is what "no cap" means here.
+	var maxC <-chan time.Time
+	if maxDuration > 0 {
+		maxTimer := time.NewTimer(maxDuration)
+		defer maxTimer.Stop()
+		maxC = maxTimer.C
+	}
+
+	reason := "remote_bye"
+	select {
+	case <-dialogCtx.Done():
+	case <-l.Context().Done():
+	case <-maxC:
+		reason = "max_duration"
+		s.Log.Info("max duration reached", "leg_id", l.ID(), "max_duration", maxDuration)
+	}
+
+	if l.State() != leg.StateHungUp {
+		s.cleanupLeg(l)
+		s.publishDisconnect(l, reason)
+	}
+}
+
 // rejectionMapping maps a user-supplied disconnect reason to a SIP final
 // status code + reason phrase, used when the leg is rejected before answer.
 // Unknown reasons return ok=false; the handler then returns 400.
@@ -973,29 +1009,7 @@ func (s *Server) doCreateSIPOutboundLeg(req CreateLegRequest) (LegView, error) {
 		addToRoom()
 
 		// Monitor for remote hangup or max duration.
-		if req.MaxDuration > 0 {
-			maxTimer := time.NewTimer(time.Duration(req.MaxDuration) * time.Second)
-			defer maxTimer.Stop()
-			select {
-			case <-call.Dialog.Context().Done():
-				if l.State() != leg.StateHungUp {
-					s.cleanupLeg(l)
-					s.publishDisconnect(l, "remote_bye")
-				}
-			case <-maxTimer.C:
-				if l.State() != leg.StateHungUp {
-					s.Log.Info("max duration reached", "leg_id", l.ID(), "max_duration", req.MaxDuration)
-					s.cleanupLeg(l)
-					s.publishDisconnect(l, "max_duration")
-				}
-			}
-		} else {
-			<-call.Dialog.Context().Done()
-			if l.State() != leg.StateHungUp {
-				s.cleanupLeg(l)
-				s.publishDisconnect(l, "remote_bye")
-			}
-		}
+		s.watchLegDialogEnd(l, call.Dialog.Context(), time.Duration(req.MaxDuration)*time.Second)
 	}()
 
 	return toLegView(l), nil
@@ -1131,11 +1145,7 @@ func (s *Server) HandleInboundCall(call *sipmod.InboundCall) {
 		s.maybeStartSpeakingDetector(l, s.takeSpeechOverride(l.ID()))
 
 		// Block until call ends (BYE received or context cancelled)
-		<-call.Dialog.Context().Done()
-		if l.State() != leg.StateHungUp {
-			s.cleanupLeg(l)
-			s.publishDisconnect(l, "remote_bye")
-		}
+		s.watchLegDialogEnd(l, call.Dialog.Context(), 0)
 		return
 
 	case <-call.Dialog.Context().Done():

--- a/internal/api/transfer.go
+++ b/internal/api/transfer.go
@@ -316,6 +316,7 @@ func (s *Server) originateForRefer(referrer *leg.SIPLeg, target string, replaces
 	newLeg := leg.NewSIPOutboundPendingLeg(s.SIPEngine, nil, s.Log)
 	newLeg.SetJitterBuffer(s.Config.SIPJitterBufferMs, s.Config.SIPJitterBufferMaxMs)
 	s.setupLegEventForwarding(newLeg)
+	s.setupHoldCallbacks(newLeg)
 	s.LegMgr.Add(newLeg)
 	s.Bus.Publish(events.LegRinging, &events.LegRingingData{
 		LegScope: events.LegScope{LegID: newLeg.ID(), AppID: newLeg.AppID()},
@@ -382,25 +383,7 @@ func (s *Server) originateForRefer(referrer *leg.SIPLeg, target string, replaces
 
 	// The referrer is gone, so nothing else observes the transferred leg's
 	// dialog: the engine's BYE handling publishes no event of its own.
-	s.watchLegDialogEnd(newLeg, call.Dialog.Context())
-}
-
-// watchLegDialogEnd blocks until the leg's dialog ends, then disconnects the
-// leg unless it was already torn down locally. It also returns when the leg's
-// own context is cancelled: a local teardown (an API hangup, or a room delete)
-// hangs the leg up and cancels its context, but our BYE to a vanished peer may
-// never get the 200 that ends the sipgo dialog, so waiting on the dialog alone
-// would block for the process lifetime. The local teardown already published
-// the disconnect, so the state guard skips a second one.
-func (s *Server) watchLegDialogEnd(l *leg.SIPLeg, dialogCtx context.Context) {
-	select {
-	case <-dialogCtx.Done():
-	case <-l.Context().Done():
-	}
-	if l.State() != leg.StateHungUp {
-		s.cleanupLeg(l)
-		s.publishDisconnect(l, "remote_bye")
-	}
+	s.watchLegDialogEnd(newLeg, call.Dialog.Context(), 0)
 }
 
 func (s *Server) notifyAndFail(referrer *leg.SIPLeg, statusCode int, reason string) {

--- a/internal/api/transfer_watch_test.go
+++ b/internal/api/transfer_watch_test.go
@@ -59,7 +59,7 @@ func TestWatchLegDialogEndDisconnectsOnRemoteBye(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.watchLegDialogEnd(l, dialogCtx)
+		s.watchLegDialogEnd(l, dialogCtx, 0)
 	}()
 
 	remoteBye()
@@ -125,7 +125,7 @@ func TestWatchLegDialogEndExitsOnLocalTeardown(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.watchLegDialogEnd(l, dialogCtx)
+		s.watchLegDialogEnd(l, dialogCtx, 0)
 	}()
 
 	select {
@@ -165,6 +165,103 @@ func TestOriginateForReferWatchesDialogAfterConnect(t *testing.T) {
 
 	if strings.Contains(body, "go s.watchLegDialogEnd(") {
 		t.Error("watchLegDialogEnd is spawned in a goroutine — it must block in originateForRefer's own goroutine so leg.connected always precedes leg.disconnected")
+	}
+}
+
+// TestWatchLegDialogEndDisconnectsOnMaxDuration pins the max-duration cap that
+// POST /v1/legs exposes as max_duration. Neither the dialog nor the leg context
+// ends here, so only the timer can wake the monitor — and the disconnect must
+// be attributed to the cap, not to a BYE that never arrived.
+func TestWatchLegDialogEndDisconnectsOnMaxDuration(t *testing.T) {
+	s := newTestServer(t)
+	s.SIPEngine = referTestEngine(t)
+
+	l := leg.NewSIPOutboundPendingLeg(s.SIPEngine, nil, s.Log)
+	s.LegMgr.Add(l)
+
+	got := make(chan events.Event, 4)
+	unsub := s.Bus.Subscribe(func(e events.Event) {
+		if e.Type == events.LegDisconnected {
+			got <- e
+		}
+	})
+	t.Cleanup(unsub)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.watchLegDialogEnd(l, context.Background(), 10*time.Millisecond)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchLegDialogEnd did not return after max duration elapsed")
+	}
+
+	select {
+	case e := <-got:
+		data, ok := e.Data.(*events.LegDisconnectedData)
+		if !ok {
+			t.Fatalf("leg.disconnected data = %T, want *events.LegDisconnectedData", e.Data)
+		}
+		if data.CDR.Reason != "max_duration" {
+			t.Errorf("cdr.reason = %q, want max_duration", data.CDR.Reason)
+		}
+	default:
+		t.Fatal("no leg.disconnected published — a leg that outlives max_duration must be reaped")
+	}
+
+	if _, ok := s.LegMgr.Get(l.ID()); ok {
+		t.Error("leg still registered after max duration — cleanupLeg must remove it")
+	}
+}
+
+// TestWatchLegDialogEndNoMaxDurationDoesNotFire guards the zero value: a leg
+// with no cap must not be reaped by a timer that fired immediately. Passing 0
+// through as a live time.Timer would tear down every uncapped call at once.
+func TestWatchLegDialogEndNoMaxDurationDoesNotFire(t *testing.T) {
+	s := newTestServer(t)
+	s.SIPEngine = referTestEngine(t)
+
+	l := leg.NewSIPOutboundPendingLeg(s.SIPEngine, nil, s.Log)
+	s.LegMgr.Add(l)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.watchLegDialogEnd(l, context.Background(), 0)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("watchLegDialogEnd returned with no cap and a live dialog — an uncapped leg was reaped")
+	case <-time.After(100 * time.Millisecond):
+		// Still blocked, as it must be.
+	}
+
+	// Unblock so the goroutine does not outlive the test.
+	l.Hangup(context.Background())
+	<-done
+}
+
+// TestOriginateForReferWiresLegCallbacks pins the callback wiring a transferred
+// leg shares with the other construction sites. setupLegEventForwarding carries
+// DTMF, RTT and the RTP-timeout reaper; setupHoldCallbacks carries leg.hold and
+// leg.unhold. Both must be installed before the leg is registered, or events
+// arriving on a freshly-added leg have nowhere to go.
+func TestOriginateForReferWiresLegCallbacks(t *testing.T) {
+	body := funcBody(t, "transfer.go", "originateForRefer")
+
+	for _, wiring := range []string{"s.setupLegEventForwarding(newLeg)", "s.setupHoldCallbacks(newLeg)"} {
+		at := strings.Index(body, wiring)
+		if at < 0 {
+			t.Errorf("originateForRefer does not call %s — a transferred leg is wired differently from every other connected leg", wiring)
+			continue
+		}
+		if add := strings.Index(body, "s.LegMgr.Add(newLeg)"); add >= 0 && at > add {
+			t.Errorf("%s runs after the leg is registered — callbacks must be wired first", wiring)
+		}
 	}
 }
 

--- a/internal/api/whatsapp.go
+++ b/internal/api/whatsapp.go
@@ -299,11 +299,7 @@ func (s *Server) driveWhatsAppOutbound(l *leg.WhatsAppLeg, media *leg.PCMedia, g
 		LegType:  string(l.Type()),
 	})
 
-	<-call.Dialog.Context().Done()
-	if l.State() != leg.StateHungUp {
-		s.cleanupLeg(l)
-		s.publishDisconnect(l, "remote_bye")
-	}
+	s.watchLegDialogEnd(l, call.Dialog.Context(), 0)
 }
 
 func legViewFrom(l leg.Leg) LegView {

--- a/tests/integration/transfer_test.go
+++ b/tests/integration/transfer_test.go
@@ -52,6 +52,92 @@ func TestTransfer_Blind_Outbound(t *testing.T) {
 	httpDelete(t, fmt.Sprintf("%s/v1/legs/%s", instC.baseURL(), inboundOnC.ID))
 }
 
+// TestTransfer_Blind_RemoteByeEndsTransferredLeg: once a blind transfer
+// completes, the leg B originated toward C is observed by nothing but its own
+// dialog monitor — the referrer that would otherwise have watched it is already
+// torn down. When C hangs up, B must publish leg.disconnected with reason
+// remote_bye and drop the leg from its manager. Without the monitor the BYE is
+// swallowed: no event, no CDR, and the leg is stuck on B for the process
+// lifetime.
+func TestTransfer_Blind_RemoteByeEndsTransferredLeg(t *testing.T) {
+	instA := newTestInstance(t, "instance-a")
+	instB := newTestInstanceWithOpts(t, "instance-b", func(c *config.Config) {
+		c.SIPReferAutoDial = true
+	})
+	instC := newTestInstance(t, "instance-c")
+
+	outboundID, _ := establishCall(t, instA, instB)
+
+	transferResp := httpPost(t, fmt.Sprintf("%s/v1/legs/%s/transfer", instA.baseURL(), outboundID), map[string]interface{}{
+		"target": fmt.Sprintf("sip:test@127.0.0.1:%d", instC.sipPort),
+	})
+	if transferResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("transfer: status %d", transferResp.StatusCode)
+	}
+
+	inboundOnC := waitForInboundLeg(t, instC.baseURL(), 5*time.Second)
+	if r := httpPost(t, fmt.Sprintf("%s/v1/legs/%s/answer", instC.baseURL(), inboundOnC.ID), nil); r.StatusCode != http.StatusAccepted {
+		t.Fatalf("answer on C: %d", r.StatusCode)
+	}
+
+	instA.collector.waitForMatch(t, events.LegTransferCompleted, func(e events.Event) bool {
+		return e.Data.GetLegID() == outboundID
+	}, 5*time.Second)
+
+	// B's surviving leg is the one it originated toward C.
+	transferred := waitForConnectedOutboundLeg(t, instB.baseURL(), 5*time.Second)
+
+	// C hangs up. B learns of it only through the transferred leg's dialog.
+	httpDelete(t, fmt.Sprintf("%s/v1/legs/%s", instC.baseURL(), inboundOnC.ID))
+
+	disc := instB.collector.waitForMatch(t, events.LegDisconnected, func(e events.Event) bool {
+		return e.Data.GetLegID() == transferred.ID
+	}, 5*time.Second)
+	if got := disc.Data.(*events.LegDisconnectedData).CDR.Reason; got != "remote_bye" {
+		t.Errorf("B cdr.reason = %q, want remote_bye", got)
+	}
+
+	// The event is not enough: the leg must also be gone from B's manager.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		resp := httpGet(t, instB.baseURL()+"/v1/legs")
+		var legs []legView
+		decodeJSON(t, resp, &legs)
+		found := false
+		for _, l := range legs {
+			if l.ID == transferred.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("transferred leg still registered on B after the remote BYE — cleanupLeg never ran")
+}
+
+// waitForConnectedOutboundLeg polls instance's leg list until a connected
+// sip_outbound leg appears.
+func waitForConnectedOutboundLeg(t *testing.T, baseURL string, timeout time.Duration) legView {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp := httpGet(t, baseURL+"/v1/legs")
+		var legs []legView
+		decodeJSON(t, resp, &legs)
+		for _, l := range legs {
+			if l.Type == "sip_outbound" && l.State == "connected" {
+				return l
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("no connected outbound leg found within %v", timeout)
+	return legView{}
+}
+
 // TestTransfer_Inbound_AutoDeclineOnTimeout: with the default (auto-dial off),
 // an inbound REFER is parked for an app decision and surfaced as
 // leg.transfer_requested. When no app accepts/declines within


### PR DESCRIPTION
 Transferred legs now publish leg.hold/leg.unhold like every other connected leg
watchLegDialogEnd generalized and reused at all four site Three unit tests