### PR TITLE
test(integration): give each instance a private RTP port range

### DIFF
--- a/tests/integration/call_test.go
+++ b/tests/integration/call_test.go
@@ -115,9 +115,17 @@ func newTestInstanceFull(t *testing.T, name string, mutate func(*config.Config),
 		AllowMultipleContacts: cfg.SIPRegistrationAllowMultipleContacts,
 	})
 
+	// A private RTP port range per instance. Without it every RTP session binds
+	// :0 from the same OS ephemeral pool the SIP port above was probed from, and
+	// a session that lands on a probed-but-not-yet-bound SIP port sends its audio
+	// into a SIP transport. See rtp_ports_test.go.
+	portAlloc := newTestPortAllocator(t)
+	cfg.RTPPortMin, cfg.RTPPortMax = portAlloc.Range()
+
 	engine, err := sipmod.NewEngine(sipmod.EngineConfig{
 		BindIP:            "127.0.0.1",
 		ListenIP:          "127.0.0.1",
+		PortAllocator:     portAlloc,
 		ExternalIP:        cfg.SIPExternalIP,
 		BindPort:          sipPort,
 		SIPHost:           name,

--- a/tests/integration/rtp_ports_test.go
+++ b/tests/integration/rtp_ports_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+package integration
+
+import (
+	"sync"
+	"testing"
+
+	sipmod "github.com/VoiceBlender/voiceblender/internal/sip"
+)
+
+// Each test instance gets a private RTP port range, disjoint from every other
+// instance's and from the OS ephemeral pool.
+//
+// Without one, EngineConfig.PortAllocator is nil and every RTP session binds :0,
+// drawing from the same OS ephemeral pool the harness uses to pick SIP ports --
+// and the harness picks a SIP port by binding :0, reading the port back and
+// closing the socket, so that port sits in the pool again until the engine binds
+// it for real. An RTP session landing on it sends a call's audio into a SIP
+// transport, which logs a parse error per packet and drops it. The call it
+// belonged to then records silence, and whichever test was asserting on that
+// audio fails somewhere unrelated to what it was testing.
+//
+// The band sits below the ephemeral range on both platforms we build for: Linux
+// defaults to 32768-60999, macOS to 49152-65535.
+const (
+	rtpBandMin  = 16384
+	rtpBandMax  = 32767
+	rtpBandSize = 128
+)
+
+var rtpBands struct {
+	mu   sync.Mutex
+	free []int
+	next int
+}
+
+// acquireRTPBand reserves a range for one instance and releases it when the test
+// ends. Bands are recycled, so a suite with more instances than bands still runs
+// as long as they are not all live at once.
+func acquireRTPBand(t *testing.T) (min, max int) {
+	t.Helper()
+	rtpBands.mu.Lock()
+	var base int
+	switch {
+	case len(rtpBands.free) > 0:
+		base = rtpBands.free[len(rtpBands.free)-1]
+		rtpBands.free = rtpBands.free[:len(rtpBands.free)-1]
+	default:
+		base = rtpBandMin + rtpBands.next*rtpBandSize
+		if base+rtpBandSize-1 > rtpBandMax {
+			rtpBands.mu.Unlock()
+			t.Fatalf("RTP port bands exhausted: %d live instances at %d ports each does not "+
+				"fit in %d-%d", rtpBands.next, rtpBandSize, rtpBandMin, rtpBandMax)
+		}
+		rtpBands.next++
+	}
+	rtpBands.mu.Unlock()
+
+	t.Cleanup(func() {
+		rtpBands.mu.Lock()
+		rtpBands.free = append(rtpBands.free, base)
+		rtpBands.mu.Unlock()
+	})
+	return base, base + rtpBandSize - 1
+}
+
+// newTestPortAllocator returns the allocator an instance's engine should use.
+func newTestPortAllocator(t *testing.T) *sipmod.PortAllocator {
+	t.Helper()
+	min, max := acquireRTPBand(t)
+	alloc, err := sipmod.NewPortAllocator(min, max)
+	if err != nil {
+		t.Fatalf("new port allocator for %d-%d: %v", min, max, err)
+	}
+	return alloc
+}
+
+// Every instance must get a band of its own, below the ephemeral pool. A shared
+// or unset range is what let a call's RTP arrive at another instance's SIP port.
+func TestInstancesGetDisjointRTPPortRanges(t *testing.T) {
+	type span struct{ min, max int }
+	var spans []span
+
+	for _, name := range []string{"a", "b", "c"} {
+		inst := newTestInstance(t, name)
+		min, max := inst.engine.PortAllocator().Range()
+		if min == 0 || max == 0 {
+			t.Fatalf("[%s] no RTP port range: sessions would bind :0 from the ephemeral pool", name)
+		}
+		// 32768 is the lowest ephemeral port on either platform we build for.
+		if max >= 32768 {
+			t.Errorf("[%s] range %d-%d reaches into the OS ephemeral pool", name, min, max)
+		}
+		for _, s := range spans {
+			if min <= s.max && s.min <= max {
+				t.Errorf("[%s] range %d-%d overlaps another instance's %d-%d", name, min, max, s.min, s.max)
+			}
+		}
+		spans = append(spans, span{min, max})
+	}
+}
+
+// And the range has to actually be used: a nil allocator reaches NewRTPSession,
+// which binds :0 and puts the port back in the pool the SIP ports come from.
+func TestRTPSessionsBindInsideTheInstanceBand(t *testing.T) {
+	inst := newTestInstance(t, "band")
+	alloc := inst.engine.PortAllocator()
+	min, max := alloc.Range()
+
+	for i := 0; i < 8; i++ {
+		sess, err := sipmod.NewRTPSessionFromAllocator(alloc)
+		if err != nil {
+			t.Fatalf("session %d: %v", i, err)
+		}
+		if p := sess.LocalPort(); p < min || p > max {
+			sess.Close()
+			t.Fatalf("session %d bound port %d, outside the instance band %d-%d", i, p, min, max)
+		}
+		sess.Close()
+	}
+}


### PR DESCRIPTION
Fixes #148.

## The problem

Roughly one integration run in two failed, never on the same test twice:

- `TestSIPREC_SRCForksRoomToRecordingServer`
- `TestMultiChannel_RoomRecording`
- `TestSIPREC_SilentStreamKeepsRealTime`
- `TestVSI_RTT_SendDelivers`
- `TestG722_DTMF`

They share nothing except that each asserts on audio that actually arrived, and none reproduces
in isolation. Every failing run was preceded by thousands of

```
ERROR failed to parse caller=TransportLayer caller=Transport<UDP>
  data="\x80\x00\x00\x1a..." error="EOF on reading line"
```

`\x80` is RTP version 2 — a call's audio arriving at a **SIP** transport, which parses it as a SIP
message, fails, and drops it. The stream records silence and some unrelated assertion fails.

## Cause

Two things in `tests/integration/call_test.go` combined.

The harness picks a SIP port by binding `udp4 127.0.0.1:0`, reading the port back and **closing**
the socket; the engine binds it again later. In between, the port is back in the OS ephemeral pool.

And the harness never set `RTPPortMin`/`RTPPortMax`, so `EngineConfig.PortAllocator` was nil and
`NewRTPSessionFromAllocator` fell through to `NewRTPSession`, which binds `:0` — from that same
pool.

So an RTP session could be handed a port an instance had already chosen as its SIP port. The more
instances a run creates, the likelier it gets, which is what made it look like load-dependent flake
rather than a bug.

Full detail and a deterministic reproduction are in #148.

## The fix

Each instance gets a private band from `16384–32767` in blocks of 128, recycled on `t.Cleanup` so a
suite with more instances than bands still runs as long as they are not all live at once.

That band sits below the ephemeral range on both platforms this builds for — Linux defaults to
32768–60999, macOS to 49152–65535 — so RTP and SIP can no longer draw from the same pool, and two
instances cannot collide with each other either.

**Tests only.** A deployed instance sets `RTP_PORT_MIN`/`RTP_PORT_MAX` (10000/20000 by default) and
configures `SIP_PORT` rather than probing for it, so nothing here changes a running server.

## Tests

- `TestInstancesGetDisjointRTPPortRanges` — every instance gets a range, it is below 32768, and no
  two overlap. **Fails without the wiring change**, which I verified by reverting it.
- `TestRTPSessionsBindInsideTheInstanceBand` — the range is actually used, i.e. no path still
  reaches `NewRTPSession`'s `:0`.

The reproduction that identified this is deliberately **not** included: it is timing-dependent by
nature and would be flaky in CI itself. It is in #148 so the mechanism stays verifiable.

## Alternative

If you would rather close the window at the probe end, reserving the SIP socket and handing the
engine an already-bound listener would also work, and would fix it for any future consumer of the
ephemeral pool rather than just RTP. It is a larger change to `EngineConfig`, so I went with the
smaller one — happy to switch.
