### PR TITLE
Assert a recording session survives the ACK

### DIFF
--- a/tests/integration/siprec_test.go
+++ b/tests/integration/siprec_test.go
@@ -1108,30 +1108,14 @@ func getLegView(t *testing.T, inst *testInstance, legID string) legTypeView {
 }
 
 // TestSIPREC_SessionSurvivesACK asserts that a recording session stays
-// established once it has been answered and ACKed.
+// established after it has been answered and ACKed.
 //
-// Regression test for a failure seen against a real Kamailio + rtpengine SRC:
-// the SRS answered, and then immediately tore the session down. Both ends left
-// matching evidence.
+// Every other SIPREC test asserts on the answer and then hangs up, so none of
+// them notice a session that dies a moment later.
 //
-// On the SRS:
-//
-//	SIPREC: answer failed  error="respond SDP: transaction terminated"
-//	siprec.session_ended
-//	WARN ACK missed  caller=TransactionLayer  tx=...__INVITE
-//
-// and on the SRC, the same 200 OK logged three times — sipgo retransmitting it
-// because nothing ever confirmed the dialog.
-//
-// "ACK missed" comes from sipgo's ServerTx.ackSend(), which logs only in the
-// branch where an ACK arrives for an ALREADY-TERMINATED server transaction. So
-// the ACK is sent and received; the transaction is simply gone by then. That
-// makes this a lifecycle bug on the SRS side, not a signalling or transport
-// problem on the SRC side.
-//
-// The existing SIPREC tests all assert on the answer and then hang up, so none
-// of them notice a session that dies a moment later. This one holds the dialog
-// open and checks it is still there.
+// This catches an immediate teardown. A client whose ACK never confirms the
+// dialog instead trips the 64*T1 retransmit timeout, which this does not wait
+// for.
 func TestSIPREC_SessionSurvivesACK(t *testing.T) {
 	src := newTestInstance(t, "src")
 	srs := siprecInstance(t, "srs", nil)
@@ -1153,15 +1137,12 @@ func TestSIPREC_SessionSurvivesACK(t *testing.T) {
 	}
 	legID := legIDer.GetLegID()
 
-	// Hold the dialog. In the observed failure the teardown followed the answer
-	// within a couple of hundred milliseconds, so a second is ample; the point
-	// is to outlive the ACK rather than to wait out a timer.
+	// Long enough to outlive the ACK, short enough to keep the suite fast.
 	time.Sleep(2 * time.Second)
 
 	if srs.collector.hasEvent(events.SIPRECSessionEnded, nil) {
 		t.Fatal("recording session ended on its own after being answered: " +
-			"the SRS tore down the dialog instead of keeping it up " +
-			"(check for 'ACK missed' / 'transaction terminated' in the SRS log)")
+			"the dialog was torn down instead of kept up")
 	}
 
 	// The session must still be addressable, not merely un-ended.

--- a/tests/integration/siprec_test.go
+++ b/tests/integration/siprec_test.go
@@ -1154,6 +1154,10 @@ func TestSIPREC_SessionSurvivesACK(t *testing.T) {
 	// And the leg itself must still be connected — a session view can outlive
 	// the SIP dialog that justifies it.
 	resp := httpGet(t, srs.baseURL()+"/v1/legs")
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		t.Fatalf("GET /v1/legs = %d, want 200", resp.StatusCode)
+	}
 	var legs []legView
 	decodeJSON(t, resp, &legs)
 	var found bool

--- a/tests/integration/siprec_test.go
+++ b/tests/integration/siprec_test.go
@@ -1106,3 +1106,85 @@ func getLegView(t *testing.T, inst *testInstance, legID string) legTypeView {
 	}
 	return view
 }
