### PR TITLE
sip: a bare rs-metadata body is not an SDP offer

### DIFF
--- a/internal/sip/multipart.go
+++ b/internal/sip/multipart.go
@@ -13,9 +13,14 @@ import (
 	"github.com/emiago/sipgo/sip"
 )
 
-// SIP body content types we recognize. SIPREC (RFC 7866) carries the metadata
-// document as application/rs-metadata+xml; deployed SBCs also emit the
-// pre-RFC application/rs-metadata, so both are accepted.
+// SIP body content types we recognize.
+//
+// Both SIPREC metadata types are accepted because the two RFCs contradicted
+// each other: RFC 7865 specified application/rs-metadata+xml, RFC 7866
+// specified application/rs-metadata, and neither registered the type.
+// RFC 9806 resolves that erratum (Err7987) in favour of +xml and registers it,
+// but it also records the interoperability consequence -- an SRC written to
+// RFC 7866 sends the unsuffixed name, which was normative for nine years.
 const (
 	ContentTypeSDP              = "application/sdp"
 	ContentTypeRSMetadata       = "application/rs-metadata+xml"
@@ -141,12 +146,23 @@ func (b *MessageBody) Part(contentType string) ([]byte, bool) {
 
 // SDP returns the session description. A single-part body is returned whatever
 // its declared type, preserving the behaviour of peers that omit or misdeclare
-// Content-Type on a plain SDP offer.
+// Content-Type on a plain SDP offer — except when it declares itself a type we
+// know is not SDP.
+//
+// RFC 7866 §9.1 lets an SRC send metadata with no SDP in an INVITE, an UPDATE,
+// or a 200 to an offerless INVITE, and is explicit that "when a SIP message
+// contains only an SDP offer or metadata, the multipart/mixed container is
+// optional". So a bare rs-metadata body is a correct request, and taking it for
+// an offer answers it 400 Bad SDP.
 func (b *MessageBody) SDP() ([]byte, bool) {
 	if b == nil || len(b.Parts) == 0 {
 		return nil, false
 	}
 	if !b.Multipart {
+		switch b.Parts[0].ContentType {
+		case ContentTypeRSMetadata, ContentTypeRSMetadataLegacy:
+			return nil, false
+		}
 		return b.Parts[0].Data, len(b.Parts[0].Data) > 0
 	}
 	data, ok := b.Part(ContentTypeSDP)

--- a/internal/sip/multipart_test.go
+++ b/internal/sip/multipart_test.go
@@ -147,6 +147,31 @@ func TestParseMessageBody_MetadataOnlyHasNoSDP(t *testing.T) {
 	}
 }
 
+// Metadata sent without SDP does not have to be multipart: RFC 7866 §9.1 makes
+// the container optional when the message carries only one of the two, so with
+// one part to send an SRC sends it bare. Reading that as an SDP offer answers a
+// correct request 400 Bad SDP.
+func TestParseMessageBody_BareMetadataIsNotSDP(t *testing.T) {
+	for _, ct := range []string{"application/rs-metadata+xml", "application/rs-metadata"} {
+		t.Run(ct, func(t *testing.T) {
+			mb, err := ParseMessageBody(ct, []byte(testMetadataBody))
+			if err != nil {
+				t.Fatalf("ParseMessageBody = %v, want nil", err)
+			}
+			if _, ok := mb.SDP(); ok {
+				t.Error("SDP() = (_, true), want false — the body declares itself metadata")
+			}
+			md, ok := mb.RSMetadata()
+			if !ok {
+				t.Fatal("RSMetadata() = (_, false), want true")
+			}
+			if string(md) != testMetadataBody {
+				t.Errorf("RSMetadata() = %q, want the body verbatim", md)
+			}
+		})
+	}
+}
+
 func TestParseMessageBody_Errors(t *testing.T) {
 	if _, err := ParseMessageBody("multipart/mixed", []byte("whatever")); err == nil {
 		t.Fatal("ParseMessageBody with no boundary = nil error, want an error")


### PR DESCRIPTION
## The problem

Metadata sent without SDP does not have to be multipart. RFC 7866 §9.1 lets an SRC send metadata in an INVITE, an UPDATE or a 200 to an offerless INVITE, and this PR handles the case where the SRC sends it bare without an SDP (e.g. in a hold/retrieve scenario).

```
UPDATE sip:srs.example.com SIP/2.0
CSeq: 11 UPDATE
Content-Type: application/rs-metadata+xml

<recording xmlns="urn:ietf:params:xml:ns:recording:1">
  <datamode>partial</datamode>
  <participantstreamassoc participant_id="…"><send>…</send></participantstreamassoc>
</recording>
```

`MessageBody.SDP()` returns the first part of a non-multipart body regardless of its type, so `hasSDP` came back true for an rs-metadata(+xml) body, the XML reached `ParseSDP()`, and `handleUpdate` answered **400 Bad SDP**. The same applies to `handleReInvite`, which feeds the body to `ApplyRemoteOffer`.

The permissive fallback stays as it was: an absent or misdeclared `Content-Type` is still treated as SDP, which is what that behaviour exists for. An SRC written to RFC 7866 sends the unsuffixed "application/rs-metadata", which is deprecated by RFC 9806 specifying "application/rs-metadata+xml". Both stay accepted, and both are excluded from the SDP fallback.

## Test

`TestParseMessageBody_BareMetadataIsNotSDP` covers both content types and asserts that the same body still resolves through `RSMetadata()` verbatim.