### PR TITLE
fix: stop double-pacing the leg-agent audio path

### DIFF
--- a/internal/api/agent.go
+++ b/internal/api/agent.go
@@ -57,7 +57,31 @@ func (sb *streamBuffer) Read(p []byte) (int, error) {
 	// Pace: wait at least one frame interval between reads so the mixer's
 	// readLoop doesn't flood its tiny incoming channel.
 	sb.awaitSlot()
+	return sb.readBlocking(p)
+}
 
+// ReadUnpaced blocks until at least len(p) bytes are buffered (or the buffer
+// is closed), with no self-imposed pacing of its own. Use this instead of
+// Read when the caller already has its own real-time consumer clock — for
+// example sip_leg.go's writeLoop, which drains outFrames on its own 20ms
+// ticker. Read's awaitSlot pacing is redundant there, and being a second,
+// uncoordinated ~20ms clock alongside writeLoop's ticker, the two slowly walk
+// out of phase with each other; periodically that phase offset crosses a full
+// frame boundary and writeLoop's non-blocking read finds outFrames empty,
+// substituting a silence frame even though the real audio was buffered and
+// ready on time. outFrames is a blocking-send, backpressured channel (unlike
+// the mixer's lossy 3-slot one Read's pacing protects), so nothing is lost by
+// reading as fast as data arrives.
+func (sb *streamBuffer) ReadUnpaced(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return sb.readBlocking(p)
+}
+
+// readBlocking is the shared wait-for-data-and-copy body of Read and
+// ReadUnpaced.
+func (sb *streamBuffer) readBlocking(p []byte) (int, error) {
 	sb.mu.Lock()
 	for len(sb.buf) < len(p) && !sb.closed {
 		sb.cond.Wait()
@@ -380,7 +404,7 @@ func (s *Server) doStartLegAgent(legID, provider, apiKey string, opts agent.Opti
 		go func() {
 			buf := make([]byte, frameSize)
 			for {
-				n, err := sb.Read(buf)
+				n, err := sb.ReadUnpaced(buf)
 				if err != nil || n == 0 {
 					return
 				}


### PR DESCRIPTION
## Summary
- `streamBuffer.Read`'s `awaitSlot` pacing and `sip_leg.go`'s `writeLoop` ticker are two independent ~20ms clocks with no shared reference between them.
- That pacing is load-bearing for the room/mixer path (it protects a lossy 3-slot channel), but the leg-agent path (`doStartLegAgent`'s non-room branch) bypasses the mixer entirely and drains through `outFrames`, a blocking-send 5-slot channel that already provides its own backpressure — the pacing is redundant there, and actively harmful, since it's a second uncoordinated clock racing the writeLoop ticker.
- With two independent clocks, any small relative phase offset between them periodically lines up so `writeLoop`'s non-blocking read finds `outFrames` empty and substitutes a silence frame, even though the real audio was already buffered and ready on time.
- On a real call (pipecat TTS agent attached directly to a SIP leg, no room) this produced audible ~20ms dropouts recurring every 600-800ms during active bot speech — heard as small gaps, trailing/extra sound after a word, and pops/stutters mid-word.

Fix: add `streamBuffer.ReadUnpaced`, a plain blocking read with no pacing of its own, and use it for the leg-agent path. The room/mixer path keeps `Read`'s existing `awaitSlot` pacing unchanged.

## Investigation
Root-caused on a live deployment by:
1. Confirming the TTS source (pipecat's own WebSocket audio output) was clean — correct content, monotonic frame IDs, zero duplicates, steady delivery with no late messages.
2. Confirming rtpengine (the SRTP relay) is a faithful passthrough via real SRTP decryption of a captured call.
3. Byte-diffing VoiceBlender's own RTP output against what actually reached the far end — identical, so the corruption was already present in what VoiceBlender itself emitted.
4. Time-aligned energy-envelope comparison against the clean pipecat source showing isolated hard-silence frames appearing mid-speech in VoiceBlender's output.
5. Temporary instrumentation of `streamBuffer.Read` and `writeLoop`'s silence-fallback branch on the live box, which showed the fallback firing periodically (~every 600-800ms) with a real frame having arrived only ~19-20ms earlier each time — the signature of two uncoordinated ~20ms clocks drifting in and out of phase, not of any actual data unavailability.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/api/... ./internal/leg/... ./internal/mixer/...`
- [x] Verified against real captured calls on a live deployment: 24 mid-speech dropouts in a ~30s call before the fix, 1 (an ordinary rare stall, not periodic) in a ~21s call after, and the caller-audible artifacting is gone.