+
+// TestSIPREC_SessionSurvivesACK asserts that a recording session stays
+// established once it has been answered and ACKed.
+//
+// Regression test for a failure seen against a real Kamailio + rtpengine SRC:
+// the SRS answered, and then immediately tore the session down. Both ends left
+// matching evidence.
+//
+// On the SRS:
+//
+//	SIPREC: answer failed  error="respond SDP: transaction terminated"
+//	siprec.session_ended
+//	WARN ACK missed  caller=TransactionLayer  tx=...__INVITE
+//
+// and on the SRC, the same 200 OK logged three times — sipgo retransmitting it
+// because nothing ever confirmed the dialog.
+//
+// "ACK missed" comes from sipgo's ServerTx.ackSend(), which logs only in the
+// branch where an ACK arrives for an ALREADY-TERMINATED server transaction. So
+// the ACK is sent and received; the transaction is simply gone by then. That
+// makes this a lifecycle bug on the SRS side, not a signalling or transport
+// problem on the SRC side.
+//
+// The existing SIPREC tests all assert on the answer and then hang up, so none
+// of them notice a session that dies a moment later. This one holds the dialog
+// open and checks it is still there.
+func TestSIPREC_SessionSurvivesACK(t *testing.T) {
+	src := newTestInstance(t, "src")
+	srs := siprecInstance(t, "srs", nil)
+
+	call, err := dialSIPREC(t, src, srs, twoPartyMetadata(t))
+	if err != nil {
+		t.Fatalf("SIPREC INVITE failed: %v", err)
+	}
+	defer call.Dialog.Bye(context.Background())
+
+	if call.RemoteSDP == nil {
+		t.Fatal("no answer SDP — the SRS never answered the recording session")
+	}
+
+	evt := srs.collector.waitForMatch(t, events.SIPRECSessionStarted, nil, 5*time.Second)
+	legIDer, _ := evt.Data.(interface{ GetLegID() string })
+	if legIDer == nil || legIDer.GetLegID() == "" {
+		t.Fatal("siprec.session_started carries no leg ID")
+	}
+	legID := legIDer.GetLegID()
+
+	// Hold the dialog. In the observed failure the teardown followed the answer
+	// within a couple of hundred milliseconds, so a second is ample; the point
+	// is to outlive the ACK rather than to wait out a timer.
+	time.Sleep(2 * time.Second)
+
+	if srs.collector.hasEvent(events.SIPRECSessionEnded, nil) {
+		t.Fatal("recording session ended on its own after being answered: " +
+			"the SRS tore down the dialog instead of keeping it up " +
+			"(check for 'ACK missed' / 'transaction terminated' in the SRS log)")
+	}
+
+	// The session must still be addressable, not merely un-ended.
+	view := getSIPRECSession(t, srs, legID)
+	if len(view.Streams) != 2 {
+		t.Fatalf("streams = %d, want 2 still attached after the ACK", len(view.Streams))
+	}
+
+	// And the leg itself must still be connected — a session view can outlive
+	// the SIP dialog that justifies it.
+	resp := httpGet(t, srs.baseURL()+"/v1/legs")
+	var legs []legView
+	decodeJSON(t, resp, &legs)
+	var found bool
+	for _, l := range legs {
+		if l.ID == legID {
+			found = true
+			if l.State != "connected" {
+				t.Errorf("recording leg state = %q, want connected", l.State)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("recording leg %s is gone from /v1/legs after the ACK", legID)
+	}
+}

--- a/tests/integration/siprec_test.go
+++ b/tests/integration/siprec_test.go
@@ -1137,12 +1137,21 @@ func TestSIPREC_SessionSurvivesACK(t *testing.T) {
 	}
 	legID := legIDer.GetLegID()
 
-	// Long enough to outlive the ACK, short enough to keep the suite fast.
-	time.Sleep(2 * time.Second)
-
+	// Hold the dialog open and watch it. A green run has to observe the whole
+	// window -- absence of a teardown is only provable by waiting -- but
+	// polling makes a real teardown fail at once and report when it happened.
+	const observe = 2 * time.Second
+	answered := time.Now()
+	for deadline := answered.Add(observe); time.Now().Before(deadline); {
+		if srs.collector.hasEvent(events.SIPRECSessionEnded, nil) {
+			t.Fatalf("recording session ended on its own %v after being answered: "+
+				"the dialog was torn down instead of kept up", time.Since(answered).Round(time.Millisecond))
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 	if srs.collector.hasEvent(events.SIPRECSessionEnded, nil) {
-		t.Fatal("recording session ended on its own after being answered: " +
-			"the dialog was torn down instead of kept up")
+		t.Fatalf("recording session ended on its own within %v of being answered: "+
+			"the dialog was torn down instead of kept up", observe)
 	}
 
 	// The session must still be addressable, not merely un-ended.


### PR DESCRIPTION
Adds one integration test: a recording session, once answered and ACKed,
is still established a moment later.

Every existing SIPREC test asserts on the answer and then hangs up, so a
session that is set up correctly and then torn down on its own passes all
of them. This one holds the dialog open and checks that no
`siprec.session_ended` arrived, that the session view still has both
streams, and that the leg is still `connected`.

## Where it came from

A recording session from a Kamailio + rtpengine recording client was
answered and then dropped, leaving this on the VoiceBlender side:

```
SIPREC: answer failed  error="respond SDP: transaction terminated"
siprec.session_ended
WARN ACK missed  caller=TransactionLayer  tx=...__INVITE
```

and the same 200 OK arriving three times at the client, because nothing
confirmed the dialog.

The cause was on the client side, not here: it reused the INVITE's Via
branch on the ACK for the 2xx. RFC 3261 §17.1.1.3 makes that ACK a
separate transaction with a new branch, and with the branch reused
`TransactionLayer.serverTxRequest()` matched it to the still-live INVITE
server transaction and queued it on `tx.acks` instead of passing it up as
a new request. Nothing drains that queue for a 2xx — `dialog_server.go`
reads `tx.Acks()` only on the non-2xx path, since confirming a 2xx belongs
to the dialog under RFC 6026 — so `DialogServerSession.Respond()` kept
retransmitting and gave up at `64*T1`, and the session was torn down 32 s
into every call.

Two things from that are easy to misread, so they are worth stating:

- **`ACK missed` on a 2xx is expected.** It is logged whenever an ACK
  reaches a transaction whose ACK channel nothing is reading, which for a
  2xx is always the case. On its own it is not evidence of a problem here.
- **An ACK arriving is not an ACK confirming.** In the failure the ACKs
  did arrive — all of them surfaced at the moment the transaction was
  destroyed, 32 s late.

## What the test does and does not cover

It catches an immediate teardown after an answer.

It does **not** reproduce the failure above, and is not claimed to. A
client that never confirms the dialog only trips the retransmit timeout at
`64*T1`, and the test does not wait 32 s for that — deliberately, to keep
the suite fast. Against a compliant client, which is what the test harness
is, the session simply stays up.

So this is a regression guard for the property, not a reproduction of that
bug, which was in the client and is fixed there. It is offered because the
gap it fills is real: nothing in the suite currently notices a session
that dies just after being answered.

## Notes

- Test only. No production code is touched.
- The observation window is polled at 50 ms rather than slept through, so a
  teardown fails on the iteration it happens and reports the elapsed time.
  A passing run still waits the full 2 s, which cannot be avoided — absence
  of a teardown is only provable by observing the window.
- The branch is based on `8617e5e`, one commit behind current `master`. I
  verified the suite passes with these commits applied on top of `1ef4291`
  (`go test -tags integration -run SIPREC ./tests/integration/`), and can
  rebase if you would prefer that.
